### PR TITLE
(maint)Fixing syntax error to get ci passing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ begin
     :syntax,
     :lint,
     :parallel_spec,
-    :metadata,
+    :metadata_lint,
   ]
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
@@ -64,10 +64,9 @@ if Rake::Task.task_defined?('metadata_lint')
   task :metadata => :metadata_lint
 end
 
-desc 'Run syntax, lint, spec and metadata tests'
+desc 'Run syntax, lint and  metadata tests'
 task :test => [
   :syntax,
   :lint,
-  :spec,
-  :metadata,
+  :metadata_lint,
 ]

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -73,7 +73,7 @@ define docker::registry(
     $local_user_strip = regsubst($local_user, '-', '', 'G')
 
     $_pass_hash = $pass_hash ? {
-      Undef   => pw_hash("${title}${auth_environment}${auth_cmd}${local_user}", 'SHA-512', $local_user_strip),
+      'Undef'   => pw_hash("${title}${auth_environment}${auth_cmd}${local_user}", 'SHA-512', $local_user_strip),
       default => $pass_hash
     }
 


### PR DESCRIPTION
This PR fixes a syntax error that puppet-lint-unquoted_string-check version 0.2.5 was complaining about.CI uses the internal ruby Gems and so is not using the latest it uses 0.2.5 which is why we didn't see this error when running locally as we use latest locally (0.3).

 lt also fixes a deprecation warning for the deprecated metadata task and replaces with metadata_lint. It also removes spec tests from running during test rake task so that  test now runs lint and metadata tests. This is so the spec tests are not running twice in ci. Verified that all tests still passing.