### PR TITLE
(maint) Adding rspec_junit_formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test do
   gem "simplecov-console"
   gem 'parallel_tests' # requires at least Ruby 1.9.3
   gem "json_pure", "<= 2.0.1" # 2.0.2 requires Ruby 2+
+  gem 'rspec_junit_formatter', '~> 0.2.3'
 
 end
 


### PR DESCRIPTION
Jenkins is currently failing  as it cannot load rspec_junit_formatter. This PR adds the formatter to the Gemfile.