### PR TITLE
(maint)updating spec tests

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -113,12 +113,12 @@ define docker::run(
   include docker::params
   if ($socket_connect != []) {
     $sockopts = join(any2array($socket_connect), ',')
-    $docker_command = "${docker::docker_command} -H ${sockopts}"
+    $docker_command = "${docker::params::docker_command} -H ${sockopts}"
   }else {
-    $docker_command = $docker::docker_command
+    $docker_command = $docker::params::docker_command
   }
-  $service_name = $docker::service_name
-  $docker_group = $docker::docker_group
+  $service_name = $docker::params::service_name
+  $docker_group = $docker::params::docker_group
 
   validate_re($image, '^[\S]*$')
   validate_re($title, '^[\S]*$')

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -16,18 +16,18 @@ describe 'docker::compose', :type => :class do
 
 
   context 'when no proxy is provided' do
-    let(:params) { {:version => '1.7.0'} }
-    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
-           'curl -s -L  https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    let(:params) { {:version => '1.16.1'} }
+    it { is_expected.to contain_exec('Install Docker Compose 1.16.1').with_command(
+           'curl -s -L  https://github.com/docker/compose/releases/download/1.16.1/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.16.1')
     }
   end
 
   context 'when proxy is provided' do
     let(:params) { {:proxy => 'http://proxy.example.org:3128/',
-                    :version => '1.7.0'} }
+                    :version => '1.16.1'} }
     it { is_expected.to compile }
-    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
-           'curl -s -L --proxy http://proxy.example.org:3128/ https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    it { is_expected.to contain_exec('Install Docker Compose 1.16.1').with_command(
+           'curl -s -L --proxy http://proxy.example.org:3128/ https://github.com/docker/compose/releases/download/1.16.1/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.16.1')
     }
   end
 
@@ -42,10 +42,10 @@ describe 'docker::compose', :type => :class do
 
   context 'when proxy contains username and password' do
     let(:params)  { {:proxy => 'http://user:password@proxy.example.org:3128/',
-                     :version => '1.7.0'} }
+                     :version => '1.16.1'} }
     it { is_expected.to compile }
-    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
-           'curl -s -L --proxy http://user:proxy@proxy.example.org:3128/ https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    it { is_expected.to contain_exec('Install Docker Compose 1.16.1').with_command(
+           'curl -s -L --proxy http://user:password@proxy.example.org:3128/ https://github.com/docker/compose/releases/download/1.16.1/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.16.1')
     }
   end
 end


### PR DESCRIPTION
Changing docker compose version (version was incorrect) and updating the when proxy contains username and password spec test also. Also added params:: back in as without this spec tests were failing.