### PR TITLE
WIP: refactor package management

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; Plugins are available for notepad++, emacs, vim, gedit,
+; textmate, visual studio, and more.
+;
+; See http://editorconfig.org for details.
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -46,73 +46,6 @@ class { 'docker':
 }
 ```
 
-To configure package sources independently and disable automatically including sources, add the following code to the manifest file:
-
-```puppet
-class { 'docker':
-  use_upstream_package_source => false,
-}
-```
-
-The latest Docker [repositories](https://docs.docker.com/engine/installation/linux/docker-ce/debian/#set-up-the-repository) are now the default repositories for version 17.06 and above. If you are using a version prior to this, the old repositories will still be configured based on the version number passed into the module.
-
-The following example will ensure the modules configures the latest repositories
-
-```puppet
-class { 'docker':
-  version => '17.09.0~ce-0~debian',
-}
-```
-
-Using a version prior to 17.06 will configure and install from the old repositories
-
-```puppet
-class { 'docker':
-  version => '1.12.0-0~wheezy',
-}
-```
-
-Docker provides a enterprise addition of the [Docker Engine](https://www.docker.com/enterprise-edition), called Docker EE. To install Docker EE on Debian systems, add the following code to the manifest file:
-
-```puppet
-class { 'docker':
-  docker_ee => true,
-  docker_ee_source_location => 'https://<docker_ee_repo_url',
-  docker_ee_key_source => 'https://<docker_ee_key_source_url',
-  docker_ee_key_id => '<key id>',
-}
-```
-
-To install install Docker EE on RHEL/CentOS:
-
-```puppet
-class { 'docker':
-  docker_ee => true,
-  docker_ee_source_location => 'https://<docker_ee_repo_url',
-  docker_ee_key_source => 'https://<docker_ee_key_source_url',
-}
-```
-
-
-For Red Hat Enterprise Linux (RHEL) based distributions, including Fedora, the docker module uses the upstream repositories. To continue using the legacy distribution packages in the CentOS Extras repo, add the following code to the manifest file:
-
-```puppet
-class { 'docker':
-  use_upstream_package_source => false,
-  service_overrides_template  => false,
-  docker_ce_package_name      => 'docker',
-}
-```
-
-To use the CE packages
-
-```puppet
-class { 'docker':
-  use_upstream_package_source => false,
-  package_ce_name => 'docker-ce',
-}
-```
-
 By default, the Docker daemon binds to a unix socket at `/var/run/docker.sock`. To change this parameter and to update the binding parameter to a tcp socket, add the following code to the manifest file:
 
 ```puppet
@@ -832,37 +765,6 @@ Valid values are `true`, `false`.
 
 Defaults to `false`.
 
-#### `use_upstream_package_source`
-
-Specifies whether to use the upstream package source.
-
-Valid values are `true`, `false`.
-
-When you run your own package mirror, set the value to `false`.
-
-#### `pin_upstream_package_source`
-
-Specifies whether to use the pin upstream package source. This option relates to apt-based distributions.
-
-Valid values are `true`, `false`.
-
-Defaults to `true`.
-
-Set to `false` to remove pinning on the upstream package repository. See also `apt_source_pin_level`.
-
-#### `apt_source_pin_level`
-
-The level to pin your source package repository to. This relates to an apt-based system (such as Debian, Ubuntu, etc). Include $use_upstream_package_source and set the value to `true`.
-
-To disable pinning, set the value to `false`.
-
-Defaults to `10`.
-
-#### `package_source_location`
-
-Specifies the location of the package source.
-
-For Debian, the value defaults to `http://get.docker.com/ubuntu`.
 
 #### `service_state`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,1 @@
+docker::docker_daemon_command: 'docker daemon'

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,2 @@
+docker::prerequired_packages:
+  - 'cgroupfs-mount'

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,2 +1,10 @@
-docker::prerequired_packages:
-  - 'cgroupfs-mount'
+docker::package_repository:
+  'docker_repo':
+    location: "https://download.docker.com/linux/%{facts.os.name}"
+    release: "${facts.os.distro.codename}"
+    repos: 'stable'
+    key:
+      source: "https://download.docker.com/linux/%{facts.os.name"
+    include:
+      deb: true
+      src: false

--- a/data/os/Debian/Trusty.yaml
+++ b/data/os/Debian/Trusty.yaml
@@ -1,0 +1,4 @@
+docker::prerequired_packages:
+  - 'linux-image-extra-virtual'
+  - "linux-image-extra-%{facts.os.distro.id}"
+

--- a/data/os/Debian/Ubuntu.yaml
+++ b/data/os/Debian/Ubuntu.yaml
@@ -1,0 +1,4 @@
+---
+docker::prerequired_packages:
+  - 'cgroup-lite'
+  - 'apparmor'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,3 @@
+---
+docker::prerequired_packages:
+  - 'device-mapper'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,3 +1,10 @@
 ---
-docker::prerequired_packages:
-  - 'device-mapper'
+docker::package_repository:
+  'docker_repo':
+    ensure: 'present'
+    assumeyes: true
+    enabled: true
+    baseurl: 'https://download.docker.com/linux/centos/7/x86_64/stable'
+    gpgkey: 'https://download.docker.com/linux/centos/gpg'
+    repo_gpgcheck: true
+    sslverify: true

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,4 +1,5 @@
 ---
+docker::daemon_command: 'dockerd'
 docker::package_repository:
   'docker_repo':
     ensure: 'present'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,9 +6,7 @@ hierarchy:
     backend: yaml
     paths:
       - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major.minor}.yaml"
-      - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.distro.codename}.yaml"
       - "os/%{facts.os.family}/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}/%{facts.os.distro.codename}.yaml"
       - "os/%{facts.os.family}.yaml"
       - "common.yaml"
-
-

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,14 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "Default docker configuration data"
+    backend: yaml
+    paths:
+      - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major.minor}.yaml"
+      - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.distro.codename}.yaml"
+      - "os/%{facts.os.family}/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}.yaml"
+      - "common.yaml"
+
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -413,8 +413,7 @@ class docker(
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
   $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
   $execdriver                        = $docker::params::execdriver,
-  $manage_package                    = $docker::params::manage_package,
-  $manage_epel                       = $docker::params::manage_epel,
+  $manage_package                    = true
   $service_name                      = $docker::params::service_name,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,
@@ -444,7 +443,7 @@ class docker(
 ) inherits docker::params {
 
   validate_string($version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
+  validate_re($facts['os']['family'], '^(Debian|RedHat|Archlinux|Gentoo)$',
               'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
   validate_bool($manage_kernel)
   validate_bool($manage_package)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -299,10 +299,6 @@
 #   Specify a custom docker command name
 #   Default is set on a per system basis in docker::params
 #
-# [*daemon_subcommand*]
-#  Specify a subcommand/flag for running docker as daemon
-#  Default is set on a per system basis in docker::params
-#
 # [*docker_users*]
 #   Specify an array of users to add to the docker group
 #   Default is empty
@@ -359,6 +355,8 @@
 class docker(
   $version                           = $docker::params::version,
   $ensure                            = $docker::params::ensure,
+  $docker_daemon_command             = $docker::params::docker_daemon_command,
+  $docker_command                    = $docker::params::docker_command,
   $package_repository                = lookup('docker::package_repository'),
   $prerequired_packages              = lookup('docker::prerequired_packages'),
   $tcp_bind                          = $docker::params::tcp_bind,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -359,28 +359,8 @@
 class docker(
   $version                           = $docker::params::version,
   $ensure                            = $docker::params::ensure,
-  $prerequired_packages              = $docker::params::prerequired_packages,
-  $docker_ce_start_command           = $docker::params::docker_ce_start_command,
-  $docker_ce_package_name            = $docker::params::docker_ce_package_name,
-  $docker_ce_source_location         = $docker::params::package_ce_source_location,
-  $docker_ce_key_source              = $docker::params::package_ce_key_source,
-  $docker_ce_key_id                  = $docker::params::package_ce_key_id,
-  $docker_ce_release                 = $docker::params::package_ce_release,
-  $docker_package_location           = $docker::params::package_source_location,
-  $docker_package_key_source         = $docker::params::package_key_source,
-  $docker_package_key_check_source   = $docker::params::package_key_check_source,
-  $docker_package_key_id             = $docker::params::package_key_id,
-  $docker_package_release            = $docker::params::package_release,
-  $docker_engine_start_command       = $docker::params::docker_engine_start_command,
-  $docker_engine_package_name        = $docker::params::docker_engine_package_name,
-  $docker_ce_channel                 = $docker::params::docker_ce_channel,
-  $docker_ee                         = $docker::params::docker_ee,
-  $docker_ee_package_name            = $docker::params::package_ee_package_name,
-  $docker_ee_source_location         = $docker::params::package_ee_source_location,
-  $docker_ee_key_source              = $docker::params::package_ee_key_source,
-  $docker_ee_key_id                  = $docker::params::package_ee_key_id,
-  $docker_ee_repos                   = $docker::params::package_ee_repos,
-  $docker_ee_release                 = $docker::params::package_ee_release,
+  $package_repository                = lookup('docker::package_repository'),
+  $prerequired_packages              = lookup('docker::prerequired_packages'),
   $tcp_bind                          = $docker::params::tcp_bind,
   $tls_enable                        = $docker::params::tls_enable,
   $tls_verify                        = $docker::params::tls_verify,
@@ -401,10 +381,6 @@ class docker(
   $log_driver                        = $docker::params::log_driver,
   $log_opt                           = $docker::params::log_opt,
   $selinux_enabled                   = $docker::params::selinux_enabled,
-  $use_upstream_package_source       = $docker::params::use_upstream_package_source,
-  $pin_upstream_package_source       = $docker::params::pin_upstream_package_source,
-  $apt_source_pin_level              = $docker::params::apt_source_pin_level,
-  $package_release                   = $docker::params::package_release,
   $service_state                     = $docker::params::service_state,
   $service_enable                    = $docker::params::service_enable,
   $manage_service                    = $docker::params::manage_service,
@@ -438,13 +414,11 @@ class docker(
   $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
   $execdriver                        = $docker::params::execdriver,
   $manage_package                    = $docker::params::manage_package,
-  $package_source                    = $docker::params::package_source,
   $manage_epel                       = $docker::params::manage_epel,
   $service_name                      = $docker::params::service_name,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,
   $daemon_environment_files          = [],
-  $repo_opt                          = $docker::params::repo_opt,
   $nowarn_kernel                     = $docker::params::nowarn_kernel,
   $os                                = $docker::params::os,
   $storage_devs                      = $docker::params::storage_devs,
@@ -544,58 +518,6 @@ class docker(
     validate_string($tls_cacert)
     validate_string($tls_cert)
     validate_string($tls_key)
-  }
-
-  if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.]\d(~|-|\.)ce|1.\d+)/ ) {
-    if ( $docker_ee) {
-      validate_string($docker::docker_ee_source_location)
-      validate_string($docker::docker_ee_key_source)
-      $package_location = $docker::docker_ee_source_location
-      $package_key_source = $docker::docker_ee_key_source
-      $package_key_check_source = true
-      $package_key = $docker::docker_ee_key_id
-      $package_repos = $docker::docker_ee_repos
-      $release = $docker::docker_ee_release
-      $docker_start_command = $docker::docker_ee_start_command
-      $docker_package_name = $docker::docker_ee_package_name
-    } else {
-        case $::osfamily {
-          'Debian' : {
-            $package_location = $docker_ce_source_location
-            $package_key_source = $docker_ce_key_source
-            $package_key = $docker_ce_key_id
-            $package_repos = $docker_ce_channel
-            $release = $docker_ce_release
-            }
-          'Redhat' : {
-            $package_location = "https://download.docker.com/linux/centos/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
-            $package_key_source = $docker_ce_key_source
-            $package_key_check_source = true
-          }
-          default: {}
-        }
-        $docker_start_command = $docker_ce_start_command
-        $docker_package_name = $docker_ce_package_name
-    }
-  } else {
-    case $::osfamily {
-      'Debian' : {
-        $package_location = $docker_package_location
-        $package_key_source = $docker_package_key_source
-        $package_key_check_source = $docker_package_key_check_source
-        $package_key = $docker_package_key_id
-        $package_repos = 'main'
-        $release = $docker_package_release
-        }
-      'Redhat' : {
-        $package_location = $docker_package_location
-        $package_key_source = $docker_package_key_source
-        $package_key_check_source = $docker_package_key_check_source
-      }
-      default : {}
-    }
-    $docker_start_command = $docker_engine_start_command
-    $docker_package_name = $docker_engine_package_name
   }
 
   contain 'docker::repos'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -413,7 +413,7 @@ class docker(
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
   $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
   $execdriver                        = $docker::params::execdriver,
-  $manage_package                    = true
+  $manage_package                    = true,
   $service_name                      = $docker::params::service_name,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,8 +5,8 @@
 # and Archlinux based distributions.
 #
 class docker::install (
- $manage_package = $docker::manage_package,
- $prerequired_packages = $docker::prerequired_packages,
+  $manage_package = $docker::manage_package,
+  $prerequired_packages = $docker::prerequired_packages,
 ){
   ensure_packages($prerequired_packages,
     {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,111 +4,14 @@
 # This module currently works only on Debian, Red Hat
 # and Archlinux based distributions.
 #
-class docker::install {
-  $docker_start_command = $docker::docker_start_command
-  validate_string($docker::version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
-              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
-  validate_bool($docker::use_upstream_package_source)
-
-  if $docker::version and $docker::ensure != 'absent' {
-    $ensure = $docker::version
-  } else {
-    $ensure = $docker::ensure
-  }
-
-  case $::osfamily {
-    'Debian': {
-      if $::operatingsystem == 'Ubuntu' {
-        case $::operatingsystemrelease {
-          # On Ubuntu 12.04 (precise) install the backported 13.10 (saucy) kernel
-          '12.04': { $kernelpackage = [
-                                        'linux-image-generic-lts-trusty',
-                                        'linux-headers-generic-lts-trusty'
-                                      ]
-          }
-          # determine the package name for 'linux-image-extra-$(uname -r)' based
-          # on the $::kernelrelease fact
-          default: { $kernelpackage = "linux-image-extra-${::kernelrelease}" }
-        }
-        $manage_kernel = $docker::manage_kernel
-      } else {
-        # Debian does not need extra kernel packages
-        $manage_kernel = false
-      }
+class docker::install (
+ $manage_package = $docker::manage_package,
+ $prerequired_packages = $docker::prerequired_packages,
+){
+  ensure_packages($prerequired_packages,
+    {
+      ensure => 'present',
+      before => Package['docker']
     }
-    'RedHat': {
-      if $::operatingsystem == 'Amazon' {
-        if versioncmp($::operatingsystemrelease, '3.10.37-47.135') < 0 {
-          fail('Docker needs Amazon version to be at least 3.10.37-47.135.')
-        }
-      }
-      elsif versioncmp($::operatingsystemrelease, '6.5') < 0 {
-        fail('Docker needs RedHat/CentOS version to be at least 6.5.')
-      }
-      $manage_kernel = false
-    }
-    default: {}
-  }
-
-  if $manage_kernel {
-    package { $kernelpackage:
-      ensure => present,
-    }
-    if $docker::manage_package {
-      Package[$kernelpackage] -> Package['docker']
-    }
-  }
-
-  if $docker::manage_package {
-
-    if empty($docker::repo_opt) {
-      $docker_hash = {}
-    } else {
-      $docker_hash = { 'install_options' => $docker::repo_opt }
-    }
-
-    if $docker::package_source {
-      case $::osfamily {
-        'Debian' : {
-          $pk_provider = 'dpkg'
-        }
-        'RedHat' : {
-          $pk_provider = 'rpm'
-        }
-        'Gentoo' : {
-          $pk_provider = 'portage'
-        }
-        default : {
-          $pk_provider = undef
-        }
-      }
-
-      case $docker::package_source {
-        /docker-engine/ : {
-          ensure_resource('package', 'docker', merge($docker_hash, {
-            ensure   => $ensure,
-            provider => $pk_provider,
-            source   => $docker::package_source,
-            name     => $docker::docker_engine_package_name,
-          }))
-        }
-        /docker-ce/ : {
-          ensure_resource('package', 'docker', merge($docker_hash, {
-            ensure   => $ensure,
-            provider => $pk_provider,
-            source   => $docker::package_source,
-            name     => $docker::docker_ce_package_name,
-          }))
-        }
-        default : {}
-      }
-
-    } else {
-      ensure_resource('package', 'docker', merge($docker_hash, {
-        ensure => $ensure,
-        name   => $docker::docker_package_name,
-      }))
-    }
-  }
+  )
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,38 +148,13 @@ class docker::params {
       $use_upstream_package_source = true
       $manage_epel = false
 
-      $package_ce_source_location = "https://download.docker.com/linux/centos/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
-      $package_ce_key_source = 'https://download.docker.com/linux/centos/gpg'
-      $package_ce_key_id = undef
-      $package_ce_release = undef
-      $package_key_id = undef
-      $package_release = undef
-      $package_source_location = "https://yum.dockerproject.org/repo/main/centos/${::operatingsystemmajrelease}"
-      $package_key_source = 'https://yum.dockerproject.org/gpg'
-      $package_key_check_source = true
-      $package_ee_source_location = $docker_ee_source_location
-      $package_ee_key_source = $docker_ee_key_source
-      $package_ee_key_id = $docker_ee_key_id
-      $package_ee_release = undef
-      $package_ee_repos = $docker_ee_repos
-      $package_ee_package_name = $docker_ee_package_name
-      $pin_upstream_package_source = undef
-      $apt_source_pin_level = undef
       $service_name = $service_name_default
-      if (versioncmp($::operatingsystemrelease, '7.0') < 0) or ($::operatingsystem == 'Amazon') {
+      if ($::operatingsystem == 'Amazon') {
         $detach_service_in_init = true
-        if $::operatingsystem == 'OracleLinux' {
-          $docker_group = 'dockerroot'
-        } else {
-          $docker_group = $docker_group_default
-        }
+        $docker_group = $docker_group_default
       } else {
         $detach_service_in_init = false
-        if $use_upstream_package_source {
-          $docker_group = $docker_group_default
-        } else {
-          $docker_group = 'dockerroot'
-        }
+        $docker_group = $docker_group_default
         include docker::systemd_reload
       }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,18 +5,7 @@
 class docker::params {
   $version                           = undef
   $ensure                            = present
-  $docker_ce_start_command           = 'dockerd'
-  $docker_ce_package_name            = 'docker-ce'
   $docker_engine_start_command       = 'docker daemon'
-  $docker_engine_package_name        = 'docker-engine'
-  $docker_ce_channel                 = stable
-  $docker_ee                         = false
-  $docker_ee_start_command           = 'dockerd'
-  $docker_ee_package_name            = 'docker-ee'
-  $docker_ee_source_location         = undef
-  $docker_ee_key_source              = undef
-  $docker_ee_key_id                  = undef
-  $docker_ee_repos                   = stable
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -133,28 +122,9 @@ class docker::params {
       $manage_epel = false
       $service_name = $service_name_default
       $docker_group = $docker_group_default
-      $use_upstream_package_source = true
-      $pin_upstream_package_source = true
-      $apt_source_pin_level = 10
-      $repo_opt = undef
       $nowarn_kernel = false
       $service_config = undef
       $storage_setup_file = undef
-
-      $package_ce_source_location = "https://download.docker.com/linux/${os}"
-      $package_ce_key_source = "https://download.docker.com/linux/${os}/gpg"
-      $package_ce_key_id = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
-      $package_ce_release = $::lsbdistcodename
-      $package_source_location = 'http://apt.dockerproject.org/repo'
-      $package_key_source = 'https://apt.dockerproject.org/gpg'
-      $package_key_check_source = undef
-      $package_key_id = '58118E89F3A912897C070ADBF76221572C52609D'
-      $package_ee_source_location = $docker_ee_source_location
-      $package_ee_key_source = $docker_ee_key_source
-      $package_ee_key_id = $docker_ee_key_id
-      $package_ee_release = $::lsbdistcodename
-      $package_ee_repos = $docker_ee_repos
-      $package_ee_package_name = $docker_ee_package_name
 
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
@@ -242,29 +212,10 @@ class docker::params {
     default: {
       $manage_epel = false
       $docker_group = $docker_group_default
-      $package_key_source = undef
-      $package_key_check_source = undef
-      $package_source_location = undef
-      $package_key_id = undef
-      $package_repos = undef
-      $package_release = undef
-      $package_ce_key_source = undef
-      $package_ce_source_location = undef
-      $package_ce_key_id = undef
-      $package_ce_repos = undef
-      $package_ce_release = undef
-      $package_ee_source_location = undef
-      $package_ee_key_source = undef
-      $package_ee_key_id = undef
-      $package_ee_release = undef
-      $package_ee_repos = undef
-      $package_ee_package_name = undef
-      $use_upstream_package_source = true
       $service_overrides_template = undef
       $service_hasstatus  = undef
       $service_hasrestart = undef
       $service_provider = undef
-      $package_name = $docker_ce_package_name
       $service_name = $service_name_default
       $detach_service_in_init = true
       $repo_opt = undef
@@ -273,22 +224,7 @@ class docker::params {
       $storage_config = undef
       $storage_setup_file = undef
       $service_config_template = undef
-      $pin_upstream_package_source = undef
-      $apt_source_pin_level = undef
     }
-  }
-
-  # Special extra packages are required on some OSes.
-  # Specifically apparmor is needed for Ubuntu:
-  # https://github.com/docker/docker/issues/4734
-  $prerequired_packages = $::osfamily ? {
-    'Debian' => $::operatingsystem ? {
-      'Debian' => ['cgroupfs-mount'],
-      'Ubuntu' => ['cgroup-lite', 'apparmor'],
-      default  => [],
-    },
-    'RedHat' => ['device-mapper'],
-    default  => [],
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,6 @@ class docker::params {
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
   $overlay2_override_kernel_check    = false
-  $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true
   $docker_command                    = 'docker'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,6 @@
 class docker::params {
   $version                           = undef
   $ensure                            = present
-  $docker_engine_start_command       = 'docker daemon'
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -58,6 +57,7 @@ class docker::params {
   $package_source                    = undef
   $manage_kernel                     = true
   $docker_command                    = 'docker'
+  $docker_daemon_command             = 'dockerd'
   $service_name_default              = 'docker'
   $docker_group_default              = 'docker'
   $storage_devs                      = undef
@@ -75,6 +75,14 @@ class docker::params {
   $compose_install_path              = '/usr/local/bin'
   $os                                = downcase($::operatingsystem)
 
+  # As of docker 17.06, 'daemon' is no longer a valid docker command
+  if (versioncmp($version, `17.06`) >= 0) {
+    $docker_binary_command = $docker_daemon_command
+  } else{
+    $docker_binary_command = "${docker_command} daemon"
+  }
+
+  # set up service defaults based on OS service provider
   case $::osfamily {
     'Debian' : {
       case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,7 @@ class docker::params {
   $os                                = downcase($::operatingsystem)
 
   # As of docker 17.06, 'daemon' is no longer a valid docker command
-  if (versioncmp($version, `17.06`) >= 0) {
+  if (versioncmp($version, '17.06') >= 0) {
     $docker_binary_command = $docker_daemon_command
   } else{
     $docker_binary_command = "${docker_command} daemon"

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -2,79 +2,26 @@
 #
 #
 class docker::repos (
-  $location = $docker::package_location,
-  $key_source = $docker::package_key_source,
-  $key_check_source = $docker::package_key_check_source,
-  ) {
+  $package_repository = $docker::package_repository,
+  $prerequired_packages = $docker::prerequired_packages,
+  $manage_repos = $docker::manage_repos,
+) {
 
-  ensure_packages($docker::prerequired_packages)
-
-  case $::osfamily {
-    'Debian': {
-      $release = $docker::release
-      $package_key = $docker::package_key
-      $package_repos = $docker::package_repos
-      if ($docker::use_upstream_package_source) {
-        ensure_packages(['debian-keyring', 'debian-archive-keyring'])
-
-        apt::source { 'docker':
-          location => $location,
-          release  => $release,
-          repos    => $package_repos,
-          key      => {
-            id     => $package_key,
-            source => $key_source,
-          },
-          require  => Package['debian-keyring', 'debian-archive-keyring'],
-          include  => {
-            src => false,
-            },
-        }
-        $url_split = split($location, '/')
-        $repo_host = $url_split[2]
-        $pin_ensure = $docker::pin_upstream_package_source ? {
-            true    => 'present',
-            default => 'absent',
-        }
-        apt::pin { 'docker':
-          ensure   => $pin_ensure,
-          origin   => $repo_host,
-          priority => $docker::apt_source_pin_level,
-        }
-        if $docker::manage_package {
-          include apt
-          if $::operatingsystem == 'Debian' and $::lsbdistcodename == 'wheezy' {
-            include apt::backports
-          }
-          Exec['apt_update'] -> Package[$docker::prerequired_packages]
-          Apt::Source['docker'] -> Package['docker']
-        }
+  ensure_packages($prerequired_packages)
+  
+  if $manage_repos {
+    case $facts['os']['family'] {
+      'Debian': {
+        include apt
+        create_resources('apt::source', $docker_repository)
       }
-
-    }
-    'RedHat': {
-
-      if ($docker::manage_package) {
-          $baseurl = $location
-          $gpgkey = $key_source
-          $gpgkey_check = $key_check_source
-        if ($docker::use_upstream_package_source) {
-          yumrepo { 'docker':
-            descr    => 'Docker',
-            baseurl  => $baseurl,
-            gpgkey   => $gpgkey,
-            gpgcheck => $gpgkey_check,
-          }
-          Yumrepo['docker'] -> Package['docker']
-        }
-        if ($::operatingsystem != 'Amazon') and ($::operatingsystem != 'Fedora') {
-          if ($docker::manage_epel == true) {
-            include 'epel'
-            Class['epel'] -> Package['docker']
-          }
-        }
+      'RedHat': {
+        create_resources('yumrepo', $docker_repository)
+      }
+      default: {
+        fail('A package repository must be provided if manage_repos=true') 
       }
     }
-    default: {}
   }
+
 }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -6,16 +6,14 @@ class docker::repos (
   $manage_repos = $docker::manage_repos,
 ) {
 
-  ensure_packages($prerequired_packages)
-
   if $manage_repos {
     case $facts['os']['family'] {
       'Debian': {
         include apt
-        create_resources('apt::source', $docker_repository)
+        create_resources('apt::source', $package_repository)
       }
       'RedHat': {
-        create_resources('yumrepo', $docker_repository)
+        create_resources('yumrepo', $package_repository)
       }
       default: {
         fail('A package repository must be provided if manage_repos=true')

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -3,12 +3,11 @@
 #
 class docker::repos (
   $package_repository = $docker::package_repository,
-  $prerequired_packages = $docker::prerequired_packages,
   $manage_repos = $docker::manage_repos,
 ) {
 
   ensure_packages($prerequired_packages)
-  
+
   if $manage_repos {
     case $facts['os']['family'] {
       'Debian': {
@@ -19,7 +18,7 @@ class docker::repos (
         create_resources('yumrepo', $docker_repository)
       }
       default: {
-        fail('A package repository must be provided if manage_repos=true') 
+        fail('A package repository must be provided if manage_repos=true')
       }
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,7 +38,7 @@
 #
 class docker::service (
   $docker_command                    = $docker::docker_command,
-  $docker_start_command              = $docker::docker_start_command,
+  $docker_daemon_command             = $docker::docker_daemon_command,
   $service_name                      = $docker::service_name,
   $tcp_bind                          = $docker::tcp_bind,
   $ip_forward                        = $docker::ip_forward,

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -1,7 +1,7 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-DOCKER="/usr/bin/<%= @docker_start_command %>"
+DOCKER="/usr/bin/<%= @docker_binary_command %>"
 
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -3,7 +3,7 @@
 # THIS FILE IS MANAGED BY PUPPET. Changes will be overwritten.
 
 # # Customize location of Docker binary (especially for development testing).
-DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKER="/usr/bin/<%= @docker_binary_command %>"
 
 # # If you need Docker to use an HTTP proxy, it can also be specified here.
 <% if @proxy -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -1,7 +1,7 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKER="/usr/bin/<%= @docker_binary_command %>"
 
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,5 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_start_command %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_binary_command %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -5,7 +5,7 @@ EnvironmentFile=-/etc/sysconfig/docker-network
 <% if @daemon_environment_files %><% @daemon_environment_files.each do |param| %>EnvironmentFile=-<%= param %>
 <% end %><% end -%>
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_start_command %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_binary_command %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
This pull refactors package management to be more flexible for implementor's, and also to positiion the code/data better for puppet 5/6 support when it's time to bring this module up to speed.

Features and changes:
- Removes the distinctions between `ce` and `ee` versions. Implementor needs to merely provide a package repository location.
- Re-adds the `docker_command` parameter, making this module compatible with `docker-latest` redhat (and other) special versions of docker that use alternative naming schemes and binaries.
- Uses `dockerd` when docker version is `17.06` or higher, and `docker daemon` when lower. (also takes into account `docker` binary name in case using `docker-latest` or other alternatively named binary)

Closes #45 #100 #38 
Closes the following issues leftover from the garethr-docker fork:
 - [Error while evaluating a Resource Statement, Apt::Source[docker] (#725)](https://github.com/garethr/garethr-docker/issues/725)
 - [Support for docker-latest package RHEL7 #698](https://github.com/garethr/garethr-docker/issues/698)
 - ([Remove hard (epel, apt) module dependencies, use soft ones #667](https://github.coom/garethr/garethr-docker/issues/667) (might not be able to)
 - [Manage repository and package separately #656](https://github.com/garethr/garethr-docker/issues/656)
 - [Version #655](https://github.com/garethr/garethr-docker/issues/655)
 - [Installation should not use --enablerepo if the upstream repo is used #598](https://github.com/garethr/garethr-docker/issues/598)
  