### PR TITLE
Cloud 1524

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-docker.svg?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-docker)
-
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppetlabs/docker.svg)](https://forge.puppetlabs.com/puppetlabs/docker)
 
 # Docker

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 ## Overview
 
-The Puppet docker module installs, configures, and manages [Docker](https://github.com/docker/docker) from the [Docker repository](https://docs.docker.com/installation/) or from the [EPEL on RedHat](https://docs.docker.io/en/latest/installation/rhel/) based distributions.
+The Puppet docker module installs, configures, and manages [Docker](https://github.com/docker/docker) from the [Docker repository](https://docs.docker.com/installation/). It supports the latest [Docker CE (Community Edition)](https://www.docker.com/community-edition) as well legacy releases.
+
+With new naming convention of the Docker packages, this module now differentiates between by prefacing any params referring to the release with `_ce` or `_engine`. There are examples of this through the README.
 
 ## Description
 
@@ -49,32 +51,60 @@ class { 'docker':
 }
 ```
 
-The latest Docker [repositories](https://blog.docker.com/2015/07/new-apt-and-yum-repos/#comment-247448) are now the default repositories for version 5 and above. To use previous repositories, add the following code to the manifest file:
+The latest Docker [repositories](https://docs.docker.com/engine/installation/linux/docker-ce/debian/#set-up-the-repository) are now the default repositories for version 17.06 and above. If you are using a version prior to this, the old repositories will still be configured based on the version number passed into the module.
+
+The following example will ensure the modules configures the latest repositories
 
 ```puppet
 class { 'docker':
-  package_name => 'lxc-docker',
-  package_source_location => 'https://get.docker.com/ubuntu',
-  package_key_source => 'https://get.docker.com/gpg',
-  package_key => '36A1D7869245C8950F966E92D8576A8BA88D21E',
-  package_release => 'docker',
+  version => '17.09.0~ce-0~debian',
 }
 ```
 
-Docker provides a commercially supported version of the [Docker Engine](https://docs.docker.com/docker-trusted-registry/install/install-csengine/), called Docker CS. To install Docker DS, add the following code to the manifest file:
+Using a versio prior to 17.06 will configure and install from the old repositories
 
 ```puppet
 class { 'docker':
-  docker_cs => true,
+  version => '1.12.0-0~wheezy',
+}
+
+Docker provides a enterprise addition of the [Docker Engine](https://www.docker.com/enterprise-edition), called Docker EE. To install Docker EE on Debian systems, add the following code to the manifest file:
+
+```puppet
+class { 'docker':
+  docker_ee => true,
+  docker_ee_source_location => 'https://<docker_ee_repo_url',
+  docker_ee_key_source => 'https://<docker_ee_key_source_url',
+  docker_ee_key_id => '<key id>',
 }
 ```
 
-For Red Hat Enterprise Linux (RHEL) based distributions, including Fedora, the docker module uses the upstream repositories. To continue using the distribution packages, add the following code to the manifest file:
+To install install Docker EE on RHEL/CentOS:
+
+```puppet
+class { 'docker':
+  docker_ee => true,
+  docker_ee_source_location => 'https://<docker_ee_repo_url',
+  docker_ee_key_source => 'https://<docker_ee_key_source_url',
+}
+```
+
+
+For Red Hat Enterprise Linux (RHEL) based distributions, including Fedora, the docker module uses the upstream repositories. To continue using the legacy distribution packages, add the following code to the manifest file:
 
 ```puppet
 class { 'docker':
   use_upstream_package_source => false,
-  package_name => 'docker',
+  package_engine_name => 'docker-name',
+}
+```
+
+To use the CE packages
+
+```puppet
+class { 'docker':
+  use_upstream_package_source => false,
+  package_ce_name => 'docker-ce',
 }
 ```
 
@@ -105,22 +135,14 @@ class { 'docker':
 }
 ```
 
-Only the latest version of Docker supports Archlinux. To specify which version of Docker to install, add the following code to the manifest file: 
-
-```puppet
-class { 'docker':
-  version => '0.5.5',
-}
-```
-
 To specify which Docker rpm package to install, add the following code to the manifest file:
 
 ```puppet
 class { 'docker' :
   manage_package              => true,
   use_upstream_package_source => false,
-  package_name                => 'docker-engine'
-  package_source              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+  package_engine_name         => 'docker-engine'
+  package_source_location     => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
   prerequired_packages        => [ 'glibc.i686', 'glibc.x86_64', 'sqlite.i686', 'sqlite.x86_64', 'device-mapper', 'device-mapper-libs', 'device-mapper-event-libs', 'device-mapper-event' ]
 }
 ```
@@ -130,6 +152,14 @@ To track the latest version of Docker, add the following code to the manifest fi
 ```puppet
 class { 'docker':
   version => 'latest',
+}
+```
+
+To install docker from a test or edge channel, add the following code to the manifest file:
+
+```puppet
+class { 'docker':
+  docker_ce_channel => 'test'
 }
 ```
 
@@ -159,7 +189,7 @@ class { 'docker':
 
 ### Images
 
-Each image name must be unique, otherwise the installation fails when a duplicate name is detected. 
+Each image name must be unique, otherwise the installation fails when a duplicate name is detected.
 
 To install a Docker image, add the `docker::image` defined type to the manifest file:
 
@@ -167,7 +197,7 @@ To install a Docker image, add the `docker::image` defined type to the manifest 
 docker::image { 'base': }
 ```
 
-The code above is equivalent to running the `docker pull base` command. However, it removes the default five minute execution timeout. 
+The code above is equivalent to running the `docker pull base` command. However, it removes the default five minute execution timeout.
 
 To include an optional parameter for installing image tags that is the equivalent to running `docker pull -t="precise" ubuntu`, add the following code to the manifest file:
 
@@ -245,7 +275,7 @@ docker::run { 'helloworld':
 
 This is equivalent to running the  `docker run -d base /bin/sh -c "while true; do echo hello world; sleep 1; done"` command to launch a Docker container managed by the local init system.
 
-`run` includes a number of optional parameters: 
+`run` includes a number of optional parameters:
 
 ```puppet
 docker::run { 'helloworld':
@@ -279,7 +309,7 @@ You can specify the ports, expose, env, dns, and volumes values with a single st
 
 To pull the image before it starts, specify the `pull_on_start` parameter.
 
-To execute a command before the container stops, specify the `before_stop` parameter. 
+To execute a command before the container stops, specify the `before_stop` parameter.
 
 Add the container name to the `after` parameter to specify which containers start first. This affects the generation of the `init.d/systemd` script.
 
@@ -287,7 +317,7 @@ Add container dependencies to the `depends` parameter. The container starts befo
 
 The `extra_parameters` parameter contains an array of command line arguments to pass to the `docker run` command. This parameter is useful for adding additional or experimental options that the docker module currently does not support.
 
-By default, automatic restarting of the service on failure is enabled by the service file for systemd based systems. 
+By default, automatic restarting of the service on failure is enabled by the service file for systemd based systems.
 
 To use an image tag, add the following code to the manifest file:
 
@@ -336,7 +366,7 @@ docker_network { 'my-net':
 }
 ```
 
-The name value and the `ensure` parameter are required. If you do not include the `driver` value, the default bridge is used. The Docker daemon must be configured for some networks and an example would be configuring the cluster store for the overlay network. 
+The name value and the `ensure` parameter are required. If you do not include the `driver` value, the default bridge is used. The Docker daemon must be configured for some networks and an example would be configuring the cluster store for the overlay network.
 
 To configure the cluster store, update the `docker` class in the manifest file:
 
@@ -364,12 +394,12 @@ A defined network can be used on a `docker::run` resource with the `net` paramet
 
 Docker Compose describes a set of containers in YAML format and runs a command to build and run those containers. Included in the docker module is the `docker_compose` type. This enables Puppet to run Compose and remediate any issues to ensure reality matches the model in your Compose file.
 
-You must install the Docker Compose utility, before you use the `docker_compose` type. 
+You must install the Docker Compose utility, before you use the `docker_compose` type.
 
 To install Docker Compose, add the following code to the manifest file:
 
 ```puppet
-class {'docker::compose': 
+class {'docker::compose':
   ensure => present,
 }
 ```
@@ -417,7 +447,7 @@ To deploy the stack, add the following code to the manifest file:
    compose_file => '/tmp/docker-compose.yaml',
    require => [Class['docker'], File['/tmp/docker-compose.yaml']],
 }
-```  
+```
 
 To remove the stack set `ensure  => absent`.
 
@@ -430,19 +460,19 @@ docker::stack { 'yourapp':
   compose_file => '/tmp/docker-compose.yaml',
   require => [Class['docker'], File['/tmp/docker-compose.yaml']],
 }
-```  
+```
 To remove the stack, set `ensure  => absent`.
 
 ### Swarm mode
 
-To natively manage a cluster of Docker Engines known as a swarm, Docker Engine 1.12 includes a swarm mode. 
+To natively manage a cluster of Docker Engines known as a swarm, Docker Engine 1.12 includes a swarm mode.
 
 To cluster your Docker engines, use one of the following Puppet resources:
 
 * [Swarm manager](#Swarm-manager)
 * [Swarm worker](#Swarm-worker)
 
-#### Swarm manager 
+#### Swarm manager
 
 To configure the swarm manager, add the following code to the manifest file:
 
@@ -450,8 +480,8 @@ To configure the swarm manager, add the following code to the manifest file:
 docker::swarm {'cluster_manager':
   init           => true,
   advertise_addr => '192.168.1.1',
-  listen_addr    => '192.168.1.1',  
-} 
+  listen_addr    => '192.168.1.1',
+}
 ```
 
 For a multihomed server and to enable cluster communications between the node, include the ```advertise_addr``` and ```listen_addr``` parameters.
@@ -467,10 +497,10 @@ advertise_addr => '192.168.1.2',
 listen_addr    => '192.168.1.2,
 manager_ip     => '192.168.1.1',
 token          => 'SWMTKN-1-2lw8bnr57qsu74d6iq2q1wr2wq2i334g7425dfr3zucimvh4bl-2vwn6gysbdj605l37c61iixie'
-} 
+}
 ```
 
-To configure a worker node or a second manager, include the swarm manager IP address in the `manager_ip` parameter. To define the role of the node in the cluster, include the `token` parameter. When creating another swarm manager and a worker node, separate tokens are required. 
+To configure a worker node or a second manager, include the swarm manager IP address in the `manager_ip` parameter. To define the role of the node in the cluster, include the `token` parameter. When creating another swarm manager and a worker node, separate tokens are required.
 
 To remove a node from a cluster, add the following code to the manifest file:
 
@@ -487,11 +517,11 @@ To create a Docker service, add the following code to the manifest file:
 
 ```puppet
 docker::services {'redis':
-    create => true,   
+    create => true,
     service_name => 'redis',
     image => 'redis:latest',
     publish => '6379:639',
-    replicas => '5', 
+    replicas => '5',
     extra_params => ['--update-delay 1m', '--restart-window 30s']
   }
 ```
@@ -500,7 +530,7 @@ To base the service off an image, include the `image` parameter and include the 
 
 To update the service, add the following code to the manifest file:
 
-```puppet 
+```puppet
 docker::services {'redis_update':
   create => false,
   update => true,
@@ -518,11 +548,11 @@ docker::services {'redis_scale':
   create => false,
   scale => true,
   service_name => 'redis',
-  replicas => '10', 
+  replicas => '10',
 }
 ```
 
-To scale the service without creating a new one, include the the `scale => true` parameter and the `create => false` parameter. In the example above, the service is scaled to 10. 
+To scale the service without creating a new one, include the the `scale => true` parameter and the `create => false` parameter. In the example above, the service is scaled to 10.
 
 To remove a service, add the following code to the manifest file:
 
@@ -537,7 +567,7 @@ To remove the service from a swarm, include the `ensure => absent` parameter and
 
 ### Private registries
 
-If a server is not specified, images are pushed and pulled from [index.docker.io](https://index.docker.io). To qualify your image name, create a private repository without authentication. 
+If a server is not specified, images are pushed and pulled from [index.docker.io](https://index.docker.io). To qualify your image name, create a private repository without authentication.
 
 To configure authentication for a private registry, add the following code to the manifest file:
 
@@ -566,7 +596,7 @@ To log out of a registry, add the following code to the manifest file:
 docker::registry { 'example.docker.io:5000':
   ensure => 'absent',
 }
-```   
+```
 
 ### Exec
 
@@ -713,7 +743,7 @@ Defaults to `undefined`.
 
 #### `socket_bind`
 
-The unix socket to bind to. 
+The unix socket to bind to.
 
 Defaults to `unix:///var/run/docker.sock.`
 
@@ -777,7 +807,7 @@ When you run your own package mirror, set the value to `false`.
 
 #### `pin_upstream_package_source`
 
-Specifies whether to use the pin upstream package source. This option relates to apt-based distributions.  
+Specifies whether to use the pin upstream package source. This option relates to apt-based distributions.
 
 Valid values are `true`, `false`.
 
@@ -787,15 +817,15 @@ Set to `false` to remove pinning on the upstream package repository. See also `a
 
 #### `apt_source_pin_level`
 
-The level to pin your source package repository to. This relates to an apt-based system (such as Debian, Ubuntu, etc). Include $use_upstream_package_source and set the value to `true`.  
+The level to pin your source package repository to. This relates to an apt-based system (such as Debian, Ubuntu, etc). Include $use_upstream_package_source and set the value to `true`.
 
-To disable pinning, set the value to `false`. 
+To disable pinning, set the value to `false`.
 
 Defaults to `10`.
 
 #### `package_source_location`
 
-Specifies the location of the package source. 
+Specifies the location of the package source.
 
 For Debian, the value defaults to `http://get.docker.com/ubuntu`.
 
@@ -1005,7 +1035,7 @@ Default is `OS and package specific`.
 
 #### `daemon_environment_files`
 
-Specifies additional environment files to add to the `service-overrides.conf` file. 
+Specifies additional environment files to add to the `service-overrides.conf` file.
 
 #### `repo_opt`
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ class { 'docker':
 }
 ```
 
-Using a versio prior to 17.06 will configure and install from the old repositories
+Using a version prior to 17.06 will configure and install from the old repositories
 
 ```puppet
 class { 'docker':
   version => '1.12.0-0~wheezy',
 }
+```
 
 Docker provides a enterprise addition of the [Docker Engine](https://www.docker.com/enterprise-edition), called Docker EE. To install Docker EE on Debian systems, add the following code to the manifest file:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -348,9 +348,13 @@ class docker(
   $version                           = $docker::params::version,
   $ensure                            = $docker::params::ensure,
   $prerequired_packages              = $docker::params::prerequired_packages,
+  $docker_ce                         = $docker::params::docker_ce,
+  $docker_ce_channel                 = $docker::params::docker_ce_channel,
   $docker_cs                         = $docker::params::docker_cs,
   $package_cs_source_location        = $docker::params::package_cs_source_location,
   $package_cs_key_source             = $docker::params::package_cs_key_source,
+  $package_ee_source_location        = $docker::params::package_ee_source_location,
+  $package_ee_key_source             = $docker::params::package_ee_key_source,
   $tcp_bind                          = $docker::params::tcp_bind,
   $tls_enable                        = $docker::params::tls_enable,
   $tls_verify                        = $docker::params::tls_verify,
@@ -529,4 +533,5 @@ class docker(
   Class['docker'] -> Docker::Registry <||> -> Docker::Image <||> -> Docker::Run <||>
   Class['docker'] -> Docker::Image <||> -> Docker::Run <||>
   Class['docker'] -> Docker::Run <||>
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -348,8 +348,21 @@ class docker(
   $version                           = $docker::params::version,
   $ensure                            = $docker::params::ensure,
   $prerequired_packages              = $docker::params::prerequired_packages,
+  $docker_ce_start_command           = $docker::params::docker_ce_start_command,
+  $docker_ce_package_name            = $docker::params::docker_ce_package_name,
+  $docker_ce_source_location         = $docker::params::package_ce_source_location,
+  $docker_ce_key_source              = $docker::params::package_ce_key_source,
+  $docker_ce_key_id                  = $docker::params::package_ce_key_id,
+  $docker_ce_release                 = $docker::params::package_ce_release,
+  $docker_package_location           = $docker::params::package_source_location,
+  $docker_package_key_source         = $docker::params::package_key_source,
+  $docker_package_key_id             = $docker::params::package_key_id,
+  $docker_package_release            = $docker::params::package_release,
+  $docker_engine_start_command       = $docker::params::docker_engine_start_command,
+  $docker_engine_package_name        = $docker::params::docker_engine_package_name,
   $docker_ce_channel                 = $docker::params::docker_ce_channel,
   $docker_ee                         = $docker::params::docker_ee,
+  $docker_ee_package_name            = $docker::params::docker_ee_package_name,
   $docker_ee_source_location         = $docker::params::docker_ee_source_location,
   $docker_ee_key_source              = $docker::params::docker_ee_key_source,
   $docker_ee_key                     = $docker::params::docker_ee_key,
@@ -518,68 +531,51 @@ class docker(
     validate_string($tls_key)
   }
 
-
   if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.]\d-ce|1.\d+)/ ) {
     if ( $docker_ee) {
-
       validate_string($docker_ee_source_location)
       validate_string($docker_ee_key_source)
       validate_string($docker_ee_key)
-
       $package_location = $docker_ee_source_location
       $package_key_source = $docker_ee_key_source
       $package_key = $docker_ee_key
       $package_repos = $docker_ee_repos
       $release = $docker_ee_release
-      $docker_start_command = 'dockerd'
-      $docker_package_name = 'docker-ee'
+      $docker_start_command = $docker_ee_start_command
+      $docker_package_name = $docker_ee_package_name
     } else {
-
         case $::osfamily {
-
           'Debian' : {
-
-            $package_location = "https://download.docker.com/linux/${os}"
-            $package_key_source = "https://download.docker.com/linux/${os}/gpg"
-            $package_key = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+            $package_location = $docker_ce_source_location
+            $package_key_source = $docker_ce_key_source
+            $package_key = $docker_ce_key_id
             $package_repos = $docker_ce_channel
-            $release = "${::lsbdistcodename}"
+            $release = $docker_ce_release
             }
-
           'Redhat' : {
-
-            $package_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker::docker_ce_channel}"
-            $package_key_source = 'https://download.docker.com/linux/centos/gpg'
+            $package_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
+            $package_key_source = $docker_ce_key_source
           }
         }
-
-        $docker_start_command = 'dockerd'
-        $docker_package_name = 'docker-ce'
-
+        $docker_start_command = $docker_ce_start_command
+        $docker_package_name = $docker_ce_package_name
     }
-
   } else {
-
     case $::osfamily {
       'Debian' : {
-
-        $package_location = "http://apt.dockerproject.org/repo"
-        $package_key_source = "https://apt.dockerproject.org/gpg"
-        $package_key = "58118E89F3A912897C070ADBF76221572C52609D"
+        $package_location = $docker_package_location
+        $package_key_source = $docker_package_key_source
+        $package_key = $docker_package_key_id
         $package_repos = 'main'
-        $release = "ubuntu-${::lsbdistcodename}"
+        $release = $docker_package_release
         }
-
       'Redhat' : {
-
-        $package_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
-        $package_key_source = 'https://yum.dockerproject.org/gpg'
+        $package_location = $docker_package_location
+        $package_key_source = $docker_package_key_source
       }
     }
-
-    $docker_start_command = 'docker daemon'
-    $docker_package_name = 'docker-engine'
-
+    $docker_start_command = $docker_engine_start_command
+    $docker_package_name = $docker_engine_package_name
   }
 
   contain 'docker::repos'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -517,11 +517,51 @@ class docker(
     validate_string($tls_cert)
     validate_string($tls_key)
   }
-  if ($docker_ce) {
-    $docker_start_command = 'dockerd'
-  } else {
-    $docker_start_command = 'docker daemon'
-  }
+
+  # if ( $docker::version =~ /^(17.0[0-5]|1.\d+)/ {
+  #   case $::osfamily {
+  #     'Debian' : {
+
+  #       $package_location = $docker::package_location
+  #       $package_key_source = $docker::package_key_source
+  #       $package_key = $docker::package_key
+  #       $package_repos = $docker::package_repos
+  #       $release = $docker::release_ce
+  #       }
+
+  #     'Redhat' : {
+
+  #       $package_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
+  #       $package_key_source = 'https://yum.dockerproject.org/gpg'
+  #     }
+
+  #   $docker_start_command = 'docker daemon'
+  #   $docker_package_name = 'docker-engine'
+
+  #   }
+
+  # } else {
+
+  #   case $::osfamily {
+  #     'Debian' : {
+
+  #       $package_location = $docker::package_location
+  #       $package_key_source = $docker::package_key_source
+  #       $package_key = $docker::package_key
+  #       $package_repos = $docker::package_repos
+  #       $release = $docker::release_ce
+  #       }
+
+  #     'Redhat' : {
+
+  #       $package_source_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker::docker_ce_channel}"
+  #       $package_key_source = 'https://download.docker.com/linux/centos/gpg'
+  #     }
+
+  #     $docker_start_command = 'dockerd'
+  #     $docker_package_name = 'docker-ce'
+  #   }
+  # }
 
   contain 'docker::repos'
   contain 'docker::install'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -520,15 +520,12 @@ class docker(
     validate_string($tls_key)
   }
 
-  class { 'docker::repos': }
-  -> class { 'docker::install': }
-  -> class { 'docker::config': }
-  ~> class { 'docker::service': }
   contain 'docker::repos'
   contain 'docker::install'
   contain 'docker::config'
   contain 'docker::service'
 
+  Class['docker::repos'] -> Class['docker::install'] -> Class['docker::config'] ~> Class['docker::service']
   Class['docker'] -> Docker::Registry <||> -> Docker::Image <||> -> Docker::Run <||>
   Class['docker'] -> Docker::Image <||> -> Docker::Run <||>
   Class['docker'] -> Docker::Run <||>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -362,12 +362,12 @@ class docker(
   $docker_engine_package_name        = $docker::params::docker_engine_package_name,
   $docker_ce_channel                 = $docker::params::docker_ce_channel,
   $docker_ee                         = $docker::params::docker_ee,
-  $docker_ee_package_name            = $docker::params::docker_ee_package_name,
-  $docker_ee_source_location         = $docker::params::docker_ee_source_location,
-  $docker_ee_key_source              = $docker::params::docker_ee_key_source,
-  $docker_ee_key                     = $docker::params::docker_ee_key,
-  $docker_ee_repos                   = $docker::params::docker_ee_repos,
-  $docker_ee_release                 = $docker::params::docker_ee_release,
+  $docker_ee_package_name            = $docker::params::package_ee_package_name,
+  $docker_ee_source_location         = $docker::params::package_ee_source_location,
+  $docker_ee_key_source              = $docker::params::package_ee_key_source,
+  $docker_ee_key_id                  = $docker::params::package_ee_key_id,
+  $docker_ee_repos                   = $docker::params::package_ee_repos,
+  $docker_ee_release                 = $docker::params::package_ee_release,
   $tcp_bind                          = $docker::params::tcp_bind,
   $tls_enable                        = $docker::params::tls_enable,
   $tls_verify                        = $docker::params::tls_verify,
@@ -538,7 +538,7 @@ class docker(
       validate_string($docker_ee_key)
       $package_location = $docker_ee_source_location
       $package_key_source = $docker_ee_key_source
-      $package_key = $docker_ee_key
+      $package_key = $docker_ee_key_id
       $package_repos = $docker_ee_repos
       $release = $docker_ee_release
       $docker_start_command = $docker_ee_start_command

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -378,11 +378,7 @@ class docker(
   $use_upstream_package_source       = $docker::params::use_upstream_package_source,
   $pin_upstream_package_source       = $docker::params::pin_upstream_package_source,
   $apt_source_pin_level              = $docker::params::apt_source_pin_level,
-  $package_source_location           = $docker::params::package_source_location,
   $package_release                   = $docker::params::package_release,
-  $package_repos                     = $docker::params::package_repos,
-  $package_key                       = $docker::params::package_key,
-  $package_key_source                = $docker::params::package_key_source,
   $service_state                     = $docker::params::service_state,
   $service_enable                    = $docker::params::service_enable,
   $manage_service                    = $docker::params::manage_service,
@@ -416,10 +412,7 @@ class docker(
   $manage_package                    = $docker::params::manage_package,
   $package_source                    = $docker::params::package_source,
   $manage_epel                       = $docker::params::manage_epel,
-  $package_name                      = $docker::params::package_name,
   $service_name                      = $docker::params::service_name,
-  $docker_command                    = $docker::params::docker_command,
-  $daemon_subcommand                 = $docker::params::daemon_subcommand,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,
   $daemon_environment_files          = [],
@@ -444,6 +437,7 @@ class docker(
   $service_overrides_template        = $docker::params::service_overrides_template,
   $service_hasstatus                 = $docker::params::service_hasstatus,
   $service_hasrestart                = $docker::params::service_hasrestart,
+
 ) inherits docker::params {
 
   validate_string($version)
@@ -522,6 +516,11 @@ class docker(
     validate_string($tls_cacert)
     validate_string($tls_cert)
     validate_string($tls_key)
+  }
+  if ($docker_ce) {
+    $docker_start_command = 'dockerd'
+  } else {
+    $docker_start_command = 'docker daemon'
   }
 
   contain 'docker::repos'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -533,16 +533,16 @@ class docker(
 
   if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.]\d-ce|1.\d+)/ ) {
     if ( $docker_ee) {
-      validate_string($docker_ee_source_location)
-      validate_string($docker_ee_key_source)
-      validate_string($docker_ee_key)
-      $package_location = $docker_ee_source_location
-      $package_key_source = $docker_ee_key_source
-      $package_key = $docker_ee_key_id
-      $package_repos = $docker_ee_repos
-      $release = $docker_ee_release
-      $docker_start_command = $docker_ee_start_command
-      $docker_package_name = $docker_ee_package_name
+      validate_string($docker::docker_ee_source_location)
+      validate_string($docker::docker_ee_key_source)
+      validate_string($docker::docker_ee_key)
+      $package_location = $docker::docker_ee_source_location
+      $package_key_source = $docker::docker_ee_key_source
+      $package_key = $docker::docker_ee_key_id
+      $package_repos = $docker::docker_ee_repos
+      $release = $docker::docker_ee_release
+      $docker_start_command = $docker::docker_ee_start_command
+      $docker_package_name = $docker::docker_ee_package_name
     } else {
         case $::osfamily {
           'Debian' : {
@@ -556,6 +556,7 @@ class docker(
             $package_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
             $package_key_source = $docker_ce_key_source
           }
+          default: {}
         }
         $docker_start_command = $docker_ce_start_command
         $docker_package_name = $docker_ce_package_name
@@ -573,6 +574,7 @@ class docker(
         $package_location = $docker_package_location
         $package_key_source = $docker_package_key_source
       }
+      default : {}
     }
     $docker_start_command = $docker_engine_start_command
     $docker_package_name = $docker_engine_package_name

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -99,13 +99,13 @@ class docker::install {
         ensure   => $ensure,
         provider => $pk_provider,
         source   => $docker::package_source,
-        name     => $package_name,
+        name     => $docker::docker_package_name,
       }))
 
     } else {
       ensure_resource('package', 'docker', merge($docker_hash, {
         ensure => $ensure,
-        name   => $package_name,
+        name   => $docker::docker_package_name,
       }))
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,14 @@
 # and Archlinux based distributions.
 #
 class docker::install {
-  $docker_command = $docker::docker_command
+  $docker_start_command = $docker::docker_start_command
+  if ($docker::docker_ce) {
+    $package_name = 'docker-ce'
+  } elsif ($docker::docker_ee) {
+    $package_name = 'docker-ee'
+  } else {
+    $package_name = 'docker-engine'
+  }
   validate_string($docker::version)
   validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
               'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
@@ -99,13 +106,13 @@ class docker::install {
         ensure   => $ensure,
         provider => $pk_provider,
         source   => $docker::package_source,
-        name     => $docker::package_name,
+        name     => $package_name,
       }))
 
     } else {
       ensure_resource('package', 'docker', merge($docker_hash, {
         ensure => $ensure,
-        name   => $docker::package_name,
+        name   => $package_name,
       }))
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,13 +6,6 @@
 #
 class docker::install {
   $docker_start_command = $docker::docker_start_command
-  if ($docker::docker_ce) {
-    $package_name = 'docker-ce'
-  } elsif ($docker::docker_ee) {
-    $package_name = 'docker-ee'
-  } else {
-    $package_name = 'docker-engine'
-  }
   validate_string($docker::version)
   validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
               'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,17 +48,6 @@ class docker::install {
       }
       $manage_kernel = false
     }
-    'Archlinux': {
-      $manage_kernel = false
-      if $docker::version {
-        notify { 'docker::version unsupported on Archlinux':
-          message => 'Versions other than latest are not supported on Arch Linux. This setting will be ignored.'
-        }
-      }
-    }
-    'Gentoo': {
-      $manage_kernel = false
-    }
     default: {}
   }
 
@@ -95,12 +84,25 @@ class docker::install {
         }
       }
 
-      ensure_resource('package', 'docker', merge($docker_hash, {
-        ensure   => $ensure,
-        provider => $pk_provider,
-        source   => $docker::package_source,
-        name     => $docker::docker_package_name,
-      }))
+      case $docker::package_source {
+        /docker-engine/ : {
+          ensure_resource('package', 'docker', merge($docker_hash, {
+            ensure   => $ensure,
+            provider => $pk_provider,
+            source   => $docker::package_source,
+            name     => $docker::docker_engine_package_name,
+          }))
+        }
+        /docker-ce/ : {
+          ensure_resource('package', 'docker', merge($docker_hash, {
+            ensure   => $ensure,
+            provider => $pk_provider,
+            source   => $docker::package_source,
+            name     => $docker::docker_ce_package_name,
+          }))
+        }
+        default : {}
+      }
 
     } else {
       ensure_resource('package', 'docker', merge($docker_hash, {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,8 @@ class docker::params {
   $docker_ee_source_location         = undef
   $docker_ee_key_source              = undef
   $docker_ee_key                     = undef
+  $docker_ee_repos                   = stable
+  $docker_ee_release                 = "${::lsbdistcodename}"
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -78,6 +80,7 @@ class docker::params {
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
+  $os                                = downcase($os[name])
 
   case $::osfamily {
     'Debian' : {
@@ -122,8 +125,6 @@ class docker::params {
         }
       }
 
-      if ( $version =~ /^(17.0[0-5]|1.\d+)/ {
-
       $manage_epel = false
       $service_name = $service_name_default
       $docker_group = $docker_group_default
@@ -154,7 +155,6 @@ class docker::params {
 
     }
     'RedHat' : {
-      $os = downcase($::os[name])
       $service_config = '/etc/sysconfig/docker'
       $storage_config = '/etc/sysconfig/docker-storage'
       $storage_setup_file = '/etc/sysconfig/docker-storage-setup'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,7 +84,7 @@ class docker::params {
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
-  $os                                = downcase($os[name])
+  $os                                = downcase($operatingsystem)
 
   case $::osfamily {
     'Debian' : {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,7 +83,7 @@ class docker::params {
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
-  $os                                = downcase($operatingsystem)
+  $os                                = downcase($::operatingsystem)
 
   case $::osfamily {
     'Debian' : {
@@ -141,15 +141,15 @@ class docker::params {
 
       $package_ce_source_location = "https://download.docker.com/linux/${os}"
       $package_ce_key_source = "https://download.docker.com/linux/${os}/gpg"
-      $package_ce_key_id = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-      $package_ce_release = "${::lsbdistcodename}"
-      $package_source_location = "http://apt.dockerproject.org/repo"
-      $package_key_source = "https://apt.dockerproject.org/gpg"
-      $package_key_id = "58118E89F3A912897C070ADBF76221572C52609D"
+      $package_ce_key_id = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+      $package_ce_release = $::lsbdistcodename
+      $package_source_location = 'http://apt.dockerproject.org/repo'
+      $package_key_source = 'https://apt.dockerproject.org/gpg'
+      $package_key_id = '58118E89F3A912897C070ADBF76221572C52609D'
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
       $package_ee_key_id = $docker_ee_key_id
-      $package_ee_release = "${::lsbdistcodename}"
+      $package_ee_release = $::lsbdistcodename
       $package_ee_repos = $docker_ee_repos
       $package_ee_package_name = $docker_ee_package_name
 
@@ -182,7 +182,7 @@ class docker::params {
       $package_ce_release = undef
       $package_key_id = undef
       $package_release = undef
-      $package_source_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
+      $package_source_location = "https://yum.dockerproject.org/repo/main/${os}/${::operatingsystemmajrelease}"
       $package_key_source = 'https://download.docker.com/linux/centos/gpg'
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,9 +6,13 @@ class docker::params {
   $version                           = undef
   $ensure                            = present
   $docker_ce_start_command           = 'dockerd'
-  $docker_start_command              = 'docker daemon'
+  $docker_ce_package_name            = 'docker-ce'
+  $docker_engine_start_command       = 'docker daemon'
+  $docker_engine_package_name        = 'docker-engine'
   $docker_ce_channel                 = stable
   $docker_ee                         = false
+  $docker_ee_start_command           = 'dockerd'
+  $docker_ee_package_name            = 'docker-ee'
   $docker_ee_source_location         = undef
   $docker_ee_key_source              = undef
   $docker_ee_key                     = undef
@@ -139,12 +143,14 @@ class docker::params {
       $package_ce_source_location = "https://download.docker.com/linux/${os}"
       $package_ce_key_source = "https://download.docker.com/linux/${os}/gpg"
       $package_ce_key_id = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-      $package_location = "http://apt.dockerproject.org/repo"
+      $package_ce_release = "${::lsbdistcodename}"
+      $package_source_location = "http://apt.dockerproject.org/repo"
       $package_key_source = "https://apt.dockerproject.org/gpg"
       $package_key_id = "58118E89F3A912897C070ADBF76221572C52609D"
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
       $package_ee_key = $docker_ee_key
+      $package_ee_release = $docker_ee_release
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
         ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
@@ -185,16 +191,12 @@ class docker::params {
         $manage_epel = false
       }
 
+      $package_ce_source_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
+      $package_ce_key_source = 'https://download.docker.com/linux/centos/gpg'
+      $package_source_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
+      $package_key_source = 'https://download.docker.com/linux/centos/gpg'
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
-      $package_cs_source_location = "https://packages.docker.com/1.9/yum/repo/main/centos/${::operatingsystemmajrelease}"
-      $package_cs_key_source = 'https://packages.docker.com/1.9/yum/gpg'
-      $package_key = undef
-      $package_cs_ke = undef
-      $package_repos = undef
-      $package_release = undef
-      $pin_upstream_package_source = undef
-      $apt_source_pin_level = undef
       $service_name = $service_name_default
       if (versioncmp($::operatingsystemrelease, '7.0') < 0) or ($::operatingsystem == 'Amazon') {
         $detach_service_in_init = true
@@ -237,62 +239,6 @@ class docker::params {
       } else {
         $nowarn_kernel = false
       }
-    }
-    'Archlinux' : {
-      include docker::systemd_reload
-
-      $manage_epel = false
-      $docker_group = $docker_group_default
-      $package_key_source = undef
-      $package_source_location = undef
-      $package_key = undef
-      $package_repos = undef
-      $package_release = undef
-      $use_upstream_package_source = false
-      $package_cs_source_location = undef
-      $package_cs_key_source = undef
-      $package_name = 'docker'
-      $service_name = $service_name_default
-      $detach_service_in_init = false
-      $repo_opt = undef
-      $nowarn_kernel = false
-      $service_provider   = 'systemd'
-      $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-archlinux.conf.erb'
-      $service_hasstatus  = true
-      $service_hasrestart = true
-      $service_config = '/etc/conf.d/docker'
-      $service_config_template = 'docker/etc/conf.d/docker.erb'
-      $storage_config = undef
-      $storage_setup_file = undef
-      $pin_upstream_package_source = undef
-      $apt_source_pin_level = undef
-    }
-    'Gentoo' : {
-      $manage_epel = false
-      $docker_group = $docker_group_default
-      $package_key_source = undef
-      $package_source_location = undef
-      $package_key = undef
-      $package_repos = undef
-      $package_release = undef
-      $use_upstream_package_source = false
-      $package_cs_source_location = undef
-      $package_cs_key_source = undef
-      $package_name = 'app-emulation/docker'
-      $service_name = $service_name_default
-      $detach_service_in_init = true
-      $repo_opt = undef
-      $nowarn_kernel = false
-      $service_provider   = 'openrc'
-      $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-archlinux.conf.erb'
-      $service_hasstatus  = true
-      $service_hasrestart = true
-      $service_config = '/etc/conf.d/docker'
-      $service_config_template = 'docker/etc/conf.d/docker.gentoo.erb'
-      $storage_config = undef
-      $storage_setup_file = undef
-      $pin_upstream_package_source = undef
-      $apt_source_pin_level = undef
     }
     default: {
       $manage_epel = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,8 +5,8 @@
 class docker::params {
   $version                           = undef
   $ensure                            = present
-  $docker_cs                         = false
-  $docker_ce                         = true
+  $docker_ce_start_command           = 'dockerd'
+  $docker_start_command              = 'docker daemon'
   $docker_ce_channel                 = stable
   $docker_ee                         = false
   $docker_ee_source_location         = undef
@@ -122,6 +122,8 @@ class docker::params {
         }
       }
 
+      if ( $version =~ /^(17.0[0-5]|1.\d+)/ {
+
       $manage_epel = false
       $service_name = $service_name_default
       $docker_group = $docker_group_default
@@ -133,9 +135,12 @@ class docker::params {
       $service_config = undef
       $storage_setup_file = undef
 
-      $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
-      $package_cs_key_source = 'https://packages.docker.com/1.9/apt/gpg'
-      $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
+      $package_ce_source_location = "https://download.docker.com/linux/${os}"
+      $package_ce_key_source = "https://download.docker.com/linux/${os}/gpg"
+      $package_ce_key_id = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+      $package_location = "http://apt.dockerproject.org/repo"
+      $package_key_source = "https://apt.dockerproject.org/gpg"
+      $package_key_id = "58118E89F3A912897C070ADBF76221572C52609D"
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
       $package_ee_key = $docker_ee_key

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -183,7 +183,7 @@ class docker::params {
       $package_key_id = undef
       $package_release = undef
       $package_source_location = "https://yum.dockerproject.org/repo/main/${os}/${::operatingsystemmajrelease}"
-      $package_key_source = 'https://download.docker.com/linux/centos/gpg'
+      $package_key_source = 'https://yum.dockerproject.org/gpg'
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
       $package_ee_key_id = $docker_ee_key_id

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,9 +6,12 @@ class docker::params {
   $version                           = undef
   $ensure                            = present
   $docker_cs                         = false
-  $docker_ee                         = false
   $docker_ce                         = true
   $docker_ce_channel                 = stable
+  $docker_ee                         = false
+  $docker_ee_source_location         = undef
+  $docker_ee_key_source              = undef
+  $docker_ee_key                     = undef
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -59,11 +62,9 @@ class docker::params {
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true
-  $package_name_default              = 'docker-ce'
+  $docker_command                    = 'docker'
   $service_name_default              = 'docker'
-  $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
-  $daemon_subcommand                 = 'daemon'
   $storage_devs                      = undef
   $storage_vg                        = undef
   $storage_root_size                 = undef
@@ -122,11 +123,8 @@ class docker::params {
       }
 
       $manage_epel = false
-      $package_name = $package_name_default
       $service_name = $service_name_default
-      $docker_command = $docker_command_default
       $docker_group = $docker_group_default
-      $package_repos = 'main'
       $use_upstream_package_source = true
       $pin_upstream_package_source = true
       $apt_source_pin_level = 10
@@ -141,9 +139,6 @@ class docker::params {
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
       $package_ee_key = $docker_ee_key
-      $package_source_location = 'http://apt.dockerproject.org/repo'
-      $package_key_source = 'https://apt.dockerproject.org/gpg'
-      $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
         ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
@@ -196,7 +191,6 @@ class docker::params {
       $pin_upstream_package_source = undef
       $apt_source_pin_level = undef
       $service_name = $service_name_default
-      $docker_command = $docker_command_default
       if (versioncmp($::operatingsystemrelease, '7.0') < 0) or ($::operatingsystem == 'Amazon') {
         $detach_service_in_init = true
         if $::operatingsystem == 'OracleLinux' {
@@ -254,7 +248,6 @@ class docker::params {
       $package_cs_key_source = undef
       $package_name = 'docker'
       $service_name = $service_name_default
-      $docker_command = $docker_command_default
       $detach_service_in_init = false
       $repo_opt = undef
       $nowarn_kernel = false
@@ -282,7 +275,6 @@ class docker::params {
       $package_cs_key_source = undef
       $package_name = 'app-emulation/docker'
       $service_name = $service_name_default
-      $docker_command = $docker_command_default
       $detach_service_in_init = true
       $repo_opt = undef
       $nowarn_kernel = false
@@ -314,7 +306,6 @@ class docker::params {
       $service_provider = undef
       $package_name = $package_name_default
       $service_name = $service_name_default
-      $docker_command = $docker_command_default
       $detach_service_in_init = true
       $repo_opt = undef
       $nowarn_kernel = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,9 +15,8 @@ class docker::params {
   $docker_ee_package_name            = 'docker-ee'
   $docker_ee_source_location         = undef
   $docker_ee_key_source              = undef
-  $docker_ee_key                     = undef
+  $docker_ee_key_id                  = undef
   $docker_ee_repos                   = stable
-  $docker_ee_release                 = "${::lsbdistcodename}"
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -149,8 +148,11 @@ class docker::params {
       $package_key_id = "58118E89F3A912897C070ADBF76221572C52609D"
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
-      $package_ee_key = $docker_ee_key
-      $package_ee_release = $docker_ee_release
+      $package_ee_key_id = $docker_ee_key_id
+      $package_ee_release = "${::lsbdistcodename}"
+      $package_ee_repos = $docker_ee_repos
+      $package_ee_package_name = $docker_ee_package_name
+
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
         ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
@@ -167,36 +169,29 @@ class docker::params {
       $service_hasstatus  = true
       $service_hasrestart = true
 
-      if ($::operatingsystem == 'Fedora') or (versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
-        $service_provider           = 'systemd'
-        $service_config_template    = 'docker/etc/sysconfig/docker.systemd.erb'
-        $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb'
-      } else {
-        $service_config_template    = 'docker/etc/sysconfig/docker.erb'
-        $service_provider           = undef
-        $service_overrides_template = undef
-      }
 
-      if (versioncmp($::operatingsystemrelease, '7.0') < 0) and $::operatingsystem != 'Amazon' {
-        $package_name = 'docker-io'
-        $use_upstream_package_source = false
-        $manage_epel = true
-      } elsif $::operatingsystem == 'Amazon' {
-        $package_name = 'docker'
-        $use_upstream_package_source = false
-        $manage_epel = false
-      } else {
-        $package_name = $package_name_default
-        $use_upstream_package_source = true
-        $manage_epel = false
-      }
+      $service_provider           = 'systemd'
+      $service_config_template    = 'docker/etc/sysconfig/docker.systemd.erb'
+      $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb'
+      $use_upstream_package_source = true
+      $manage_epel = false
 
       $package_ce_source_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
       $package_ce_key_source = 'https://download.docker.com/linux/centos/gpg'
+      $package_ce_key_id = undef
+      $package_ce_release = undef
+      $package_key_id = undef
+      $package_release = undef
       $package_source_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
       $package_key_source = 'https://download.docker.com/linux/centos/gpg'
       $package_ee_source_location = $docker_ee_source_location
       $package_ee_key_source = $docker_ee_key_source
+      $package_ee_key_id = $docker_ee_key_id
+      $package_ee_release = undef
+      $package_ee_repos = $docker_ee_repos
+      $package_ee_package_name = $docker_ee_package_name
+      $pin_upstream_package_source = undef
+      $apt_source_pin_level = undef
       $service_name = $service_name_default
       if (versioncmp($::operatingsystemrelease, '7.0') < 0) or ($::operatingsystem == 'Amazon') {
         $detach_service_in_init = true
@@ -245,17 +240,26 @@ class docker::params {
       $docker_group = $docker_group_default
       $package_key_source = undef
       $package_source_location = undef
-      $package_key = undef
-      $package_cs_source_location = undef
-      $package_cs_key_source = undef
+      $package_key_id = undef
       $package_repos = undef
       $package_release = undef
+      $package_ce_key_source = undef
+      $package_ce_source_location = undef
+      $package_ce_key_id = undef
+      $package_ce_repos = undef
+      $package_ce_release = undef
+      $package_ee_source_location = undef
+      $package_ee_key_source = undef
+      $package_ee_key_id = undef
+      $package_ee_release = undef
+      $package_ee_repos = undef
+      $package_ee_package_name = undef
       $use_upstream_package_source = true
       $service_overrides_template = undef
       $service_hasstatus  = undef
       $service_hasrestart = undef
       $service_provider = undef
-      $package_name = $package_name_default
+      $package_name = $docker_ce_package_name
       $service_name = $service_name_default
       $detach_service_in_init = true
       $repo_opt = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,9 @@ class docker::params {
   $version                           = undef
   $ensure                            = present
   $docker_cs                         = false
+  $docker_ee                         = false
+  $docker_ce                         = true
+  $docker_ce_channel                 = stable
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -56,7 +59,7 @@ class docker::params {
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true
-  $package_name_default              = 'docker-engine'
+  $package_name_default              = 'docker-ce'
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
@@ -135,6 +138,9 @@ class docker::params {
       $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
       $package_cs_key_source = 'https://packages.docker.com/1.9/apt/gpg'
       $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
+      $package_ee_source_location = $docker_ee_source_location
+      $package_ee_key_source = $docker_ee_key_source
+      $package_ee_key = $docker_ee_key
       $package_source_location = 'http://apt.dockerproject.org/repo'
       $package_key_source = 'https://apt.dockerproject.org/gpg'
       $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
@@ -148,6 +154,7 @@ class docker::params {
 
     }
     'RedHat' : {
+      $os = downcase($::os[name])
       $service_config = '/etc/sysconfig/docker'
       $storage_config = '/etc/sysconfig/docker-storage'
       $storage_setup_file = '/etc/sysconfig/docker-storage-setup'
@@ -177,12 +184,9 @@ class docker::params {
         $use_upstream_package_source = true
         $manage_epel = false
       }
-      $package_key_source = 'https://yum.dockerproject.org/gpg'
-      if $::operatingsystem == 'Fedora' {
-        $package_source_location = "https://yum.dockerproject.org/repo/main/fedora/${::operatingsystemmajrelease}"
-      } else {
-        $package_source_location = "https://yum.dockerproject.org/repo/main/centos/${::operatingsystemmajrelease}"
-      }
+
+      $package_ee_source_location = $docker_ee_source_location
+      $package_ee_key_source = $docker_ee_key_source
       $package_cs_source_location = "https://packages.docker.com/1.9/yum/repo/main/centos/${::operatingsystemmajrelease}"
       $package_cs_key_source = 'https://packages.docker.com/1.9/yum/gpg'
       $package_key = undef

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -34,6 +34,7 @@ define docker::registry(
   $password    = undef,
   $email       = undef,
   $local_user  = 'root',
+  $version     = $docker::version,
 ) {
   include docker::params
 
@@ -42,7 +43,7 @@ define docker::registry(
   $docker_command = $docker::params::docker_command
 
   if $ensure == 'present' {
-    if $username != undef and $password != undef and $email != undef {
+    if $username != undef and $password != undef and $email != undef and $version =~ /1[.][1-9]0?/ {
       $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -9,36 +9,13 @@ class docker::repos (
   $key_source = $docker::package_key_source,
   ) {
 
+  notify {"$location":}
+
   ensure_packages($docker::prerequired_packages)
 
   case $::osfamily {
     'Debian': {
       if ($docker::use_upstream_package_source) {
-        # if ($docker::docker_cs) {
-        #   $location = $docker::package_cs_source_location
-        #   $key_source = $docker::package_cs_key_source
-        #   $package_key = $docker::package_cs_key
-        # } elsif ($docker::docker_ee) {
-        #   $location = $docker::package_ee_source_location
-        #   $key_source = $docker::package_ee_key_source
-        #   $package_key = $docker::package_ee_key
-        # } else {
-        #     if ($docker::docker_ce) {
-        #       $location = "https://download.docker.com/linux/${os}"
-        #       $key_source = "https://download.docker.com/linux/${os}/gpg"
-        #       $package_key = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-        #       $package_repos = $docker::$docker_ce_channel
-        #       $release = "${::lsbdistcodename}"
-        #     } else {
-        #       $location = "http://apt.dockerproject.org/repo"
-        #       $key_source = "https://apt.dockerproject.org/gpg"
-        #       $package_key = "58118E89F3A912897C070ADBF76221572C52609D"
-        #       $package_repos = 'main'
-        #       $release = "ubuntu-${::lsbdistcodename}"
-        #     }
-        # }
-
-        # $location = $dpcker::package_location
         package {['debian-keyring', 'debian-archive-keyring']:
           ensure => installed,
         }
@@ -78,26 +55,8 @@ class docker::repos (
     'RedHat': {
 
       if ($docker::manage_package) {
-        # if ($docker::docker_cs) {
-        #   $baseurl = $docker::package_cs_source_location
-        #   $gpgkey = $docker::package_cs_key_source
-        # }
-        # elsif ($docker::docker_ee) {
-        #   $baseurl = $docker::package_ee_source_location
-        #   $gpgkey = $docker::package_ee_key_source
-        # }
-        # else {
-        #   if ($docker::docker_ce) {
-        #     $package_source_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker::docker_ce_channel}"
-        #     $package_key_source = 'https://download.docker.com/linux/centos/gpg'
-        #   } else {
-        #     $package_source_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
-        #     $package_key_source = 'https://yum.dockerproject.org/gpg'
-        #   }
-
           $baseurl = $location
           $gpgkey = $key_source
-        # }
         if ($docker::use_upstream_package_source) {
           yumrepo { 'docker':
             descr    => 'Docker',

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -59,7 +59,7 @@ class docker::repos (
           yumrepo { 'docker':
             descr    => 'Docker',
             baseurl  => $baseurl,
-            gpgkey   => $gpgkey,
+            gpgkey   => 'https://yum.dockerproject.org/gpg',
             gpgcheck => true,
           }
           Yumrepo['docker'] -> Package['docker']

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -3,18 +3,16 @@
 #
 class docker::repos (
   $location = $docker::package_location,
-  $release = $docker::release,
-  $package_repos = $docker::package_repos,
-  $package_key = $docker::package_key,
   $key_source = $docker::package_key_source,
   ) {
-
-  notify {"$location":}
 
   ensure_packages($docker::prerequired_packages)
 
   case $::osfamily {
     'Debian': {
+      $release = $docker::release
+      $package_key = $docker::package_key
+      $package_repos = $docker::package_repos
       if ($docker::use_upstream_package_source) {
         package {['debian-keyring', 'debian-archive-keyring']:
           ensure => installed,

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,37 +1,44 @@
 # == Class: docker::repos
 #
 #
-class docker::repos {
+class docker::repos (
+  $location = $docker::package_location,
+  $release = $docker::release,
+  $package_repos = $docker::package_repos,
+  $package_key = $docker::package_key,
+  $key_source = $docker::package_key_source,
+  ) {
 
   ensure_packages($docker::prerequired_packages)
-  $os = downcase($os[name])
 
   case $::osfamily {
     'Debian': {
       if ($docker::use_upstream_package_source) {
-        if ($docker::docker_cs) {
-          $location = $docker::package_cs_source_location
-          $key_source = $docker::package_cs_key_source
-          $package_key = $docker::package_cs_key
-        } elsif ($docker::docker_ee) {
-          $location = $docker::package_ee_source_location
-          $key_source = $docker::package_ee_key_source
-          $package_key = $docker::package_ee_key
-        } else {
-            if ($docker::docker_ce) {
-              $location = "https://download.docker.com/linux/${os}"
-              $key_source = "https://download.docker.com/linux/${os}/gpg"
-              $package_key = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-              $package_repos = $docker::docker_ce_channel
-              $release = "${::lsbdistcodename}"
-            } else {
-              $location = "http://apt.dockerproject.org/repo"
-              $key_source = "https://apt.dockerproject.org/gpg"
-              $package_key = "58118E89F3A912897C070ADBF76221572C52609D"
-              $package_repos = 'main'
-              $release = "ubuntu-${::lsbdistcodename}"
-            }
-        }
+        # if ($docker::docker_cs) {
+        #   $location = $docker::package_cs_source_location
+        #   $key_source = $docker::package_cs_key_source
+        #   $package_key = $docker::package_cs_key
+        # } elsif ($docker::docker_ee) {
+        #   $location = $docker::package_ee_source_location
+        #   $key_source = $docker::package_ee_key_source
+        #   $package_key = $docker::package_ee_key
+        # } else {
+        #     if ($docker::docker_ce) {
+        #       $location = "https://download.docker.com/linux/${os}"
+        #       $key_source = "https://download.docker.com/linux/${os}/gpg"
+        #       $package_key = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+        #       $package_repos = $docker::$docker_ce_channel
+        #       $release = "${::lsbdistcodename}"
+        #     } else {
+        #       $location = "http://apt.dockerproject.org/repo"
+        #       $key_source = "https://apt.dockerproject.org/gpg"
+        #       $package_key = "58118E89F3A912897C070ADBF76221572C52609D"
+        #       $package_repos = 'main'
+        #       $release = "ubuntu-${::lsbdistcodename}"
+        #     }
+        # }
+
+        # $location = $dpcker::package_location
         package {['debian-keyring', 'debian-archive-keyring']:
           ensure => installed,
         }
@@ -71,26 +78,26 @@ class docker::repos {
     'RedHat': {
 
       if ($docker::manage_package) {
-        if ($docker::docker_cs) {
-          $baseurl = $docker::package_cs_source_location
-          $gpgkey = $docker::package_cs_key_source
-        }
-        elsif ($docker::docker_ee) {
-          $baseurl = $docker::package_ee_source_location
-          $gpgkey = $docker::package_ee_key_source
-        }
-        else {
-          if ($docker::docker_ce) {
-            $package_source_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker::docker_ce_channel}"
-            $package_key_source = 'https://download.docker.com/linux/centos/gpg'
-          } else {
-            $package_source_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
-            $package_key_source = 'https://yum.dockerproject.org/gpg'
-          }
+        # if ($docker::docker_cs) {
+        #   $baseurl = $docker::package_cs_source_location
+        #   $gpgkey = $docker::package_cs_key_source
+        # }
+        # elsif ($docker::docker_ee) {
+        #   $baseurl = $docker::package_ee_source_location
+        #   $gpgkey = $docker::package_ee_key_source
+        # }
+        # else {
+        #   if ($docker::docker_ce) {
+        #     $package_source_location = "https://download.docker.com/linux/${os}/${::operatingsystemmajrelease}/${::architecture}/${docker::docker_ce_channel}"
+        #     $package_key_source = 'https://download.docker.com/linux/centos/gpg'
+        #   } else {
+        #     $package_source_location = "https://yum.dockerproject.org/repo/main/$os/${::operatingsystemmajrelease}"
+        #     $package_key_source = 'https://yum.dockerproject.org/gpg'
+        #   }
 
-          $baseurl = $package_source_location
-          $gpgkey = $package_key_source
-        }
+          $baseurl = $location
+          $gpgkey = $key_source
+        # }
         if ($docker::use_upstream_package_source) {
           yumrepo { 'docker':
             descr    => 'Docker',

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -4,7 +4,7 @@
 class docker::repos {
 
   ensure_packages($docker::prerequired_packages)
-  os = downcase($os[name])
+  $os = downcase($os[name])
 
   case $::osfamily {
     'Debian': {
@@ -21,6 +21,15 @@ class docker::repos {
             if ($docker::docker_ce) {
               $location = "https://download.docker.com/linux/${os}"
               $key_source = "https://download.docker.com/linux/${os}/gpg"
+              $package_key = "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+              $package_repos = $docker::docker_ce_channel
+              $release = "${::lsbdistcodename}"
+            } else {
+              $location = "http://apt.dockerproject.org/repo"
+              $key_source = "https://apt.dockerproject.org/gpg"
+              $package_key = "58118E89F3A912897C070ADBF76221572C52609D"
+              $package_repos = 'main'
+              $release = "ubuntu-${::lsbdistcodename}"
             }
         }
         package {['debian-keyring', 'debian-archive-keyring']:
@@ -28,8 +37,8 @@ class docker::repos {
         }
         apt::source { 'docker':
           location => $location,
-          release  => $docker::package_release,
-          repos    => $docker::package_repos,
+          release  => $release,
+          repos    => $package_repos,
           key      => {
             id     => $package_key,
             source => $key_source,
@@ -60,7 +69,6 @@ class docker::repos {
 
     }
     'RedHat': {
-      $os = downcase($::os[name])
 
       if ($docker::manage_package) {
         if ($docker::docker_cs) {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,8 +38,9 @@
 #
 class docker::service (
   $docker_command                    = $docker::docker_command,
+  $docker_start_command              = $docker::docker_start_command,
   $service_name                      = $docker::service_name,
-  $daemon_subcommand                 = $docker::daemon_subcommand,
+  # $daemon_subcommand                 = $docker::daemon_subcommand,
   $tcp_bind                          = $docker::tcp_bind,
   $ip_forward                        = $docker::ip_forward,
   $iptables                          = $docker::iptables,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -40,7 +40,6 @@ class docker::service (
   $docker_command                    = $docker::docker_command,
   $docker_start_command              = $docker::docker_start_command,
   $service_name                      = $docker::service_name,
-  # $daemon_subcommand                 = $docker::daemon_subcommand,
   $tcp_bind                          = $docker::tcp_bind,
   $ip_forward                        = $docker::ip_forward,
   $iptables                          = $docker::iptables,

--- a/metadata.json
+++ b/metadata.json
@@ -39,18 +39,6 @@
         "8.0",
         "9.0"
       ]
-    },
-    {
-      "operatingsystem": "Archlinux"
-    },
-    {
-      "operatingsystem": "Gentoo"
-    },
-    {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "21"
-      ]
     }
   ],
   "requirements": [

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'docker' do
-  package_name = 'docker-engine'
+  package_name = 'docker-ce'
   service_name = 'docker'
   command = 'docker'
 
@@ -93,7 +93,7 @@ describe 'docker' do
       registry_host = 'localhost'
       registry_port = 5000
       @registry_address = "#{registry_host}:#{registry_port}"
-      @registry_email = 'user@example.com'
+      # @registry_email = 'user@example.com'
       @config_file = '/root/.docker/config.json'
       @manifest = <<-EOS
         class { 'docker': }
@@ -116,7 +116,6 @@ describe 'docker' do
         docker::registry { '#{@registry_address}':
           username => 'username',
           password => 'password',
-          email    => '#{@registry_email}',
         }
       EOS
       apply_manifest(manifest, :catch_failures=>true)
@@ -131,7 +130,7 @@ describe 'docker' do
       EOS
       apply_manifest(manifest, :catch_failures=>true)
       shell("grep #{@registry_address} #{@config_file}", :acceptable_exit_codes => [1,2])
-      shell("grep #{@registry_email} #{@config_file}", :acceptable_exit_codes => [1,2])
+      # shell("grep #{@registry_email} #{@config_file}", :acceptable_exit_codes => [1,2])
     end
   end
 

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 
 describe 'docker', :type => :class do
 
-  ['Debian', 'Ubuntu', 'RedHat', 'Archlinux', 'Gentoo'].each do |osfamily|
+  ['Debian', 'Ubuntu', 'RedHat'].each do |osfamily|
     context "on #{osfamily}" do
 
       if osfamily == 'Debian'
         let(:facts) { {
+          :architecture           => 'amd64',
           :osfamily               => 'Debian',
           :operatingsystem        => 'Debian',
           :lsbdistid              => 'Debian',
-          :lsbdistcodename        => 'wheezy',
-          :kernelrelease          => '3.2.0-4-amd64',
-          :operatingsystemrelease => '7.3',
-          :operatingsystemmajrelease => '7',
+          :lsbdistcodename        => 'stretch',
+          :kernelrelease          => '4.9.0-3-amd64',
+          :operatingsystemrelease => '9.0',
+          :operatingsystemmajrelease => '9',
         } }
         service_config_file = '/etc/default/docker'
         storage_config_file = '/etc/default/docker'
@@ -25,13 +26,14 @@ describe 'docker', :type => :class do
 
       if osfamily == 'Ubuntu'
         let(:facts) { {
+          :architecture           => 'amd64',
           :osfamily               => 'Debian',
           :operatingsystem        => 'Ubuntu',
           :lsbdistid              => 'Ubuntu',
-          :lsbdistcodename        => 'maverick',
-          :kernelrelease          => '3.8.0-29-generic',
-          :operatingsystemrelease => '10.04',
-          :operatingsystemmajrelease => '10',
+          :lsbdistcodename        => 'xenial',
+          :kernelrelease          => '4.4.0-21-generic',
+          :operatingsystemrelease => '16.04',
+          :operatingsystemmajrelease => '16.04',
         } }
         service_config_file = '/etc/default/docker'
         storage_config_file = '/etc/default/docker'
@@ -45,12 +47,12 @@ describe 'docker', :type => :class do
         end
       end
 
-      if osfamily == 'Ubuntu' or osfamily == 'Debian'
+      if osfamily == 'Ubuntu'
 
         it { should contain_class('apt') }
-        it { should contain_package('docker').with_name('docker-engine').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo') }
-        it { should contain_apt__pin('docker').with_origin('apt.dockerproject.org') }
+        it { should contain_package('docker').with_name('docker-ce').with_ensure('present') }
+        it { should contain_apt__source('docker').with_location('https://download.docker.com/linux/ubuntu') }
+        it { should contain_apt__pin('docker').with_origin('download.docker.com') }
         it { should contain_package('docker').with_install_options(nil) }
 
         it { should contain_file('/etc/default/docker').without_content(/icc=/) }
@@ -64,7 +66,7 @@ describe 'docker', :type => :class do
           let(:params) { {'use_upstream_package_source' => false } }
           it { should_not contain_apt__source('docker') }
           it { should_not contain_apt__pin('docker') }
-          it { should contain_package('docker').with_name('docker-engine') }
+          it { should contain_package('docker').with_name('docker-ce') }
         end
 
         context 'with no upstream package source' do
@@ -901,7 +903,7 @@ describe 'docker', :type => :class do
       :kernelversion => '2.6.32',
     } }
 
-    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_package('docker').with_name('docker-ce') }
     it { should contain_yumrepo('docker') }
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=rhel7-extras') }
@@ -911,33 +913,6 @@ describe 'docker', :type => :class do
     it { should contain_file(service_config_file).with_content(/^http_proxy='http:\/\/127.0.0.1:3128'/) }
     it { should contain_file(service_config_file).with_content(/^  https_proxy='http:\/\/127.0.0.1:3128'/) }
     it { should contain_service('docker').with_provider('systemd').with_hasstatus(true).with_hasrestart(true) }
-  end
-
-  context 'specific to Oracle Linux 7 or above' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystem => 'OracleLinux',
-      :operatingsystemrelease => '7.0',
-      :operatingsystemmajrelease => '7',
-      :kernelversion => '2.6.32',
-    } }
-
-    it { should contain_package('docker').with_name('docker-engine') }
-    it { should_not contain_class('epel') }
-    it { should contain_package('docker').with_install_options('--enablerepo=ol7_addons') }
-  end
-
-  context 'specific to Scientific Linux 7 or above' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystem => 'Scientific',
-      :operatingsystemrelease => '7.0',
-      :operatingsystemmajrelease => '7',
-      :kernelversion => '2.6.32',
-    } }
-
-    it { should contain_package('docker').with_name('docker-engine') }
-    it { should_not contain_class('epel') }
   end
 
   context 'specific to Ubuntu Precise' do
@@ -965,7 +940,7 @@ describe 'docker', :type => :class do
       :kernelrelease          => '3.8.0-29-generic'
     } }
     it { should contain_service('docker').with_provider('upstart') }
-    it { should contain_package('docker').with_name('docker-engine').with_ensure('present')  }
+    it { should contain_package('docker').with_name('docker-ce').with_ensure('present')  }
     it { should contain_package('apparmor') }
   end
 
@@ -995,33 +970,6 @@ describe 'docker', :type => :class do
 
       it { should contain_service('docker').with_provider('systemd').with_hasstatus(true).with_hasrestart(true) }
     end
-  end
-
-
-  context 'specific to older RedHat based distros' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystem => 'RedHat',
-      :operatingsystemrelease => '6.4',
-      :operatingsystemmajrelease => '6',
-      :kernelversion => '2.6.32',
-    } }
-    it do
-      expect {
-        should contain_package('docker')
-      }.to raise_error(Puppet::Error, /version to be at least 6.5/)
-    end
-  end
-
-  context 'specific to Amazon Linux (based on centos6) distros' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystem => 'Amazon',
-      :operatingsystemrelease => '2015.09',
-      :operatingsystemmajrelease => '2015',
-      :kernelversion => '2.6.32',
-    } }
-    it {should contain_service('docker').without_provider }
   end
 
   context 'with an invalid distro name' do

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -10,46 +10,52 @@ describe 'docker::registry', :type => :define do
 		:kernelrelease             => '3.2.0-4-amd64',
 		:operatingsystemmajrelease => '8',
 	} }
+  let(:params) { { 'version' => '17.06' } }
   it { should contain_exec('localhost:5000 auth') }
 
   context 'with ensure => present' do
-    let(:params) { { 'ensure' => 'absent' } }
+    let(:params) { { 'ensure' => 'absent', 'version' => '17.06' } }
     it { should contain_exec('localhost:5000 auth').with_command('docker logout localhost:5000') }
   end
 
   context 'with ensure => present' do
-    let(:params) { { 'ensure' => 'present' } }
+    let(:params) { { 'ensure' => 'present', 'version' => '17.06' } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and username => user1' do
-    let(:params) { { 'ensure' => 'present', 'username' => 'user1' } }
+    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'version' => '17.06'  } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and password => secret' do
-    let(:params) { { 'ensure' => 'present', 'password' => 'secret' } }
+    let(:params) { { 'ensure' => 'present', 'password' => 'secret', 'version' => '17.06'  } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and email => user1@example.io' do
-    let(:params) { { 'ensure' => 'present', 'email' => 'user1@example.io' } }
+    let(:params) { { 'ensure' => 'present', 'email' => 'user1@example.io', 'version' => '17.06'  } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and username => user1, and password => secret and email => user1@example.io' do
-    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
+    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '17.06'  } }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_environment('password=secret') }
+  end
+
+ context 'with ensure => present and username => user1, and password => secret and email => user1@example.io and version < 1.11.0' do
+    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '1.9.0' } }
     it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
   end
 
-  context 'with username => user1, and password => secret and email => user1@example.io' do
-    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
+  context 'with username => user1, and password => secret' do
+    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'version' => '17.06'  } }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_environment('password=secret') }
   end
 
-  context 'with username => user1, and password => secret, and email => user1@example.io and local_user => testuser' do
-    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'local_user' => 'testuser' } }
-    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_user('testuser').with_environment('password=secret') }
+  context 'with username => user1, and password => secret and local_user => testuser' do
+    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'local_user' => 'testuser', 'version' => '17.06'  } }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_user('testuser').with_environment('password=secret') }
   end
 
   context 'with an invalid ensure value' do

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -1,7 +1,7 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKER="/usr/bin/<%= @docker_start_command %>"
 
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,5 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_start_command %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -5,7 +5,7 @@ EnvironmentFile=-/etc/sysconfig/docker-network
 <% if @daemon_environment_files %><% @daemon_environment_files.each do |param| %>EnvironmentFile=-<%= param %>
 <% end %><% end -%>
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_start_command %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
This PR will add the functionality to install the latest versions of docker-ce on all channels in the new docker repos. It maintains support for using the docker-engine package from the old repos based on the version number passed into the module. 

It removed where necessary case statements for unsupported OS's like Archlinux, Gentoo and older versions of RHEL. 