### PR TITLE
(CLOUD-1560)-adding-functionality to remove systemd service files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,14 @@ If using Hiera, you can configure the `docker::run_instance` class:
       command: '/bin/sh -c "while true; do echo hello world; sleep 1; done"'
 ```
 
+To remove a running container, add the following code to the manifest file. This will also remove the systemd service file associated with the container.
+
+'''puppet
+docker::run { 'helloworld':
+  ensure => absent,
+}
+'''
+
 ### Networks
 
 Docker 1.9.x officially supports networks. To expose the `docker_network` type, which is used to manage networks, add the following code to the manifest file:

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -320,6 +320,10 @@ define docker::run(
             timeout     => 0
         }
 
+        File { "/etc/systemd/system/${service_prefix}${sanitised_title}.service":
+          ensure => absent,
+          path   => "/etc/systemd/system/${service_prefix}${sanitised_title}.service",
+        }
     }
     else {
       file { $initscript:

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -89,6 +89,7 @@ describe 'the Puppet Docker module' do
         sleep 15
 
         shell('docker inspect container-3-6', :acceptable_exit_codes => [1])
+        shell('test -f /etc/systemd/system/container-3-6.service', :acceptable_exit_codes => [1])
       end
     end
 

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -658,6 +658,7 @@ require 'spec_helper'
         it { should compile.with_all_deps }
         it { should contain_service('docker-sample').with_ensure(false) }
         it { should contain_exec("remove container docker-sample").with_command('docker rm -v sample') }
+        it { should_not contain_file('docker-sample.service')}
       end
 
     end


### PR DESCRIPTION
This PR adds functionality so that when docker run is set to ensure => absent,  the systemd service files are removed. I have verified that this works with single and multiple containers and it is working as expected.