### PR TITLE
Allow all digits (IP) for proxy URL

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -30,7 +30,7 @@ class docker::compose(
   validate_re($ensure, '^(present|absent)$')
   validate_absolute_path($install_path)
   if $proxy != undef {
-      validate_re($proxy, '^(https?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
+      validate_re($proxy, '^(https?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([\da-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
   }
 
   if $ensure == 'present' {

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -48,4 +48,13 @@ describe 'docker::compose', :type => :class do
            'curl -s -L --proxy http://user:password@proxy.example.org:3128/ https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
     }
   end
+
+  context 'when proxy IP is provided' do
+    let(:params) { {:proxy => 'http://10.10.10.10:3128/',
+                    :version => '1.7.0'} }
+    it { is_expected.to compile }
+    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
+           'curl -s -L --proxy http://10.10.10.10:3128/ https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    }
+  end
 end


### PR DESCRIPTION
In our environment the proxy URL is an IP address, the regex did not allow the last octet to be numeric.