### PR TITLE
docker::run: Add service_provider param to override OS detection

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,7 +563,11 @@ class docker(
             $package_key_source = $docker_ce_key_source
             $package_key_check_source = true
           }
-          default: {}
+          default: {
+            $package_location = $docker_package_location
+            $package_key_source = $docker_package_key_source
+            $package_key_check_source = $docker_package_key_check_source
+          }
         }
         $docker_start_command = $docker_ce_start_command
         $docker_package_name = $docker_ce_package_name
@@ -583,7 +587,11 @@ class docker(
         $package_key_source = $docker_package_key_source
         $package_key_check_source = $docker_package_key_check_source
       }
-      default : {}
+      default : {
+        $package_location = $docker_package_location
+        $package_key_source = $docker_package_key_source
+        $package_key_check_source = $docker_package_key_check_source
+      }
     }
     $docker_start_command = $docker_engine_start_command
     $docker_package_name = $docker_engine_package_name

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,7 +48,9 @@ class docker::install {
       }
       $manage_kernel = false
     }
-    default: {}
+    default: {
+      $manage_kernel = false
+    }
   }
 
   if $manage_kernel {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -129,6 +129,8 @@ class docker::service (
   } else {
     if $::osfamily == 'Debian' {
       $_service_config = "/etc/default/${service_name}"
+    } else {
+      $_service_config = undef
     }
   }
 

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
-['Debian', 'RedHat'].each do |osfamily|
+['Debian', 'RedHat', 'generic systemd'].each do |osfamily|
   describe 'docker::run', :type => :define do
     let(:title) { 'sample' }
+    params = {'command' => 'command', 'image' => 'base'}
+
     context "on #{osfamily}" do
 
       if osfamily == 'Debian'
@@ -32,10 +34,19 @@ require 'spec_helper'
         initscript = '/etc/systemd/system/docker-sample.service'
         command = 'docker'
         systemd = true
+      elsif osfamily == 'generic systemd'
+        let(:facts) { {
+          :osfamily        => 'Gentoo',
+          :operatingsystem => 'Generic',
+        } }
+        params.merge!({'service_provider' => 'systemd'})
+        initscript = '/etc/systemd/system/docker-sample.service'
+        command = 'docker'
+        systemd = true
       end
 
       context 'passing the required params' do
-        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        let(:params) { params }
         it { should compile.with_all_deps }
         it { should contain_service('docker-sample') }
         if (osfamily == 'Debian')
@@ -56,7 +67,7 @@ require 'spec_helper'
       end
 
       context 'when passing `after` containers' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'after' => ['foo', 'bar', 'foo_bar/baz']} }
+        let(:params) { params.merge({'after' => ['foo', 'bar', 'foo_bar/baz']}) }
         if (systemd)
           it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-foo.service/) }
           it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-bar.service/) }
@@ -72,7 +83,7 @@ require 'spec_helper'
       end
 
       context 'when passing `depends` containers' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'depends' => ['foo', 'bar', 'foo_bar/baz']} }
+        let(:params) { params.merge({'depends' => ['foo', 'bar', 'foo_bar/baz']}) }
         if (systemd)
           it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-foo.service/) }
           it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-bar.service/) }
@@ -91,7 +102,7 @@ require 'spec_helper'
       end
 
       context 'when passing `depend_services`' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'depend_services' => ['foo', 'bar']} }
+        let(:params) { params.merge({'depend_services' => ['foo', 'bar']}) }
         if (systemd)
           it { should contain_file(initscript).with_content(/After=(.*\s+)?foo.service/) }
           it { should contain_file(initscript).with_content(/After=(.*\s+)?bar.service/) }
@@ -107,12 +118,10 @@ require 'spec_helper'
 
       context 'removing containers and volumes' do
         context 'when trying to remove the volume and not the container on stop' do
-          let(:params) {{
-            'command' => 'command',
-            'image' => 'base',
+          let(:params) { params.merge({
             'remove_container_on_stop' => false,
             'remove_volume_on_stop' => true,
-          }}
+          }) }
           it do
             expect {
               should contain_service('docker-sample')
@@ -121,12 +130,10 @@ require 'spec_helper'
         end
 
         context 'when trying to remove the volume and not the container on start' do
-          let(:params) {{
-            'command' => 'command',
-            'image' => 'base',
+          let(:params) { params.merge({
             'remove_container_on_start' => false,
             'remove_volume_on_start' => true,
-          }}
+          }) }
           it do
             expect {
               should contain_service('docker-sample')
@@ -135,12 +142,10 @@ require 'spec_helper'
         end
 
         context 'when not removing containers on container start and stop' do
-          let(:params) {{
-            'command' => 'command',
-            'image' => 'base',
+          let(:params) { params.merge({
             'remove_container_on_start' => false,
             'remove_container_on_stop' => false,
-          }}
+          }) }
           if (systemd)
             it { should_not contain_file(initscript).with_content(/ExecStartPre=-\/usr\/bin\/docker rm/) }
           else
@@ -149,7 +154,7 @@ require 'spec_helper'
         end
 
         context 'when removing containers on container start' do
-          let(:params) { {'command' => 'command', 'image' => 'base', 'remove_container_on_start' => true} }
+          let(:params) { params.merge({'remove_container_on_start' => true}) }
           if (systemd)
             it { should contain_file(initscript).with_content(/ExecStartPre=-\/usr\/bin\/docker rm/) }
           else
@@ -158,7 +163,7 @@ require 'spec_helper'
         end
 
         context 'when removing containers on container stop' do
-          let(:params) { {'command' => 'command', 'image' => 'base', 'remove_container_on_stop' => true} }
+          let(:params) { params.merge({'remove_container_on_stop' => true}) }
           if (systemd)
             it { should contain_file(initscript).with_content(/ExecStop=-\/usr\/bin\/docker rm/) }
           else
@@ -167,7 +172,7 @@ require 'spec_helper'
         end
 
         context 'when not removing volumes on container start' do
-          let(:params) { {'command' => 'command', 'image' => 'base', 'remove_volume_on_start' => false} }
+          let(:params) { params.merge({'remove_volume_on_start' => false}) }
           if (systemd)
             it { should_not contain_file(initscript).with_content(/ExecStartPre=-\/usr\/bin\/docker rm -v/) }
           else
@@ -176,7 +181,7 @@ require 'spec_helper'
         end
 
         context 'when removing volumes on container start' do
-          let(:params) { {'command' => 'command', 'image' => 'base', 'remove_volume_on_start' => true} }
+          let(:params) { params.merge({'remove_volume_on_start' => true}) }
           if (systemd)
             it { should contain_file(initscript).with_content(/ExecStartPre=-\/usr\/bin\/docker rm -v/) }
           else
@@ -185,7 +190,7 @@ require 'spec_helper'
         end
 
         context 'when not removing volumes on container stop' do
-          let(:params) { {'command' => 'command', 'image' => 'base', 'remove_volume_on_stop' => false} }
+          let(:params) { params.merge({'remove_volume_on_stop' => false}) }
           if (systemd)
             it { should_not contain_file(initscript).with_content(/ExecStop=-\/usr\/bin\/docker rm -v/) }
           else
@@ -194,7 +199,7 @@ require 'spec_helper'
         end
 
         context 'when removing volumes on container stop' do
-          let(:params) { {'command' => 'command', 'image' => 'base', 'remove_volume_on_stop' => true} }
+          let(:params) { params.merge({'remove_volume_on_stop' => true}) }
           if (systemd)
             it { should contain_file(initscript).with_content(/ExecStop=-\/usr\/bin\/docker rm -v/) }
           else
@@ -204,180 +209,180 @@ require 'spec_helper'
       end
 
       context 'with autorestart functionality' do
-        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        let(:params) { params }
         if (systemd)
           it { should contain_file(initscript).with_content(/Restart=on-failure/) }
         end
       end
 
       context 'when lxc_conf disables swap' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'lxc_conf' => 'lxc.cgroup.memory.memsw.limit_in_bytes=536870912'} }
+        let(:params) { params.merge({'lxc_conf' => 'lxc.cgroup.memory.memsw.limit_in_bytes=536870912'}) }
         it { should contain_file(initscript).with_content(/-lxc-conf=\"lxc.cgroup.memory.memsw.limit_in_bytes=536870912\"/) }
       end
 
       context 'when `use_name` is true' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'use_name' => true } }
+        let(:params) { params.merge({'use_name' => true }) }
         it { should contain_file(initscript).with_content(/ --name sample /) }
       end
 
       context 'when stopping the service' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'running' => false} }
+        let(:params) { params.merge({'running' => false}) }
         it { should contain_service('docker-sample').with_ensure(false) }
       end
 
       context 'when passing a memory limit in bytes' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'memory_limit' => '1000b'} }
+        let(:params) { params.merge({'memory_limit' => '1000b'}) }
         it { should contain_file(initscript).with_content(/-m 1000b/) }
       end
 
       context 'when passing a cpuset' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => '3'} }
+        let(:params) { params.merge({'cpuset' => '3'}) }
         it { should contain_file(initscript).with_content(/--cpuset=3/) }
       end
 
       context 'when passing a multiple cpu cpuset' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => ['0', '3']} }
+        let(:params) { params.merge({'cpuset' => ['0', '3']}) }
         it { should contain_file(initscript).with_content(/--cpuset=0,3/) }
       end
 
       context 'when not passing a cpuset' do
-        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        let(:params) { params }
         it { should contain_file(initscript).without_content(/--cpuset=/) }
       end
 
       context 'when passing a links option' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'links' => ['example:one', 'example:two']} }
+        let(:params) { params.merge({'links' => ['example:one', 'example:two']}) }
         it { should contain_file(initscript).with_content(/--link example:one/).with_content(/--link example:two/) }
       end
 
       context 'when passing a hostname' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'hostname' => 'example.com'} }
+        let(:params) { params.merge({'hostname' => 'example.com'}) }
         it { should contain_file(initscript).with_content(/-h 'example.com'/) }
       end
 
       context 'when not passing a hostname' do
-        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        let(:params) { params }
         it { should contain_file(initscript).without_content(/-h ''/) }
       end
 
       context 'when passing a username' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'username' => 'bob'} }
+        let(:params) { params.merge({'username' => 'bob'}) }
         it { should contain_file(initscript).with_content(/-u 'bob'/) }
       end
 
       context 'when not passing a username' do
-        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        let(:params) { params }
         it { should contain_file(initscript).without_content(/-u ''/) }
       end
 
       context 'when passing a port number' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'ports' => '4444'} }
+        let(:params) { params.merge({'ports' => '4444'}) }
         it { should contain_file(initscript).with_content(/-p 4444/) }
       end
 
       context 'when passing a port to expose' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'expose' => '4666'} }
+        let(:params) { params.merge({'expose' => '4666'}) }
         it { should contain_file(initscript).with_content(/--expose=4666/) }
       end
 
       context 'when passing a label' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'labels' => 'key=value'} }
+        let(:params) { params.merge({'labels' => 'key=value'}) }
         it { should contain_file(initscript).with_content(/-l key=value/) }
       end
 
       context 'when passing a hostentry' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'hostentries' => 'dummyhost:127.0.0.2'} }
+        let(:params) { params.merge({'hostentries' => 'dummyhost:127.0.0.2'}) }
         it { should contain_file(initscript).with_content(/--add-host dummyhost:127.0.0.2/) }
       end
 
       context 'when connecting to shared data volumes' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'volumes_from' => '6446ea52fbc9'} }
+        let(:params) { params.merge({'volumes_from' => '6446ea52fbc9'}) }
         it { should contain_file(initscript).with_content(/--volumes-from 6446ea52fbc9/) }
       end
 
       context 'when connecting to several shared data volumes' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'volumes_from' => ['sample-linked-container-1', 'sample-linked-container-2']} }
+        let(:params) { params.merge({'volumes_from' => ['sample-linked-container-1', 'sample-linked-container-2']}) }
         it { should contain_file(initscript).with_content(/--volumes-from sample-linked-container-1/) }
         it { should contain_file(initscript).with_content(/--volumes-from sample-linked-container-2/) }
       end
 
       context 'when passing several port numbers' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'ports' => ['4444', '4555']} }
+        let(:params) { params.merge({'ports' => ['4444', '4555']}) }
         it { should contain_file(initscript).with_content(/-p 4444/).with_content(/-p 4555/) }
       end
 
       context 'when passing several labels' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'labels' => ['key1=value1', 'key2=value2']} }
+        let(:params) { params.merge({'labels' => ['key1=value1', 'key2=value2']}) }
         it { should contain_file(initscript).with_content(/-l key1=value1/).with_content(/-l key2=value2/) }
       end
 
       context 'when passing several ports to expose' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'expose' => ['4666', '4777']} }
+        let(:params) { params.merge({'expose' => ['4666', '4777']}) }
         it { should contain_file(initscript).with_content(/--expose=4666/).with_content(/--expose=4777/) }
       end
 
       context 'when passing serveral environment variables' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'env' => ['FOO=BAR', 'FOO2=BAR2']} }
+        let(:params) { params.merge({'env' => ['FOO=BAR', 'FOO2=BAR2']}) }
         it { should contain_file(initscript).with_content(/-e FOO=BAR/).with_content(/-e FOO2=BAR2/) }
       end
 
       context 'when passing an environment variable' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'env' => 'FOO=BAR'} }
+        let(:params) { params.merge({'env' => 'FOO=BAR'}) }
         it { should contain_file(initscript).with_content(/-e FOO=BAR/) }
       end
 
       context 'when passing serveral environment files' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'env_file' => ['/etc/foo.env', '/etc/bar.env']} }
+        let(:params) { params.merge({'env_file' => ['/etc/foo.env', '/etc/bar.env']}) }
         it { should contain_file(initscript).with_content(/--env-file \/etc\/foo.env/).with_content(/--env-file \/etc\/bar.env/) }
       end
 
       context 'when passing an environment file' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'env_file' => '/etc/foo.env'} }
+        let(:params) { params.merge({'env_file' => '/etc/foo.env'}) }
         it { should contain_file(initscript).with_content(/--env-file \/etc\/foo.env/) }
       end
 
       context 'when passing serveral dns addresses' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'dns' => ['8.8.8.8', '8.8.4.4']} }
+        let(:params) { params.merge({'dns' => ['8.8.8.8', '8.8.4.4']}) }
         it { should contain_file(initscript).with_content(/--dns 8.8.8.8/).with_content(/--dns 8.8.4.4/) }
       end
 
       context 'when passing a dns address' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'dns' => '8.8.8.8'} }
+        let(:params) { params.merge({'dns' => '8.8.8.8'}) }
         it { should contain_file(initscript).with_content(/--dns 8.8.8.8/) }
       end
 
       context 'when passing serveral sockets to connect to' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'socket_connect' => ['tcp://127.0.0.1:4567', 'tcp://127.0.0.2:4567']} }
+        let(:params) { params.merge({'socket_connect' => ['tcp://127.0.0.1:4567', 'tcp://127.0.0.2:4567']}) }
         it { should contain_file(initscript).with_content(/-H tcp:\/\/127.0.0.1:4567/) }
       end
 
       context 'when passing a socket to connect to' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'socket_connect' => 'tcp://127.0.0.1:4567'} }
+        let(:params) { params.merge({'socket_connect' => 'tcp://127.0.0.1:4567'}) }
         it { should contain_file(initscript).with_content(/-H tcp:\/\/127.0.0.1:4567/) }
       end
 
       context 'when passing serveral dns search domains' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'dns_search' => ['my.domain.local', 'other-domain.de']} }
+        let(:params) { params.merge({'dns_search' => ['my.domain.local', 'other-domain.de']}) }
         it { should contain_file(initscript).with_content(/--dns-search my.domain.local/).with_content(/--dns-search other-domain.de/) }
       end
 
       context 'when passing a dns search domain' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'dns_search' => 'my.domain.local'} }
+        let(:params) { params.merge({'dns_search' => 'my.domain.local'}) }
         it { should contain_file(initscript).with_content(/--dns-search my.domain.local/) }
       end
 
       context 'when disabling network' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'disable_network' => true} }
+        let(:params) { params.merge({'disable_network' => true}) }
         it { should contain_file(initscript).with_content(/-n false/) }
       end
 
       context 'when running privileged' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'privileged' => true} }
+        let(:params) { params.merge({'privileged' => true}) }
         it { should contain_file(initscript).with_content(/--privileged/) }
       end
 
       context 'should run with correct detached value' do
-        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        let(:params) { params }
         if (systemd)
           it { should_not contain_file(initscript).with_content(/--detach=true/) }
         else
@@ -386,74 +391,74 @@ require 'spec_helper'
       end
 
       context 'should be able to override detached' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'detach' => false} }
+        let(:params) { params.merge({'detach' => false}) }
         it { should contain_file(initscript).without_content(/--detach=true/) }
       end
 
       context 'when running with a tty' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'tty' => true} }
+        let(:params) { params.merge({'tty' => true}) }
         it { should contain_file(initscript).with_content(/-t/) }
       end
 
       context 'when passing serveral extra parameters' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'extra_parameters' => ['--rm', '-w /tmp']} }
+        let(:params) { params.merge({'extra_parameters' => ['--rm', '-w /tmp']}) }
         it { should contain_file(initscript).with_content(/--rm/).with_content(/-w \/tmp/) }
       end
 
       context 'when passing an extra parameter' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+        let(:params) { params.merge({'extra_parameters' => '-c 4'}) }
         it { should contain_file(initscript).with_content(/-c 4/) }
       end
 
       context 'when passing a data volume' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'volumes' => '/var/log'} }
+        let(:params) { params.merge({'volumes' => '/var/log'}) }
         it { should contain_file(initscript).with_content(/-v \/var\/log/) }
       end
 
       context 'when passing serveral data volume' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'volumes' => ['/var/lib/couchdb', '/var/log']} }
+        let(:params) { params.merge({'volumes' => ['/var/lib/couchdb', '/var/log']}) }
         it { should contain_file(initscript).with_content(/-v \/var\/lib\/couchdb/) }
         it { should contain_file(initscript).with_content(/-v \/var\/log/) }
       end
 
       context 'when using network mode' do
-        let(:params) { {'command' => 'command', 'image' => 'nginx', 'net' => 'host'} }
+        let(:params) { params.merge({'net' => 'host'}) }
         it { should contain_file(initscript).with_content(/--net host/) }
       end
 
       context 'when `pull_on_start` is true' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'pull_on_start' => true } }
+        let(:params) { params.merge({'pull_on_start' => true }) }
         it { should contain_file(initscript).with_content(/docker pull base/) }
       end
 
       context 'when `pull_on_start` is false' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'pull_on_start' => false } }
+        let(:params) { params.merge({'pull_on_start' => false }) }
         it { should_not contain_file(initscript).with_content(/docker pull base/) }
       end
 
       context 'when `before_start` is set' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'before_start' => "echo before_start" } }
+        let(:params) { params.merge({'before_start' => "echo before_start" }) }
         it { should contain_file(initscript).with_content(/before_start/) }
       end
 
       context 'when `before_start` is not set' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'before_start' => false } }
+        let(:params) { params.merge({'before_start' => false }) }
         it { should_not contain_file(initscript).with_content(/before_start/) }
       end
 
       context 'when `before_stop` is set' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'before_stop' => "echo before_stop" } }
+        let(:params) { params.merge({'before_stop' => "echo before_stop" }) }
         it { should contain_file(initscript).with_content(/before_stop/) }
       end
 
       context 'when `before_stop` is not set' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'before_stop' => false } }
+        let(:params) { params.merge({'before_stop' => false }) }
         it { should_not contain_file(initscript).with_content(/before_stop/) }
       end
 
       context 'with an title that will not format into a path' do
         let(:title) { 'this/that' }
-        let(:params) { {'image' => 'base'} }
+        let(:params) { params }
 
         if osfamily == 'Debian'
           new_initscript = '/etc/systemd/system/docker-this-that.service'
@@ -467,7 +472,7 @@ require 'spec_helper'
 
       context 'with manage_service turned off' do
         let(:title) { 'this/that' }
-        let(:params) { {'image' => 'base', 'manage_service' => false} }
+        let(:params) { params.merge({'manage_service' => false}) }
 
         if osfamily == 'Debian'
           new_initscript = '/etc/systemd/system/docker-this-that.service'
@@ -481,7 +486,7 @@ require 'spec_helper'
 
       context 'with service_prefix set to empty string' do
         let(:title) { 'this/that' }
-        let(:params) { {'image' => 'base', 'service_prefix' => ''} }
+        let(:params) { params.merge({'service_prefix' => ''}) }
 
         if osfamily == 'Debian'
           new_initscript = '/etc/systemd/system/this-that.service'
@@ -504,7 +509,7 @@ require 'spec_helper'
 
       context 'with title that need sanitisation' do
         let(:title) { 'this/that_other' }
-        let(:params) { {'image' => 'base' } }
+        let(:params) { params }
 
         if osfamily == 'Debian'
           new_initscript = '/etc/systemd/system/docker-this-that_other.service'
@@ -517,7 +522,7 @@ require 'spec_helper'
       end
 
       context 'with an invalid image name' do
-        let(:params) { {'command' => 'command', 'image' => 'with spaces', 'running' => 'not a boolean'} }
+        let(:params) { params.merge({'image' => 'with spaces', 'running' => 'not a boolean'}) }
         it do
           expect {
             should contain_service('docker-sample')
@@ -527,7 +532,7 @@ require 'spec_helper'
 
       context 'with an invalid running value' do
         let(:title) { 'with spaces' }
-        let(:params) { {'command' => 'command', 'image' => 'base', 'running' => 'not a boolean'} }
+        let(:params) { params.merge({'running' => 'not a boolean'}) }
         it do
           expect {
             should contain_service('docker-sample')
@@ -537,7 +542,7 @@ require 'spec_helper'
 
       context 'with an invalid memory value' do
         let(:title) { 'with spaces' }
-        let(:params) { {'command' => 'command', 'image' => 'base', 'memory' => 'not a number'} }
+        let(:params) { params.merge({'memory' => 'not a number'}) }
         it do
           expect {
             should contain_service('docker-sample')
@@ -547,7 +552,7 @@ require 'spec_helper'
 
       context 'with a missing memory unit' do
         let(:title) { 'with spaces' }
-        let(:params) { {'command' => 'command', 'image' => 'base', 'memory' => '10240'} }
+        let(:params) { params.merge({'memory' => '10240'}) }
         it do
           expect {
             should contain_service('docker-sample')
@@ -556,7 +561,7 @@ require 'spec_helper'
       end
 
       context 'with restart policy set to no' do
-        let(:params) { {'restart' => 'no', 'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+        let(:params) { params.merge({'restart' => 'no', 'extra_parameters' => '-c 4'}) }
         it { should contain_exec('run sample with docker') }
         it { should contain_exec('run sample with docker').with_unless(/\/var\/run\/docker-sample.cid/) }
         it { should contain_exec('run sample with docker').with_unless(/-a/) }
@@ -568,7 +573,7 @@ require 'spec_helper'
       end
 
       context 'with restart policy set to always' do
-        let(:params) { {'restart' => 'always', 'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+        let(:params) { params.merge({'restart' => 'always', 'extra_parameters' => '-c 4'}) }
         it { should contain_exec('run sample with docker') }
         it { should contain_exec('run sample with docker').with_unless(/\/var\/run\/docker-sample.cid/) }
         it { should contain_exec('run sample with docker').with_unless(/-a/) }
@@ -580,7 +585,7 @@ require 'spec_helper'
       end
 
       context 'with restart policy set to on-failure' do
-        let(:params) { {'restart' => 'on-failure', 'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+        let(:params) { params.merge({'restart' => 'on-failure', 'extra_parameters' => '-c 4'}) }
         it { should contain_exec('run sample with docker') }
         it { should contain_exec('run sample with docker').with_unless(/\/var\/run\/docker-sample.cid/) }
         it { should contain_exec('run sample with docker').with_unless(/-a/) }
@@ -592,7 +597,7 @@ require 'spec_helper'
       end
 
       context 'with restart policy set to on-failure:3' do
-        let(:params) { {'restart' => 'on-failure:3', 'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+        let(:params) { params.merge({'restart' => 'on-failure:3', 'extra_parameters' => '-c 4'}) }
         it { should contain_exec('run sample with docker') }
         it { should contain_exec('run sample with docker').with_unless(/\/var\/run\/docker-sample.cid/) }
         it { should contain_exec('run sample with docker').with_unless(/-a/) }
@@ -604,13 +609,13 @@ require 'spec_helper'
       end
 
       context 'when `docker_service` is false' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => false} }
+        let(:params) { params.merge({'docker_service' => false}) }
         it { should compile.with_all_deps }
         it { should contain_service('docker-sample') }
       end
 
       context 'when `docker_service` is true' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => true} }
+        let(:params) { params.merge({'docker_service' => true}) }
         let(:pre_condition) { "service { 'docker': }" }
         it { should compile.with_all_deps }
         it { should contain_service('docker').that_comes_before('Service[docker-sample]') }
@@ -618,14 +623,14 @@ require 'spec_helper'
       end
 
       context 'when `docker_service` is true and `restart_service_on_docker_refresh` is false' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => true, 'restart_service_on_docker_refresh' => false} }
+        let(:params) { params.merge({'docker_service' => true, 'restart_service_on_docker_refresh' => false}) }
         let(:pre_condition) { "service { 'docker': }" }
         it { should compile.with_all_deps }
         it { should contain_service('docker').that_comes_before('Service[docker-sample]') }
       end
 
       context 'when `docker_service` is `my-docker`' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => 'my-docker'} }
+        let(:params) { params.merge({'docker_service' => 'my-docker'}) }
         let(:pre_condition) { "service{ 'my-docker': }" }
         it { should compile.with_all_deps }
         it { should contain_service('my-docker').that_comes_before('Service[docker-sample]') }
@@ -633,28 +638,28 @@ require 'spec_helper'
       end
 
       context 'when `docker_service` is `my-docker` and `restart_service_on_docker_refresh` is false' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => 'my-docker', 'restart_service_on_docker_refresh' => false} }
+        let(:params) { params.merge({'docker_service' => 'my-docker', 'restart_service_on_docker_refresh' => false}) }
         let(:pre_condition) { "service{ 'my-docker': }" }
         it { should compile.with_all_deps }
         it { should contain_service('my-docker').that_comes_before('Service[docker-sample]') }
       end
 
       context 'with syslog_identifier' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'syslog_identifier' => 'docker-universe' } }
+        let(:params) { params.merge({'syslog_identifier' => 'docker-universe' }) }
         if systemd
           it { should contain_file(initscript).with_content(/^SyslogIdentifier=docker-universe$/) }
         end
       end
 
       context 'with extra_systemd_parameters' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'extra_systemd_parameters' => {'RestartSec' => 5}} }
+        let(:params) { params.merge({'extra_systemd_parameters' => {'RestartSec' => 5}}) }
         if (systemd)
           it { should contain_file(initscript).with_content(/^RestartSec=5$/) }
         end
       end
 
       context 'with ensure absent' do
-        let(:params) { {'ensure' => 'absent', 'command' => 'command', 'image' => 'base'} }
+        let(:params) { params.merge({'ensure' => 'absent'}) }
         it { should compile.with_all_deps }
         it { should contain_service('docker-sample').with_ensure(false) }
         it { should contain_exec("remove container docker-sample").with_command('docker rm -v sample') }


### PR DESCRIPTION
I know support for Gentoo in this module was dropped when it moved into the puppetlabs space.  That said, it is still the easiest way to get Docker up and running on Gentoo with just a few extra parameters:

```puppet
class { 'docker':
  docker_ce_package_name     => 'app-emulation/docker',
  service_config             => '/etc/conf.d/docker',
  service_config_template    => 'docker/etc/sysconfig/docker.systemd.erb',
  service_overrides_template => 'mine/docker/systemd-overrides.conf.erb',
  service_provider           => 'systemd',
}
```

where the `mine/docker/systemd-overrides.conf.erb` template contains:

```ini
[Service]
EnvironmentFile=-/etc/conf.d/docker
ExecStart=
ExecStart=/usr/bin/dockerd $OPTIONS
```

Unfortunately, the `docker::run` type detects that it is running on Gentoo and sets things up for OpenRC.  Gentoo has first class support for systemd and I'd like to be able to tell the run type to use `systemd`, just as I do with `Class[docker]` via the `service_provider` parameter.

This pull request adds a `service_provider` parameter to the `docker::run` type which can be set to override the operating system detection.  It can be set to `systemd` to enable systemd support.  If it is set to anything else, or it is unset (the default), then the type falls back to the OS detection behavior that was there before.

The default behavior of the type is unchanged.

I have added rspec tests to validate this behavior.

This pull request also contains a couple of trivial variable definitions in default cases that were left undefined on non-RedHat and Debian systems.