### PR TITLE
allow configuration of gem sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV["GEM_SOURCE"] || "https://rubygems.org"
 
 group :test do
   gem "rake", "~> 10.0"


### PR DESCRIPTION
This contribution allows developers to configure the source of developer dependencies. This allows developers behind a firewall to point to an approved mirrored source of the publicly available gems that are used to develop and test the module.