### PR TITLE
Allow setting commented TMPDIR in systemd file for backwards compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -348,6 +348,14 @@
 # [*storage_pool_autoextend_percent*]
 #   Extend the pool by specified percentage when threshold is hit.
 #
+# [*tmp_dir_config*]
+#    Whether to set the TMPDIR value in the systemd config file
+#    Default: true (set the value); false will comment out the line.
+#    Note: false is backwards compatible prior to PR #58
+#
+# [*tmp_dir*]
+#    Sets the tmp dir for Docker (path)
+#
 class docker(
   $version                           = $docker::params::version,
   $ensure                            = $docker::params::ensure,
@@ -401,6 +409,7 @@ class docker(
   $service_enable                    = $docker::params::service_enable,
   $manage_service                    = $docker::params::manage_service,
   $root_dir                          = $docker::params::root_dir,
+  $tmp_dir_config                    = $docker::params::tmp_dir_config,
   $tmp_dir                           = $docker::params::tmp_dir,
   $manage_kernel                     = $docker::params::manage_kernel,
   $dns                               = $docker::params::dns,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class docker::params {
   $service_enable                    = true
   $manage_service                    = true
   $root_dir                          = undef
+  $tmp_dir_config                    = true
   $tmp_dir                           = '/tmp/'
   $dns                               = undef
   $dns_search                        = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -78,6 +78,7 @@ class docker::service (
   $dm_loopmetadatasize               = $docker::dm_loopmetadatasize,
   $dm_datadev                        = $docker::dm_datadev,
   $dm_metadatadev                    = $docker::dm_metadatadev,
+  $tmp_dir_config                    = $docker::tmp_dir_config,
   $tmp_dir                           = $docker::tmp_dir,
   $nowarn_kernel                     = $docker::nowarn_kernel,
   $dm_thinpooldev                    = $docker::dm_thinpooldev,

--- a/templates/etc/sysconfig/docker.systemd.erb
+++ b/templates/etc/sysconfig/docker.systemd.erb
@@ -29,5 +29,5 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
   https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
-TMPDIR="<%= @tmp_dir %>"
+<% if @tmp_dir_config %>TMPDIR="<%= @tmp_dir %>"<% else %># TMPDIR="<%= @tmp_dir %>"<% end %>
 <% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>


### PR DESCRIPTION
The tmpdir fix in #58 was not backwards compatible, in that there was no way to retain the legacy config (so that we can restart docker for some nodes sooner than others, which happens when that file is updated).

Added a flag tmp_dir_config defaulting to true, which sets TMPDIR in the config.  Setting it to false has TMPDIR commented out (legacy behavior).