### PR TITLE
Allow multiple docker::services declarations

### DIFF
--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -132,7 +132,7 @@ define docker::services(
   $exec_create = "${docker_command} create --name ${docker_service_create_flags}"
   $unless_create = "docker service ls | grep -w ${service_name}"
 
-  exec { 'Docker service create':
+  exec { "${title} docker service create":
     command     => $exec_create,
     environment => 'HOME=/root',
     path        => ['/bin', '/usr/bin'],
@@ -159,7 +159,7 @@ define docker::services(
 
   $exec_update = "${docker_command} update ${docker_service_flags}"
 
-  exec { 'Docker service update':
+  exec { "${title} docker service update":
     command     => $exec_update,
     environment => 'HOME=/root',
     path        => ['/bin', '/usr/bin'],
@@ -176,7 +176,7 @@ define docker::services(
 
   $exec_scale = "${docker_command} scale ${service_name}=${replicas}"
 
-  exec { 'Docker service scale':
+  exec { "${title} docker service scale":
     command     => $exec_scale,
     environment => 'HOME=/root',
     path        => ['/bin', '/usr/bin'],
@@ -185,7 +185,7 @@ define docker::services(
   }
 
   if $ensure == 'absent' {
-    exec { 'Remove service':
+    exec { "${title} docker service remove":
       command => "docker service rm ${service_name}",
       onlyif  => "docker service ls | grep -w ${service_name}",
       path    => ['/bin', '/usr/bin'],

--- a/spec/defines/services_spec.rb
+++ b/spec/defines/services_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'docker::services', :type => :define do
-  let(:title) { 'create services' }
+  let(:title) { 'test_service' }
 	let(:facts) { {
 		:osfamily                  => 'Debian',
 		:operatingsystem           => 'Debian',
@@ -21,7 +21,21 @@ describe 'docker::services', :type => :define do
             'extra_params' => ['--update-delay 1m', '--restart-window 30s']
     } }
     it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Docker service create').with_command(/docker service create/) }
+    it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
+
+    context 'multiple services declaration' do
+      let(:pre_condition) {
+        "
+        docker::services { 'test_service_2':
+          service_name => 'foo_2',
+          image        => 'foo:bar',
+        }
+        "
+      }
+      it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
+      it { should contain_exec('test_service_2 docker service create').with_command(/docker service create/) }
+
+    end
   end
 
   context 'with ensure => present and service update' do
@@ -32,7 +46,7 @@ describe 'docker::services', :type => :define do
 	    'image'          => 'bar:latest',
     } }
     it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Docker service update').with_command(/docker service update/) }
+    it { should contain_exec('test_service docker service update').with_command(/docker service update/) }
   end
 
   context 'with ensure => present and service scale' do
@@ -43,7 +57,7 @@ describe 'docker::services', :type => :define do
 	    'replicas'       => '5',
     } }
     it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Docker service scale').with_command(/docker service scale/) }
+    it { should contain_exec('test_service docker service scale').with_command(/docker service scale/) }
   end
 
   context 'with ensure => absent' do
@@ -52,6 +66,6 @@ describe 'docker::services', :type => :define do
 	    'service_name'   => 'foo',
     } }
     it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Remove service').with_command(/docker service rm/) }
+    it { should contain_exec('test_service docker service remove').with_command(/docker service rm/) }
   end
 end


### PR DESCRIPTION
When declaring two or more docker::services, catalog will fail with
/Duplicate declaration: Exec[docker service create]/

This commit includes ${title} in exec resources so it doens't throw any
error and fix some semantic issues on test and exec names.

Fixes #51