### PR TITLE
(maint)updating arrow alignment for puppet language style guide

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -29,7 +29,9 @@ class docker::repos {
             source => $key_source,
           },
           require  => Package['debian-keyring', 'debian-archive-keyring'],
-          include  => { 'src' => false, },
+          include  => {
+            src => false,
+            },
         }
         $url_split = split($location, '/')
         $repo_host = $url_split[2]


### PR DESCRIPTION
When bundle exec rake test is executed within the module it passes fine however when running in Jenkins , Jenkins complains about the arrow alignment in repos.pp manifest. (see below)

###########Jenkins output##########
+ bundle exec rake test
09:16:42 ---> syntax:manifests
09:16:42 ---> syntax:templates
09:16:42 ---> syntax:hiera:yaml
09:16:47 manifests/repos.pp - WARNING: indentation of => is not properly aligned on line 32

This PR just makes small  arrow alignment change as advised in the puppet language style guide.I have rerun in the module and spec tests pass but just need  pr merged to verify  this resolves the Jenkins issue.