### PR TITLE
CLOUD-1610 Adding registry mirror flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,28 +644,35 @@ docker::registry_auth::registries:
 
 If using Docker V1.11 or later the docker login e-mail flag has been deprecated [docker_change_log](https://docs.docker.com/release-notes/docker-engine/#1110-2016-04-13). Add the following code to the manifest file:
 
-'''puppet
+```puppet
 docker::registry { 'example.docker.io:5000'}
   username => 'user',
   password => 'secret',
 }
-''
+```
 
 If using hiera, configure the 'docker::registry_auth' class:
 
-'''yaml
+```yaml
 docker::registry_auth::registries:
   'example.docker.io:5000':
     username: 'user1'
     password: 'secret'
   }
-'''
+```
 
 To log out of a registry, add the following code to the manifest file:
 
 ```puppet
 docker::registry { 'example.docker.io:5000':
   ensure => 'absent',
+}
+```
+
+To set a preferred registry mirror, add the following code to the manifest file:
+```puppet
+class { 'docker':
+  registry_mirror => 'http://testmirror.io'
 }
 ```
 

--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -60,6 +60,10 @@ module Puppet::Parser::Functions
       flags << "-H '#{opts['host_socket']}'"
     end
 
+    if opts['registry_mirror'].to_s != 'undef'
+      flags << "--registry-mirror='#{opts['registry_mirror']}'"
+    end
+
     flags.flatten.join(" ")
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -352,6 +352,10 @@
 # [*tmp_dir*]
 #    Sets the tmp dir for Docker (path)
 #
+# [*registry_mirror*]
+#   Sets the prefered container registry mirror.
+#   Default: undef
+#    
 class docker(
   Optional[String] $version                           = $docker::params::version,
   String $ensure                                      = $docker::params::ensure,
@@ -462,7 +466,7 @@ class docker(
   Optional[String] $service_overrides_template        = $docker::params::service_overrides_template,
   Optional[Boolean] $service_hasstatus                = $docker::params::service_hasstatus,
   Optional[Boolean] $service_hasrestart               = $docker::params::service_hasrestart,
-
+  Optional[String] $registry_mirror                   = $docker::params::registry_mirror,
 ) inherits docker::params {
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,6 +83,7 @@ class docker::params {
   $storage_pool_autoextend_threshold = undef
   $storage_pool_autoextend_percent   = undef
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
+  $registry_mirror                   = undef
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
   $os                                = downcase($::operatingsystem)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -112,6 +112,7 @@ class docker::service (
   $tls_cacert                        = $docker::tls_cacert,
   $tls_cert                          = $docker::tls_cert,
   $tls_key                           = $docker::tls_key,
+  $registry_mirror                   = $docker::registry_mirror,
 ) {
 
   unless $::osfamily =~ /(Debian|RedHat|Archlinux|Gentoo)/ {

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -88,6 +88,21 @@ describe 'docker' do
     end
   end
 
+  context "When registry_mirror is set" do
+    let(:pp) {"
+      class { 'docker':
+        registry_mirror => 'http://testmirror.io'
+      }
+    "}
+     it 'should apply with no errors' do
+       apply_manifest(pp, :catch_failures=>true)
+     end
+
+    describe file('/etc/default/docker') do
+      it { should contain 'registry-mirror' }
+    end
+  end
+
   context 'registry' do
     before(:all) do
       registry_host = 'localhost'

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -201,8 +201,7 @@ describe 'docker', :type => :class do
         context 'with custom service_name' do
           let(:params) {{ 'service_name' => 'docker.io' }}
           it { should contain_file('/etc/default/docker.io') }
-        end
-
+       end
       end
 
       if osfamily == 'RedHat'
@@ -228,6 +227,11 @@ describe 'docker', :type => :class do
         context 'with no_proxy param' do
           let(:params) { {'no_proxy' => '.github.com' } }
           it { should contain_file(service_config_file).with_content(/no_proxy='.github.com'/) }
+        end
+
+        context 'with registry_mirror param set to mirror value' do
+          let(:params) {{ 'registry_mirror' => 'https://mirror.gcr.io' }}
+          it { should contain_file('/etc/sysconfig/docker').with_content(/registry-mirror/) }
         end
 
         context 'when given a specific tmp_dir' do

--- a/templates/etc/sysconfig/docker.systemd.erb
+++ b/templates/etc/sysconfig/docker.systemd.erb
@@ -9,6 +9,7 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
  --iptables=<%= @iptables -%>
  --ip-masq=<%= @ip_masq -%>
 <% unless @icc == nil %> --icc=<%= @icc %><% end -%>
+<% if @registry_mirror %> --registry-mirror=<%= @registry_mirror %><% end -%>
 <% if @fixed_cidr %> --fixed-cidr <%= @fixed_cidr %><% end -%>
 <% if @default_gateway %> --default-gateway <%= @default_gateway %><% end -%>
 <% if @bridge %> --bridge <%= @bridge %><% end -%>


### PR DESCRIPTION
This PR adds the registry-mirror flag so that the user can specify a preferred registry mirror. I have verified that it is working as expected. After the manifest is applied docker system info shows the specified registry mirror. The readme has been updated and unit and acceptance tests added. Unit and acceptance tests are passing.