### PR TITLE
Allow multiple docker::secrets declarations

### DIFF
--- a/manifests/secrets.pp
+++ b/manifests/secrets.pp
@@ -27,7 +27,7 @@ define docker::secrets (
     $exec_secret = "${docker_command} ${docker_secrets_flags}"
     $unless_secret = "${docker_command} inspect ${secret_name}"
 
-  exec { 'docker secret create':
+  exec { "${title} docker secret create":
     command => $exec_secret,
     unless  => $unless_secret,
     path    => ['/bin', '/usr/bin'],
@@ -36,7 +36,7 @@ define docker::secrets (
 
   if $ensure == 'absent'{
 
-  exec { 'docker secret rm':
+  exec { "${title} docker secret rm":
     command => "${docker_command} rm ${secret_name}",
     onlyif  => "${docker_command} inspect ${secret_name}",
     path    => ['/bin', '/usr/bin'],

--- a/spec/defines/secrets_spec.rb
+++ b/spec/defines/secrets_spec.rb
@@ -17,14 +17,27 @@ describe 'docker::secrets', :type => :define do
       'secret_path' => '/root/secret.txt',
       'label' => ['test'],
     } }
-    it { should contain_exec('docker secret create').with_command(/docker secret create/) }
+    it { should contain_exec('test_secret docker secret create').with_command(/docker secret create/) }
+    context 'multiple secrets declaration' do
+      let(:pre_condition) {
+        "
+        docker::secrets{'test_secret_2':
+          secret_name => 'test_secret_2',
+          secret_path => '/root/secret_2.txt',
+        }
+        "
+      }
+      it { should contain_exec('test_secret docker secret create').with_command(/docker secret create/) }
+      it { should contain_exec('test_secret_2 docker secret create').with_command(/docker secret create/) }
+    end
   end
 
   context 'with ensure => absent and secret_name => test_secret' do
     let(:params) { {
       'ensure' => 'absent',
       'secret_name' => 'test_secret'} }
-    it { should contain_exec('docker secret rm').with_command(/docker secret rm/) }
+    it { should contain_exec('test_secret docker secret rm').with_command(/docker secret rm/) }
   end
+
 
 end


### PR DESCRIPTION
When declaring two or more docker::secrets, catalog will fail with
/Duplicate declaration: Exec[docker secret create]/

This commit includes ${title} in exec resources so it doens't throw any
error

Fixes #51