### PR TITLE
Add support for overlay2.override_kernel_check setting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,6 +279,10 @@
 #   synchronization, to continue even though the configuration may be buggy.
 #   Defaults to true
 #
+# [*overlay2_override_kernel_check*]
+#   Overrides the Linux kernel version check allowing using overlay2 with kernel < 4.0.
+#   Default value is false
+#
 # [*manage_package*]
 #   Won't install or define the docker package, useful if you want to use your own package
 #   Defaults to true
@@ -421,6 +425,7 @@ class docker(
   $dm_use_deferred_deletion          = $docker::params::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
+  $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
   $execdriver                        = $docker::params::execdriver,
   $manage_package                    = $docker::params::manage_package,
   $package_source                    = $docker::params::package_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,7 @@ class docker::params {
   $dm_use_deferred_deletion          = undef
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
+  $overlay2_override_kernel_check    = false
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -320,7 +320,7 @@ define docker::run(
             timeout     => 0
         }
 
-        File { "/etc/systemd/system/${service_prefix}${sanitised_title}.service":
+        file { "/etc/systemd/system/${service_prefix}${sanitised_title}.service":
           ensure => absent,
           path   => "/etc/systemd/system/${service_prefix}${sanitised_title}.service",
         }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -85,6 +85,7 @@ class docker::service (
   $dm_use_deferred_deletion          = $docker::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::dm_override_udev_sync_check,
+  $overlay2_override_kernel_check    = $docker::overlay2_override_kernel_check,
   $storage_devs                      = $docker::storage_devs,
   $storage_vg                        = $docker::storage_vg,
   $storage_root_size                 = $docker::storage_root_size,

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -25,22 +25,24 @@ other_args="<% -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @storage_driver == 'devicemapper' -%>
-<% if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
-<% if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
-<% if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
-<% if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
-<% if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
-<% if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
-<% if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
-<% if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
-<% else -%>
-<% if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
-<% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
-<% end -%>
-<% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
-<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
-<% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
-<% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+  <%- if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
+  <%- if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
+  <%- if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
+  <%- if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
+  <%- if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
+  <%- if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
+  <%- if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
+  <%- if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
+  <%- else -%>
+    <%- if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
+    <%- if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
+  <%- end -%>
+  <%- if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+  <%- if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
+  <%- if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
+  <%- if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% elsif @storage_driver == 'overlay2' -%>
+  <%- if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/conf.d/docker.gentoo.erb
+++ b/templates/etc/conf.d/docker.gentoo.erb
@@ -25,22 +25,24 @@ DOCKER_OPTS="<% -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @storage_driver == 'devicemapper' -%>
-<% if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
-<% if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
-<% if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
-<% if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
-<% if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
-<% if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
-<% if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
-<% if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
-<% else -%>
-<% if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
-<% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
-<% end -%>
-<% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
-<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
-<% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
-<% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+  <%- if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
+  <%- if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
+  <%- if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
+  <%- if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
+  <%- if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
+  <%- if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
+  <%- if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
+  <%- if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
+  <%- else -%>
+    <%- if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
+    <%- if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
+  <%- end -%>
+  <%- if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+  <%- if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
+  <%- if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
+  <%- if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% elsif @storage_driver == 'overlay2' -%>
+  <%- if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -42,22 +42,24 @@ DOCKER_OPTS="\
 <% if @mtu %> --mtu=<%= @mtu %> <% end -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @storage_driver == 'devicemapper' -%>
-<% if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
-<% if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
-<% if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
-<% if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
-<% if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
-<% if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
-<% if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
-<% if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
-<% else -%>
-<% if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
-<% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
-<% end -%>
-<% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
-<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
-<% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
-<% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+  <%- if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
+  <%- if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
+  <%- if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
+  <%- if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
+  <%- if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
+  <%- if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
+  <%- if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
+  <%- if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
+  <%- else -%>
+    <%- if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
+    <%- if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
+  <%- end -%>
+  <%- if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+  <%- if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
+  <%- if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
+  <%- if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% elsif @storage_driver == 'overlay2' -%>
+  <%- if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker-storage.erb
+++ b/templates/etc/sysconfig/docker-storage.erb
@@ -17,21 +17,23 @@
 DOCKER_STORAGE_OPTIONS="<% -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @storage_driver == 'devicemapper' -%>
-<% if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
-<% if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
-<% if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
-<% if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
-<% if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
-<% if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
-<% if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
-<% if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
-<% else -%>
-<% if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
-<% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
-<% end -%>
-<% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
-<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
-<% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
-<% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+  <%- if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
+  <%- if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>
+  <%- if @dm_mkfsarg %> --storage-opt "dm.mkfsarg=<%= @dm_mkfsarg %>"<% end -%>
+  <%- if @dm_mountopt %> --storage-opt dm.mountopt=<%= @dm_mountopt %><% end -%>
+  <%- if @dm_blocksize %> --storage-opt dm.blocksize=<%= @dm_blocksize %><% end -%>
+  <%- if @dm_loopdatasize %> --storage-opt dm.loopdatasize=<%= @dm_loopdatasize %><% end -%>
+  <%- if @dm_loopmetadatasize %> --storage-opt dm.loopmetadatasize=<%= @dm_loopmetadatasize %><% end -%>
+  <%- if @dm_thinpooldev %> --storage-opt dm.thinpooldev=<%= @dm_thinpooldev -%>
+  <%- else -%>
+    <%- if @dm_datadev %> --storage-opt dm.datadev=<%= @dm_datadev %><% end -%>
+    <%- if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
+  <%- end -%>
+  <%- if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+  <%- if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
+  <%- if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
+  <%- if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% elsif @storage_driver == 'overlay2' -%>
+  <%- if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 "


### PR DESCRIPTION
Quoting https://docs.docker.com/engine/reference/commandline/dockerd/ :

> overlay2.override_kernel_check
> 
> Overrides the Linux kernel version check allowing overlay2. Support for specifying multiple lower directories needed by overlay2 was added to the Linux kernel in 4.0.0. However, some older kernel versions may be patched to add multiple lower directory support for OverlayFS. This option should only be used after verifying this support exists in the kernel. Applying this option on a kernel without this support will cause failures on mount.

This is required to use overlay2 on Centos 7 with kernel 3.x.