### PR TITLE
Additional flags for creating a network

### DIFF
--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
       ['--ipam-driver=%s',  :ipam_driver],
       ['--aux-address=%s',  :aux_address],
       ['--opt=%s',          :options],
+      ['%s',                :additional_flags],
     ].each do |(format, key)|
       values    = resource[key]
       new_flags = multi_flags.call(values, format)

--- a/lib/puppet/type/docker_network.rb
+++ b/lib/puppet/type/docker_network.rb
@@ -35,6 +35,10 @@ Puppet::Type.newtype(:docker_network) do
 		desc 'Additional options for the network driver'
 	end
 
+	newparam(:additional_flags) do
+		desc "Additional flags for the 'docker network create'"
+	end
+
 	newproperty(:id) do
 		desc 'The ID of the network provided by Docker'
     validate do |value|


### PR DESCRIPTION
This PR adds the functionality to pass additional flags to the `docker network create` command as there are several missing flags in the current implementation of the `docker_network` resource. In my current use case I just need the `--internal` flag. So another solution could be to just add a new parameter `internal` for the `docker_network` resource but I decided to do this with a more generic solution. With this solution it's possible to use all of the currently available flags and all the flags that may be available in the future without adapting this module again.