### PR TITLE
(CLOUD-1505) Replace validate functions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
   repositories:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
-      ref: 2.1.0
+      ref: 2.1.0 
   symlinks:
     docker: "#{source_dir}"

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -21,15 +21,18 @@
 #   Proxy to use for downloading Docker Compose.
 #
 class docker::compose(
-  $ensure = 'present',
-  $version = $docker::params::compose_version,
-  $install_path = $docker::params::compose_install_path,
-  $proxy = undef
+  Optional[String] $ensure = 'present',
+  Optional[String] $version = $docker::params::compose_version,
+  Optional[String] $install_path = $docker::params::compose_install_path,
+  Optional[String] $proxy = undef
 ) inherits docker::params {
-  validate_string($version)
-  validate_re($ensure, '^(present|absent)$')
-  validate_absolute_path($install_path)
-  if $proxy != undef {
+  if $version {
+    assert_type(String[1], $version)
+  }
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
+  assert_type(String[1], $install_path)
+  if $proxy  {
+      #assert_type(Pattern[/^(https?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([\da-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$/], $proxy)
       validate_re($proxy, '^(https?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([\da-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
   }
 

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -3,25 +3,31 @@
 # A define which executes a command inside a container.
 #
 define docker::exec(
-  $detach = false,
-  $interactive = false,
-  $tty = false,
-  $container = undef,
-  $command = undef,
-  $unless = undef,
-  $sanitise_name = true,
+  Optional[Boolean] $detach = false,
+  Optional[Boolean] $interactive = false,
+  Optional[Boolean] $tty = false,
+  Optional[String] $container = undef,
+  Optional[String] $command = undef,
+  Optional[String] $unless = undef,
+  Optional[Boolean] $sanitise_name = true,
 ) {
   include docker::params
 
   $docker_command = $docker::params::docker_command
-  validate_string($docker_command)
+  assert_type(String[1], $docker_command)
 
-  validate_string($container)
-  validate_string($command)
-  validate_string($unless)
-  validate_bool($detach)
-  validate_bool($interactive)
-  validate_bool($tty)
+  if $container {
+  assert_type(String[1], $container)
+  }
+  if $command {
+  assert_type(String[1], $command)
+  }
+  if $unless {
+    assert_type(String[1], $unless)
+  }
+  assert_type(Boolean, $detach)
+  assert_type(Boolean, $interactive)
+  assert_type(Boolean, $tty)
 
   $docker_exec_flags = docker_exec_flags({
     detach => $detach,

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -24,20 +24,20 @@
 #   If you want to load a docker image from specific docker tar
 #
 define docker::image(
-  $ensure       = 'present',
-  $image        = $title,
-  $image_tag    = undef,
-  $image_digest = undef,
-  $force        = false,
-  $docker_file  = undef,
-  $docker_dir   = undef,
-  $docker_tar   = undef,
+  Optional[String] $ensure       = 'present',
+  Optional[String] $image        = $title,
+  Optional[String] $image_tag    = undef,
+  Optional[String] $image_digest = undef,
+  Optional[Boolean] $force        = false,
+  Optional[String] $docker_file  = undef,
+  Optional[String] $docker_dir   = undef,
+  Optional[String] $docker_tar   = undef,
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command
-  validate_re($ensure, '^(present|absent|latest)$')
-  validate_re($image, '^[\S]*$')
-  validate_bool($force)
+  assert_type(Pattern[/^(present|absent|latest)$/], $ensure)
+  assert_type(Pattern[/^[\S]*$/], $image)
+  assert_type(Boolean, $force)
 
   # Wrapper used to ensure images are up to date
   ensure_resource('file', '/usr/local/bin/update_docker_image.sh',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -349,161 +349,181 @@
 #   Extend the pool by specified percentage when threshold is hit.
 #
 class docker(
-  $version                           = $docker::params::version,
-  $ensure                            = $docker::params::ensure,
-  $prerequired_packages              = $docker::params::prerequired_packages,
-  $docker_ce_start_command           = $docker::params::docker_ce_start_command,
-  $docker_ce_package_name            = $docker::params::docker_ce_package_name,
-  $docker_ce_source_location         = $docker::params::package_ce_source_location,
-  $docker_ce_key_source              = $docker::params::package_ce_key_source,
-  $docker_ce_key_id                  = $docker::params::package_ce_key_id,
-  $docker_ce_release                 = $docker::params::package_ce_release,
-  $docker_package_location           = $docker::params::package_source_location,
-  $docker_package_key_source         = $docker::params::package_key_source,
-  $docker_package_key_id             = $docker::params::package_key_id,
-  $docker_package_release            = $docker::params::package_release,
-  $docker_engine_start_command       = $docker::params::docker_engine_start_command,
-  $docker_engine_package_name        = $docker::params::docker_engine_package_name,
-  $docker_ce_channel                 = $docker::params::docker_ce_channel,
-  $docker_ee                         = $docker::params::docker_ee,
-  $docker_ee_package_name            = $docker::params::package_ee_package_name,
-  $docker_ee_source_location         = $docker::params::package_ee_source_location,
-  $docker_ee_key_source              = $docker::params::package_ee_key_source,
-  $docker_ee_key_id                  = $docker::params::package_ee_key_id,
-  $docker_ee_repos                   = $docker::params::package_ee_repos,
-  $docker_ee_release                 = $docker::params::package_ee_release,
-  $tcp_bind                          = $docker::params::tcp_bind,
-  $tls_enable                        = $docker::params::tls_enable,
-  $tls_verify                        = $docker::params::tls_verify,
-  $tls_cacert                        = $docker::params::tls_cacert,
-  $tls_cert                          = $docker::params::tls_cert,
-  $tls_key                           = $docker::params::tls_key,
-  $ip_forward                        = $docker::params::ip_forward,
-  $ip_masq                           = $docker::params::ip_masq,
-  $bip                               = $docker::params::bip,
-  $mtu                               = $docker::params::mtu,
-  $iptables                          = $docker::params::iptables,
-  $icc                               = $docker::params::icc,
-  $socket_bind                       = $docker::params::socket_bind,
-  $fixed_cidr                        = $docker::params::fixed_cidr,
-  $bridge                            = $docker::params::bridge,
-  $default_gateway                   = $docker::params::default_gateway,
-  $log_level                         = $docker::params::log_level,
-  $log_driver                        = $docker::params::log_driver,
-  $log_opt                           = $docker::params::log_opt,
-  $selinux_enabled                   = $docker::params::selinux_enabled,
-  $use_upstream_package_source       = $docker::params::use_upstream_package_source,
-  $pin_upstream_package_source       = $docker::params::pin_upstream_package_source,
-  $apt_source_pin_level              = $docker::params::apt_source_pin_level,
-  $package_release                   = $docker::params::package_release,
-  $service_state                     = $docker::params::service_state,
-  $service_enable                    = $docker::params::service_enable,
-  $manage_service                    = $docker::params::manage_service,
-  $root_dir                          = $docker::params::root_dir,
-  $tmp_dir                           = $docker::params::tmp_dir,
-  $manage_kernel                     = $docker::params::manage_kernel,
-  $dns                               = $docker::params::dns,
-  $dns_search                        = $docker::params::dns_search,
-  $socket_group                      = $docker::params::socket_group,
-  $labels                            = $docker::params::labels,
-  $extra_parameters                  = undef,
-  $shell_values                      = undef,
-  $proxy                             = $docker::params::proxy,
-  $no_proxy                          = $docker::params::no_proxy,
-  $storage_driver                    = $docker::params::storage_driver,
-  $dm_basesize                       = $docker::params::dm_basesize,
-  $dm_fs                             = $docker::params::dm_fs,
-  $dm_mkfsarg                        = $docker::params::dm_mkfsarg,
-  $dm_mountopt                       = $docker::params::dm_mountopt,
-  $dm_blocksize                      = $docker::params::dm_blocksize,
-  $dm_loopdatasize                   = $docker::params::dm_loopdatasize,
-  $dm_loopmetadatasize               = $docker::params::dm_loopmetadatasize,
-  $dm_datadev                        = $docker::params::dm_datadev,
-  $dm_metadatadev                    = $docker::params::dm_metadatadev,
-  $dm_thinpooldev                    = $docker::params::dm_thinpooldev,
-  $dm_use_deferred_removal           = $docker::params::dm_use_deferred_removal,
-  $dm_use_deferred_deletion          = $docker::params::dm_use_deferred_deletion,
-  $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
-  $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
-  $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
-  $execdriver                        = $docker::params::execdriver,
-  $manage_package                    = $docker::params::manage_package,
-  $package_source                    = $docker::params::package_source,
-  $manage_epel                       = $docker::params::manage_epel,
-  $service_name                      = $docker::params::service_name,
-  $docker_users                      = [],
-  $docker_group                      = $docker::params::docker_group,
-  $daemon_environment_files          = [],
-  $repo_opt                          = $docker::params::repo_opt,
-  $nowarn_kernel                     = $docker::params::nowarn_kernel,
-  $os                                = $docker::params::os,
-  $storage_devs                      = $docker::params::storage_devs,
-  $storage_vg                        = $docker::params::storage_vg,
-  $storage_root_size                 = $docker::params::storage_root_size,
-  $storage_data_size                 = $docker::params::storage_data_size,
-  $storage_min_data_size             = $docker::params::storage_min_data_size,
-  $storage_chunk_size                = $docker::params::storage_chunk_size,
-  $storage_growpart                  = $docker::params::storage_growpart,
-  $storage_auto_extend_pool          = $docker::params::storage_auto_extend_pool,
-  $storage_pool_autoextend_threshold = $docker::params::storage_pool_autoextend_threshold,
-  $storage_pool_autoextend_percent   = $docker::params::storage_pool_autoextend_percent,
-  $storage_config                    = $docker::params::storage_config,
-  $storage_config_template           = $docker::params::storage_config_template,
-  $storage_setup_file                = $docker::params::storage_setup_file,
-  $service_provider                  = $docker::params::service_provider,
-  $service_config                    = $docker::params::service_config,
-  $service_config_template           = $docker::params::service_config_template,
-  $service_overrides_template        = $docker::params::service_overrides_template,
-  $service_hasstatus                 = $docker::params::service_hasstatus,
-  $service_hasrestart                = $docker::params::service_hasrestart,
+  Optional[String] $version                           = $docker::params::version,
+  String $ensure                                      = $docker::params::ensure,
+  Tuple $prerequired_packages                         = $docker::params::prerequired_packages,
+  String $docker_ce_start_command                     = $docker::params::docker_ce_start_command,
+  Optional[String] $docker_ce_package_name            = $docker::params::docker_ce_package_name,
+  Optional[String] $docker_ce_source_location         = $docker::params::package_ce_source_location,
+  Optional[String] $docker_ce_key_source              = $docker::params::package_ce_key_source,
+  Optional[String] $docker_ce_key_id                  = $docker::params::package_ce_key_id,
+  Optional[String] $docker_ce_release                 = $docker::params::package_ce_release,
+  Optional[String] $docker_package_location                     = $docker::params::package_source_location,
+  Optional[String] $docker_package_key_source                   = $docker::params::package_key_source,
+  Optional[String] $docker_package_key_id             = $docker::params::package_key_id,
+  Optional[String] $docker_package_release            = $docker::params::package_release,
+  String $docker_engine_start_command                 = $docker::params::docker_engine_start_command,
+  String $docker_engine_package_name                  = $docker::params::docker_engine_package_name,
+  String $docker_ce_channel                           = $docker::params::docker_ce_channel,
+  Optional[Boolean] $docker_ee                                  = $docker::params::docker_ee,
+  Optional[String] $docker_ee_package_name                      = $docker::params::package_ee_package_name,
+  Optional[String] $docker_ee_source_location         = $docker::params::package_ee_source_location,
+  Optional[String] $docker_ee_key_source              = $docker::params::package_ee_key_source,
+  Optional[String] $docker_ee_key_id                  = $docker::params::package_ee_key_id,
+  Optional[String] $docker_ee_repos                             = $docker::params::package_ee_repos,
+  Optional[String] $docker_ee_release                 = $docker::params::package_ee_release,
+  Variant[String,Tuple,Undef] $tcp_bind               = $docker::params::tcp_bind,
+  Boolean $tls_enable                                 = $docker::params::tls_enable,
+  Boolean $tls_verify                                 = $docker::params::tls_verify,
+  Optional[String] $tls_cacert                        = $docker::params::tls_cacert,
+  Optional[String] $tls_cert                          = $docker::params::tls_cert,
+  Optional[String] $tls_key                           = $docker::params::tls_key,
+  Boolean $ip_forward                                 = $docker::params::ip_forward,
+  Boolean $ip_masq                                    = $docker::params::ip_masq,
+  Optional[String] $bip                               = $docker::params::bip,
+  Optional[String] $mtu                               = $docker::params::mtu,
+  Boolean $iptables                                   = $docker::params::iptables,
+  Optional[Boolean] $icc                              = $docker::params::icc,
+  String $socket_bind                                 = $docker::params::socket_bind,
+  Optional[String] $fixed_cidr                        = $docker::params::fixed_cidr,
+  Optional[String] $bridge                            = $docker::params::bridge,
+  Optional[String] $default_gateway                   = $docker::params::default_gateway,
+  Optional[String] $log_level                         = $docker::params::log_level,
+  Optional[String] $log_driver                        = $docker::params::log_driver,
+  Array $log_opt                                      = $docker::params::log_opt,
+  Optional[String] $selinux_enabled                   = $docker::params::selinux_enabled,
+  Optional[Boolean] $use_upstream_package_source      = $docker::params::use_upstream_package_source,
+  Optional[Boolean] $pin_upstream_package_source      = $docker::params::pin_upstream_package_source,
+  Optional[Integer] $apt_source_pin_level             = $docker::params::apt_source_pin_level,
+  Optional[String] $package_release                   = $docker::params::package_release,
+  String $service_state                               = $docker::params::service_state,
+  Boolean $service_enable                             = $docker::params::service_enable,
+  Boolean $manage_service                             = $docker::params::manage_service,
+  Optional[String] $root_dir                          = $docker::params::root_dir,
+  Optional[String] $tmp_dir                           = $docker::params::tmp_dir,
+  Boolean $manage_kernel                              = $docker::params::manage_kernel,
+  Variant[String,Array,Undef] $dns                    = $docker::params::dns,
+  Variant[String,Array,Undef] $dns_search             = $docker::params::dns_search,
+  Optional[String] $socket_group                      = $docker::params::socket_group,
+  Array $labels                                       = $docker::params::labels,
+  Variant[String,Array,Undef] $extra_parameters       = undef,
+  Variant[String,Array,Undef] $shell_values           = undef,
+  Optional[String] $proxy                             = $docker::params::proxy,
+  Optional[String] $no_proxy                          = $docker::params::no_proxy,
+  Optional[String] $storage_driver                    = $docker::params::storage_driver,
+  Optional[String] $dm_basesize                       = $docker::params::dm_basesize,
+  Optional[String] $dm_fs                             = $docker::params::dm_fs,
+  Optional[String] $dm_mkfsarg                        = $docker::params::dm_mkfsarg,
+  Optional[String] $dm_mountopt                       = $docker::params::dm_mountopt,
+  Optional[String] $dm_blocksize                      = $docker::params::dm_blocksize,
+  Optional[String] $dm_loopdatasize                   = $docker::params::dm_loopdatasize,
+  Optional[String] $dm_loopmetadatasize               = $docker::params::dm_loopmetadatasize,
+  Optional[String] $dm_datadev                        = $docker::params::dm_datadev,
+  Optional[String] $dm_metadatadev                    = $docker::params::dm_metadatadev,
+  Optional[String] $dm_thinpooldev                    = $docker::params::dm_thinpooldev,
+  Optional[String] $dm_use_deferred_removal           = $docker::params::dm_use_deferred_removal,
+  Optional[String] $dm_use_deferred_deletion          = $docker::params::dm_use_deferred_deletion,
+  Optional[String] $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
+  Optional[String] $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
+  Boolean $overlay2_override_kernel_check             = $docker::params::overlay2_override_kernel_check,
+  Optional[String] $execdriver                        = $docker::params::execdriver,
+  Boolean $manage_package                             = $docker::params::manage_package,
+  Optional[String] $package_source                    = $docker::params::package_source,
+  Boolean $manage_epel                                = $docker::params::manage_epel,
+  Optional[String] $service_name                      = $docker::params::service_name,
+  Array $docker_users                                 = [],
+  String $docker_group                                = $docker::params::docker_group,
+  Array $daemon_environment_files                     = [],
+  Variant[String,Hash,Undef] $repo_opt                = $docker::params::repo_opt,
+  Boolean $nowarn_kernel                              = $docker::params::nowarn_kernel,
+  Optional[String] $os                                = $docker::params::os,
+  Optional[String] $storage_devs                      = $docker::params::storage_devs,
+  Optional[String] $storage_vg                        = $docker::params::storage_vg,
+  Optional[String] $storage_root_size                 = $docker::params::storage_root_size,
+  Optional[String] $storage_data_size                 = $docker::params::storage_data_size,
+  Optional[String] $storage_min_data_size             = $docker::params::storage_min_data_size,
+  Optional[String] $storage_chunk_size                = $docker::params::storage_chunk_size,
+  Optional[String] $storage_growpart                  = $docker::params::storage_growpart,
+  Optional[String] $storage_auto_extend_pool          = $docker::params::storage_auto_extend_pool,
+  Optional[String] $storage_pool_autoextend_threshold = $docker::params::storage_pool_autoextend_threshold,
+  Optional[String] $storage_pool_autoextend_percent   = $docker::params::storage_pool_autoextend_percent,
+  Optional[String] $storage_config                    = $docker::params::storage_config,
+  Optional[String] $storage_config_template           = $docker::params::storage_config_template,
+  Optional[String] $storage_setup_file                = $docker::params::storage_setup_file,
+  Optional[String] $service_provider                  = $docker::params::service_provider,
+  Optional[String] $service_config                    = $docker::params::service_config,
+  Optional[String] $service_config_template           = $docker::params::service_config_template,
+  Optional[String] $service_overrides_template        = $docker::params::service_overrides_template,
+  Optional[Boolean] $service_hasstatus                          = $docker::params::service_hasstatus,
+  Optional[Boolean] $service_hasrestart                         = $docker::params::service_hasrestart,
 
 ) inherits docker::params {
 
-  validate_string($version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
-              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
-  validate_bool($manage_kernel)
-  validate_bool($manage_package)
-  validate_bool($manage_service)
-  validate_array($docker_users)
-  validate_array($daemon_environment_files)
-  validate_array($log_opt)
-  validate_bool($tls_enable)
-  validate_bool($ip_forward)
-  validate_bool($iptables)
-  validate_bool($ip_masq)
-  if $icc != undef {
-    validate_bool($icc)
-  }
-  validate_string($bridge)
-  validate_string($fixed_cidr)
-  validate_string($default_gateway)
-  validate_string($bip)
+  if $version {
+	  assert_type(String[1], $version)
+	}
 
+ if $::osfamily {
+   assert_type(Pattern[/^(Debian|RedHat|Archlinux|Gentoo)$/], $::osfamily) |$a, $b| {
+     fail('This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
+    }
+  }
+  assert_type(Boolean, $manage_kernel)
+  assert_type(Boolean, $manage_service)
+  assert_type(Array, $docker_users)
+  assert_type(Array, $daemon_environment_files)
+  assert_type(Array, $log_opt)
+  assert_type(Boolean, $tls_enable)
+  assert_type(Boolean, $ip_forward)
+  assert_type(Boolean, $iptables)
+  assert_type(Boolean, $ip_masq)
+  if $icc != undef {
+    assert_type(Boolean, $icc)
+  }
+  if $bridge {
+  assert_type(String[1], $bridge)
+  }
+  if $fixed_cidr {
+  assert_type(String[1], $fixed_cidr)
+  }
+  if $default_gateway {
+  assert_type(String[1], $default_gateway)
+  }
+  if $bip {
+  assert_type(String[1], $bip)
+  }
   if ($default_gateway) and (!$bridge) {
     fail('You must provide the $bridge parameter.')
   }
 
   if $log_level {
-    validate_re($log_level, '^(debug|info|warn|error|fatal)$', 'log_level must be one of debug, info, warn, error or fatal')
+    assert_type(Pattern[/^(debug|info|warn|error|fatal)$/], $log_level) |$a, $b| {
+        fail('log_level must be one of debug, info, warn, error or fatal')
+    }
   }
 
   if $log_driver {
-    validate_re($log_driver, '^(none|json-file|syslog|journald|gelf|fluentd|splunk)$',
-                'log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk')
+    assert_type(Pattern[/^(none|json-file|syslog|journald|gelf|fluentd|splunk)$/], $log_driver) |$a, $b| {
+      fail('log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk')
+    }
   }
 
   if $selinux_enabled {
-    validate_re($selinux_enabled, '^(true|false)$', 'selinux_enabled must be true or false')
+    assert_type(Pattern[/^(true|false)$/], $selinux_enabled) |$a, $b| {
+      fail('selinux_enabled must be true or false')
+    }
   }
 
   if $storage_driver {
-    validate_re($storage_driver, '^(aufs|devicemapper|btrfs|overlay|overlay2|vfs|zfs)$',
-                'Valid values for storage_driver are aufs, devicemapper, btrfs, overlay, overlay2, vfs, zfs.' )
+    assert_type(Pattern[/^(aufs|devicemapper|btrfs|overlay|overlay2|vfs|zfs)$/], $storage_driver) |$a, $b| {
+      fail('Valid values for storage_driver are aufs, devicemapper, btrfs, overlay, overlay2, vfs, zfs.')
+    }
   }
 
   if $dm_fs {
-    validate_re($dm_fs, '^(ext4|xfs)$', 'Only ext4 and xfs are supported currently for dm_fs.')
+    assert_type(Pattern[/^(ext4|xfs)$/], $dm_fs) |$a, $b| {
+      fail('Only ext4 and xfs are supported currently for dm_fs.')
+    }
   }
 
   if ($dm_loopdatasize or $dm_loopmetadatasize) and ($dm_datadev or $dm_metadatadev) {
@@ -531,15 +551,19 @@ class docker(
     if(!$tcp_bind) {
         fail('You need to provide tcp bind parameter for TLS.')
     }
-    validate_string($tls_cacert)
-    validate_string($tls_cert)
-    validate_string($tls_key)
+    assert_type(String[1], $tls_cacert)
+    assert_type(String[1], $tls_cert)
+    assert_type(String[1], $tls_key)
   }
 
   if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.]\d-ce|1.\d+)/ ) {
     if ( $docker_ee) {
-      validate_string($docker::docker_ee_source_location)
-      validate_string($docker::docker_ee_key_source)
+      if $docker::docker_ee_source_location {
+        assert_type(String[1], $docker::docker_ee_source_location)
+      }
+      if $docker::docker_ee_key_source {
+        assert_type(String[1], $docker::docker_ee_key_source)
+      }
       $package_location = $docker::docker_ee_source_location
       $package_key_source = $docker::docker_ee_key_source
       $package_key = $docker::docker_ee_key_id
@@ -595,4 +619,3 @@ class docker(
   Class['docker'] -> Docker::Run <||>
 
 }
-

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,11 +6,15 @@
 #
 class docker::install {
   $docker_start_command = $docker::docker_start_command
-  validate_string($docker::version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
-              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
-  validate_bool($docker::use_upstream_package_source)
-
+  if $docker::version {
+    assert_type(String[1], $docker::version)
+  }
+  if $::osfamily {
+    assert_type(Pattern[/^(Debian|RedHat|Archlinux|Gentoo)$/], $::osfamily) |$a, $b| {
+      fail('This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
+    }
+  }
+  assert_type(Boolean, $docker::use_upstream_package_source)
   if $docker::version and $docker::ensure != 'absent' {
     $ensure = $docker::version
   } else {

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -33,20 +33,19 @@
 #   Required to be true for idempotency
 #
 define docker::registry(
-  $server      = $title,
-  $ensure      = 'present',
-  $username    = undef,
-  $password    = undef,
-  $pass_hash   = undef,
-  $email       = undef,
-  $local_user  = 'root',
-  $version     = $docker::version,
-  $receipt     = true,
+  Optional[String] $server      = $title,
+  Optional[String] $ensure      = 'present',
+  Optional[String] $username    = undef,
+  Optional[String] $password    = undef,
+  Optional[String] $pass_hash   = undef,
+  Optional[String] $email       = undef,
+  Optional[String] $local_user  = 'root',
+  Optional[String] $version     = $docker::version,
+  Optional[Boolean] $receipt     = true,
 ) {
   include docker::params
 
-  validate_re($ensure, '^(present|absent)$')
-
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
   $docker_command = $docker::params::docker_command
 
   if $ensure == 'present' {

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -60,55 +60,55 @@
 # Default: on-failure
 #
 define docker::run(
-  $image,
-  $ensure = 'present',
-  $command = undef,
-  $memory_limit = '0b',
-  $cpuset = [],
-  $ports = [],
-  $labels = [],
-  $expose = [],
-  $volumes = [],
-  $links = [],
-  $use_name = false,
-  $running = true,
-  $volumes_from = [],
-  $net = 'bridge',
-  $username = false,
-  $hostname = false,
-  $env = [],
-  $env_file = [],
-  $dns = [],
-  $dns_search = [],
-  $lxc_conf = [],
-  $service_prefix = 'docker-',
-  $restart_service = true,
-  $restart_service_on_docker_refresh = true,
-  $manage_service = true,
-  $docker_service = false,
-  $disable_network = false,
-  $privileged = false,
-  $detach = undef,
-  $extra_parameters = undef,
-  $systemd_restart = 'on-failure',
-  $extra_systemd_parameters = {},
-  $pull_on_start = false,
-  $after = [],
-  $after_service = [],
-  $depends = [],
-  $depend_services = [],
-  $tty = false,
-  $socket_connect = [],
-  $hostentries = [],
-  $restart = undef,
-  $before_start = false,
-  $before_stop = false,
-  $remove_container_on_start = true,
-  $remove_container_on_stop = true,
-  $remove_volume_on_start = false,
-  $remove_volume_on_stop = false,
-  $stop_wait_time = 0,
-  $syslog_identifier = undef,
+  Optional[String] $image,
+  Optional[String] $ensure = 'present',
+  Optional[String] $command = undef,
+  Optional[String] $memory_limit = '0b',
+  Variant[String,Array,Undef] $cpuset = [],
+  Variant[String,Array,Undef] $ports = [],
+  Variant[String,Array,Undef] $labels = [],
+  Variant[String,Array,Undef] $expose = [],
+  Variant[String,Array,Undef] $volumes = [],
+  Variant[String,Array,Undef] $links = [],
+  Optional[Boolean] $use_name = false,
+  Optional[Boolean] $running = true,
+  Variant[String,Array,Undef] $volumes_from = [],
+  Optional[String] $net = 'bridge',
+  Variant[String,Boolean] $username = false,
+  Variant[String,Boolean] $hostname = false,
+  Variant[String,Array,Undef] $env = [],
+  Variant[String,Array,Undef] $env_file = [],
+  Variant[String,Array,Undef] $dns = [],
+  Variant[String,Array,Undef] $dns_search = [],
+  Variant[String,Array,Undef] $lxc_conf = [],
+  Optional[String] $service_prefix = 'docker-',
+  Optional[Boolean] $restart_service = true,
+  Optional[Boolean] $restart_service_on_docker_refresh = true,
+  Optional[Boolean] $manage_service = true,
+  Variant[String,Boolean] $docker_service = false,
+  Optional[Boolean] $disable_network = false,
+  Optional[Boolean] $privileged = false,
+  Optional[Boolean] $detach = undef,
+  Variant[String,Tuple,Undef] $extra_parameters = undef,
+  Optional[String] $systemd_restart = 'on-failure',
+  Variant[String,Hash,Undef] $extra_systemd_parameters = {},
+  Optional[Boolean] $pull_on_start = false,
+  Variant[String,Array,Undef] $after = [],
+  Variant[String,Array,Undef] $after_service = [],
+  Variant[String,Array,Undef] $depends = [],
+  Variant[String,Array,Undef] $depend_services = [],
+  Optional[Boolean] $tty = false,
+  Variant[String,Array,Undef] $socket_connect = [],
+  Variant[String,Array,Undef] $hostentries = [],
+  Optional[String] $restart = undef,
+  Variant[String,Boolean] $before_start = false,
+  Variant[String,Boolean] $before_stop = false,
+  Optional[Boolean] $remove_container_on_start = true,
+  Optional[Boolean] $remove_container_on_stop = true,
+  Optional[Boolean] $remove_volume_on_start = false,
+  Optional[Boolean] $remove_volume_on_stop = false,
+  Optional[Integer] $stop_wait_time = 0,
+  Optional[String] $syslog_identifier = undef,
 ) {
   include docker
   if ($socket_connect != []) {
@@ -120,39 +120,53 @@ define docker::run(
   $service_name = $docker::service_name
   $docker_group = $docker::docker_group
 
-  validate_re($image, '^[\S]*$')
-  validate_re($title, '^[\S]*$')
-  validate_re($memory_limit, '^[\d]*(b|k|m|g)$')
-  validate_re($ensure, '^(present|absent)')
-  if $restart {
-    validate_re($restart, '^(no|always|unless-stopped|on-failure)|^on-failure:[\d]+$')
+  if $image {
+  assert_type(Pattern[/^[\S]*$/], $image)
   }
-  validate_string($docker_command)
-  validate_string($service_name)
-  validate_string($docker_group)
+  if $title {
+  assert_type(Pattern[/^[\S]*$/], $title)
+  }
+  if $memory_limit {
+  assert_type(Pattern[/^[\d]*(b|k|m|g)$/], $memory_limit)
+  }
+  if $ensure {
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
+  }
+  if $restart {
+    assert_type(Pattern[/^(no|always|unless-stopped|on-failure)|^on-failure:[\d]+$/], $restart)
+  }
+  if $docker_command {
+  assert_type(String[1], $docker_command)
+  }
+  if $service_name {
+  assert_type(String[1], $service_name)
+  }
+  if $docker_group{
+  assert_type(String[1], $docker_group)
+  }
 
   if $command {
-    validate_string($command)
+    assert_type(String[1], $command)
   }
   if $username {
-    validate_string($username)
+  assert_type(String, $username)
   }
   if $hostname {
-    validate_string($hostname)
+  assert_type(String, $hostname)
   }
-  validate_bool($running)
-  validate_bool($disable_network)
-  validate_bool($privileged)
-  validate_bool($restart_service)
-  validate_bool($restart_service_on_docker_refresh)
-  validate_bool($tty)
-  validate_bool($remove_container_on_start)
-  validate_bool($remove_container_on_stop)
-  validate_bool($remove_volume_on_start)
-  validate_bool($remove_volume_on_stop)
-  validate_bool($use_name)
+  assert_type(Boolean, $running)
+  assert_type(Boolean, $disable_network)
+  assert_type(Boolean, $privileged)
+  assert_type(Boolean, $restart_service)
+  assert_type(Boolean, $restart_service_on_docker_refresh)
+  assert_type(Boolean, $tty)
+  assert_type(Boolean, $remove_container_on_start)
+  assert_type(Boolean, $remove_container_on_stop)
+  assert_type(Boolean, $remove_volume_on_start)
+  assert_type(Boolean, $remove_volume_on_stop)
+  assert_type(Boolean, $use_name)
 
-  validate_integer($stop_wait_time)
+  assert_type(Integer, $stop_wait_time)
 
   if ($remove_volume_on_start and !$remove_container_on_start) {
     fail("In order to remove the volume on start for ${title} you need to also remove the container")
@@ -169,15 +183,15 @@ define docker::run(
     }
   }
 
-  validate_hash($extra_systemd_parameters)
+  assert_type(Hash, $extra_systemd_parameters)
   if $systemd_restart {
-    validate_re($systemd_restart, '^(no|always|on-success|on-failure|on-abnormal|on-abort|on-watchdog)$')
+    assert_type(Pattern[/^(no|always|on-success|on-failure|on-abnormal|on-abort|on-watchdog)$/], $systemd_restart)
   }
 
   if $detach == undef {
     $valid_detach = $docker::params::detach_service_in_init
   } else {
-    validate_bool($detach)
+    assert_type(Boolean, $detach)
     $valid_detach = $detach
   }
 

--- a/manifests/secrets.pp
+++ b/manifests/secrets.pp
@@ -1,18 +1,22 @@
 define docker::secrets (
 
-  $ensure = 'present',
-  $label = [],
-  $secret_name = undef,
-  $secret_path = undef,
+  Optional[String] $ensure = 'present',
+  Variant[String,Array,Undef] $label = [],
+  Optional[String] $secret_name = undef,
+  Optional[String] $secret_path = undef,
 ){
   include docker::params
 
   $docker_command = "${docker::params::docker_command} secret"
-  validate_re($ensure, '^(present|absent)$')
-  validate_string($docker_command)
-  validate_string($secret_name)
-  validate_string($secret_path)
-  validate_array($label)
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
+  assert_type(String[1], $docker_command)
+  if $secret_name {
+  assert_type(String[1], $secret_name)
+  }
+  if $secret_path {
+  assert_type(String[1], $secret_path)
+  }
+  assert_type(Array, $label)
 
 
 

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -65,41 +65,55 @@
 #
 
 define docker::services(
-  $ensure       = 'present',
-  $create       = true,
-  $update       = false,
-  $scale        = false,
-  $detach       = true,
-  $tty          = false,
-  $env          = [],
-  $label        = [],
-  $extra_params = [],
-  $image        = undef,
-  $service_name = undef,
-  $publish      = undef,
-  $replicas     = undef,
-  $user         = undef,
-  $workdir      = undef,
-  $host_socket  = undef,
+  Optional[String] $ensure        = 'present',
+  Optional[Boolean] $create       = true,
+  Optional[Boolean] $update       = false,
+  Optional[Boolean] $scale        = false,
+  Optional[Boolean] $detach       = true,
+  Optional[Boolean] $tty          = false,
+  Optional[Array] $env            = [],
+  Optional[Array] $label          = [],
+  Optional[Array] $extra_params   = [],
+  Variant[String,Array,Undef] $image          = undef,
+  Variant[String,Array,Undef] $service_name   = undef,
+  Variant[String,Array,Undef] $publish        = undef,
+  Variant[String,Array,Undef] $replicas       = undef,
+  Variant[String,Array,Undef] $user           = undef,
+  Variant[String,Array,Undef] $workdir        = undef,
+  Variant[String,Array,Undef] $host_socket    = undef,
 ){
 
   include docker::params
 
   $docker_command = "${docker::params::docker_command} service"
-  validate_re($ensure, '^(present|absent)$')
-  validate_string($docker_command)
-  validate_string($image)
-  validate_string($service_name)
-  validate_string($publish)
-  validate_string($replicas)
-  validate_string($user)
-  validate_string($workdir)
-  validate_string($host_socket)
-  validate_bool($detach)
-  validate_bool($tty)
-  validate_bool($create)
-  validate_bool($update)
-  validate_bool($scale)
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
+  assert_type(String[1], $docker_command)
+  if $image {
+  assert_type(String[1], $image)
+  }
+  if $service_name {
+  assert_type(String[1], $service_name)
+  }
+  if $publish {
+  assert_type(String[1], $publish)
+  }
+  if $replicas {
+  assert_type(String[1], $replicas)
+  }
+  if $user {
+  assert_type(String[1], $user)
+  }
+  if $workdir {
+  assert_type(String[1], $workdir)
+  }
+  if $host_socket {
+  assert_type(String[1], $host_socket)
+  }
+  assert_type(Boolean, $detach)
+  assert_type(Boolean, $tty)
+  assert_type(Boolean, $create)
+  assert_type(Boolean, $update)
+  assert_type(Boolean, $scale)
 
   if $ensure == 'absent' {
     if $update {
@@ -189,4 +203,3 @@ define docker::services(
     }
   }
 }
-

--- a/manifests/stack.pp
+++ b/manifests/stack.pp
@@ -9,14 +9,14 @@
 #  Defaults to present
 #
 # [*stack_name*]
-#   The name of the stack that you are deploying 
+#   The name of the stack that you are deploying
 #   Defaults to undef
 #
 # [*bundle_file*]
 #  Path to a Distributed Application Bundle file
 #  Please note this is experimental
 #  Defaults to undef
-# 
+#
 # [*compose_file*]
 #  Path to a Compose file
 #  Defaults to undef
@@ -36,22 +36,26 @@
 
 define docker::stack(
 
-  $ensure = 'present',
-  $stack_name = undef,
-  $bundle_file = undef,
-  $compose_file = undef,
-  $prune = undef,
-  $with_registry_auth = undef,
+  Optional[String] $ensure = 'present',
+  Optional[String] $stack_name = undef,
+  Optional[String] $bundle_file = undef,
+  Optional[String] $compose_file = undef,
+  Optional[String] $prune = undef,
+  Optional[String] $with_registry_auth = undef,
 
   ){
 
   include docker::params
 
   $docker_command = "${docker::params::docker_command} stack"
-  validate_re($ensure, '^(present|absent)$')
-  validate_string($docker_command)
-  validate_string($stack_name)
-  validate_string($bundle_file)
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
+  assert_type(String[1], $docker_command)
+  if $stack_name {
+  assert_type(String[1], $stack_name)
+  }
+  if $bundle_file {
+  assert_type(String[1], $bundle_file)
+  }
 
   if $ensure == 'present'{
       $docker_stack_flags = docker_stack_flags ({

--- a/manifests/swarm.pp
+++ b/manifests/swarm.pp
@@ -1,10 +1,10 @@
 # == Define: docker::swarm
-# 
+#
 # A define that managers a Docker Swarm Mode cluster
 #
 # == Paramaters
 #
-# [*ensure*] 
+# [*ensure*]
 #  This ensures that the cluster is present or not.
 #  Defaults to present
 #  Note this forcefully removes a node from the cluster. Make sure all worker nodes
@@ -13,7 +13,7 @@
 # [*init*]
 #  This creates the first worker node for a new cluster.
 #  Set init to true to create a new cluster
-#  Defaults to false  
+#  Defaults to false
 #
 # [*join*]
 #  This adds either a worker or manger node to the cluster.
@@ -33,7 +33,7 @@
 # [*cert_expiry*]
 #  Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
 #  defaults to undef
-#  
+#
 # [*dispatcher_heartbeat*]
 #  Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
 #  Defaults to undef
@@ -72,39 +72,55 @@
 
 define docker::swarm(
 
-  $ensure = 'present',
-  $init = false,
-  $join = false,
-  $advertise_addr = undef,
-  $autolock = false,
-  $cert_expiry = undef,
-  $dispatcher_heartbeat = undef,
-  $external_ca = undef,
-  $force_new_cluster = false,
-  $listen_addr = undef,
-  $max_snapshots = undef,
-  $snapshot_interval = undef,
-  $token = undef,
-  $manager_ip = undef,
+  Optional[String] $ensure = 'present',
+  Optional[Boolean] $init = false,
+  Optional[Boolean] $join = false,
+  Optional[String] $advertise_addr = undef,
+  Optional[Boolean] $autolock = false,
+  Optional[String] $cert_expiry = undef,
+  Optional[String] $dispatcher_heartbeat = undef,
+  Optional[String] $external_ca = undef,
+  Optional[Boolean] $force_new_cluster = false,
+  Optional[String] $listen_addr = undef,
+  Optional[String] $max_snapshots = undef,
+  Optional[String] $snapshot_interval = undef,
+  Optional[String] $token = undef,
+  Optional[String] $manager_ip = undef,
   ){
 
   include docker::params
 
   $docker_command = "${docker::params::docker_command} swarm"
-  validate_re($ensure, '^(present|absent)$')
-  validate_string($docker_command)
-  validate_string($cert_expiry)
-  validate_string($dispatcher_heartbeat)
-  validate_string($external_ca)
-  validate_string($max_snapshots)
-  validate_string($snapshot_interval)
-  validate_string($token)
-  validate_ip_address($advertise_addr)
-  validate_ip_address($listen_addr)
-  validate_bool($init)
-  validate_bool($join)
-  validate_bool($autolock)
-  validate_bool($force_new_cluster)
+  assert_type(Pattern[/^present$|^absent$/], $ensure)
+  assert_type(String[1], $docker_command)
+  if $cert_expiry {
+  assert_type(String[1], $cert_expiry)
+  }
+  if $dispatcher_heartbeat {
+  assert_type(String[1], $dispatcher_heartbeat)
+  }
+  if $external_ca {
+  assert_type(String[1], $external_ca)
+  }
+  if $max_snapshots {
+  assert_type(String[1], $max_snapshots)
+  }
+  if $snapshot_interval {
+  assert_type(String[1], $snapshot_interval)
+  }
+  if $token {
+  assert_type(String[1], $token)
+  }
+  if $advertise_addr {
+  assert_type(String[1], $advertise_addr)
+  }
+  if $listen_addr {
+  assert_type(String[1], $listen_addr)
+  }
+  assert_type(Boolean, $init)
+  assert_type(Boolean, $join)
+  assert_type(Boolean, $autolock)
+  assert_type(Boolean, $force_new_cluster)
 
   if $init {
   $docker_swarm_init_flags = docker_swarm_init_flags({

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-docker",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-docker/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.24.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 2.1.0"},
     {"name":"stahnma/epel","version_requirement":">= 0.0.6"}
   ],

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -594,12 +594,12 @@ describe 'docker', :type => :class do
       end
 
       context 'with service_enable set to false' do
-        let(:params) { {'service_enable' => 'false'} }
+        let(:params) { {'service_enable' => false} }
         it { should contain_service('docker').with_enable('false') }
       end
 
       context 'with service_enable set to true' do
-        let(:params) { {'service_enable' => 'true'} }
+        let(:params) { {'service_enable' => true} }
         it { should contain_service('docker').with_enable('true') }
       end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -34,7 +34,7 @@ RSpec.configure do |c|
       end
       on(host, 'yum update -y -q') if fact_on(host, 'osfamily') == 'RedHat'
 
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.24.0'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '2.1.0'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'stahnma-epel'), { :acceptable_exit_codes => [0,1] }
 


### PR DESCRIPTION
Hi 
Request for a quick look.This is still in WIP.Following changes are done to the files.
1.Validate_* functions are replaced with validate_legacy functions on all the manifests file
2.Updated the metadata.json,.fixtures.yml & spec_helper_acceptance to use the latest version of puppetlabs-apt module(which is updated and replaced with validate_legacy functions on release 3.3.0.0 and later those functions are removed on release 4.4.0)
4.Added datatypes to all the variables.Tests are executed and they are running clean.

Even though all warning is removed.The following work is pending.
Remove validate_legacy functions.Update the Readme with the details of the Datatype and add/update the tests.

Following changes are done validate_legacy functions are replaced with assert_type function.
Fixed the spec tests failures.(One more to fix on compose.pp-we r still using the validate_re function)



