### PR TITLE
docker::registry fixes

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -73,11 +73,14 @@ define docker::registry(
     $local_user_strip = regsubst($local_user, '-', '', 'G')
 
     $_pass_hash = $pass_hash ? {
-      'Undef'   => pw_hash("${title}${auth_environment}${auth_cmd}${local_user}", 'SHA-512', $local_user_strip),
+      Undef   => pw_hash("${title}${auth_environment}${auth_cmd}${local_user}", 'SHA-512', $local_user_strip),
       default => $pass_hash
     }
 
-    file { "/root/registry-auth-puppet_receipt_${server}_${local_user}":
+    # server may be an URI, which can contain /
+    $server_strip = regsubst($server, '/', '_', 'G')
+
+    file { "/root/registry-auth-puppet_receipt_${server_strip}_${local_user}":
       ensure  => $ensure,
       content => $_pass_hash,
       notify  => Exec["${title} auth"],


### PR DESCRIPTION
I had issues with latest version of the module (`1.0.4`). Specifically in `docker::registry` definition

This PR fixes the following issues:

1. fix wrong `$pass_hash` condition, `'Undef'` considered `String` and not real `undef`
2. `$server` param may be an `URI` and can contain slashes (e.g: https://index.docker.io/v1/), so strip them.



  
  