### PR TITLE
(maint)updating readme for github issue #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,13 +582,14 @@ To remove the service from a swarm, include the `ensure => absent` parameter and
 
 If a server is not specified, images are pushed and pulled from [index.docker.io](https://index.docker.io). To qualify your image name, create a private repository without authentication.
 
-To configure authentication for a private registry, add the following code to the manifest file:
+To configure authentication for a private registry, add the following code to the manifest file , depending on what version of Docker you are running. If you are using Docker V1.10 or earlier add the following code to the manifest file ensuring that you specify the docker version:
 
 ```puppet
 docker::registry { 'example.docker.io:5000':
   username => 'user',
   password => 'secret',
   email    => 'user@example.com',
+  version  => '<docker_version>'
 }
 ```
 
@@ -600,8 +601,28 @@ docker::registry_auth::registries:
     username: 'user1'
     password: 'secret'
     email: 'user1@example.io'
+    version: '<docker_version>'
   }
 ```
+
+If using Docker V1.11 or later the docker login e-mail flag has been deprecated [docker_change_log](https://docs.docker.com/release-notes/docker-engine/#1110-2016-04-13). Add the following code to the manifest file:
+
+'''puppet
+docker::registry { 'example.docker.io:5000'}
+  username => 'user',
+  password => 'secret',
+}
+''
+
+If using hiera, configure the 'docker::registry_auth' class:
+
+'''yaml
+docker::registry_auth::registries:
+  'example.docker.io:5000':
+    username: 'user1'
+    password: 'secret'
+  }
+'''
 
 To log out of a registry, add the following code to the manifest file:
 


### PR DESCRIPTION
This PR update the read-me in relation to GitHub issue #68. If the user is using Docker V1.10.0.3 or earlier and leaves the  version as undefined the puppet run will fail with a comparison warning. I have updated the readme with 2 code examples 1 for V1.10.3 and earlier and one from V1.11.0 and later (when e-mail login was deprecated).