### PR TITLE
removing manage_kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ To create the Docker hosted repository and install the Docker package, add a sin
 include 'docker'
 ```
 
-If you are using Ubuntu, all the required Kernel extensions are installed. To disable this feature, add the following code to the manifest file:
-
-```puppet
-class { 'docker':
-  manage_kernel => false,
-}
-```
-
 To configure package sources independently and disable automatically including sources, add the following code to the manifest file:
 
 ```puppet
@@ -919,14 +911,6 @@ Defaults to `true'.
 The custom root directory for the containers.
 
 Defaults to `undefined`.
-
-#### `manage_kernel`
-
-Specifies whether to install the Kernel required by Docker.
-
-Valid values are `true`, `false`.
-
-Defaults to `true`.
 
 #### `dns`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,10 +187,6 @@
 #   Custom root directory for containers
 #   Defaults to undefined
 #
-# [*manage_kernel*]
-#   Attempt to install the correct Kernel required by docker
-#   Defaults to true
-#
 # [*dns*]
 #   Custom dns server address
 #   Defaults to undefined
@@ -407,7 +403,6 @@ class docker(
   Optional[String] $root_dir                          = $docker::params::root_dir,
   Optional[Boolean] $tmp_dir_config                    = $docker::params::tmp_dir_config,
   Optional[String] $tmp_dir                           = $docker::params::tmp_dir,
-  Boolean $manage_kernel                              = $docker::params::manage_kernel,
   Variant[String,Array,Undef] $dns                    = $docker::params::dns,
   Variant[String,Array,Undef] $dns_search             = $docker::params::dns_search,
   Optional[String] $socket_group                      = $docker::params::socket_group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,49 +17,6 @@ class docker::install {
     $ensure = $docker::ensure
   }
 
-  case $::osfamily {
-    'Debian': {
-      if $::operatingsystem == 'Ubuntu' {
-        case $::operatingsystemrelease {
-          # On Ubuntu 12.04 (precise) install the backported 13.10 (saucy) kernel
-          '12.04': { $kernelpackage = [
-                                        'linux-image-generic-lts-trusty',
-                                        'linux-headers-generic-lts-trusty'
-                                      ]
-          }
-          # determine the package name for 'linux-image-extra-$(uname -r)' based
-          # on the $::kernelrelease fact
-          default: { $kernelpackage = "linux-image-extra-${::kernelrelease}" }
-        }
-        $manage_kernel = $docker::manage_kernel
-      } else {
-        # Debian does not need extra kernel packages
-        $manage_kernel = false
-      }
-    }
-    'RedHat': {
-      if $::operatingsystem == 'Amazon' {
-        if versioncmp($::operatingsystemrelease, '3.10.37-47.135') < 0 {
-          fail('Docker needs Amazon version to be at least 3.10.37-47.135.')
-        }
-      }
-      elsif versioncmp($::operatingsystemrelease, '6.5') < 0 {
-        fail('Docker needs RedHat/CentOS version to be at least 6.5.')
-      }
-      $manage_kernel = false
-    }
-    default: {}
-  }
-
-  if $manage_kernel {
-    package { $kernelpackage:
-      ensure => present,
-    }
-    if $docker::manage_package {
-      Package[$kernelpackage] -> Package['docker']
-    }
-  }
-
   if $docker::manage_package {
 
     if empty($docker::repo_opt) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,7 +68,6 @@ class docker::params {
   $overlay2_override_kernel_check    = false
   $manage_package                    = true
   $package_source                    = undef
-  $manage_kernel                     = true
   $docker_command                    = 'docker'
   $service_name_default              = 'docker'
   $docker_group_default              = 'docker'

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -720,33 +720,6 @@ describe 'docker', :type => :class do
 
   end
 
-  context 'specific to Ubuntu Maverick' do
-    let(:facts) { {
-      :osfamily               => 'Debian',
-      :operatingsystem        => 'Ubuntu',
-      :lsbdistid              => 'Ubuntu',
-      :lsbdistcodename        => 'maverick',
-      :kernelrelease          => '3.8.0-29-generic',
-      :operatingsystemrelease => '10.04',
-      :os                     => { :distro => { :codename => 'wheezy' }, :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' } }
-    } }
-
-    context 'with no parameters' do
-      it { should contain_package('linux-image-extra-3.8.0-29-generic') }
-      it { should contain_package('apparmor') }
-    end
-
-    context 'with no upstream package source' do
-      let(:params) { {'use_upstream_package_source' => false } }
-      it { should contain_package('linux-image-extra-3.8.0-29-generic') }
-    end
-
-    context 'when not managing the kernel' do
-      let(:params) { {'manage_kernel' => false} }
-      it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
-    end
-  end
-
   context 'specific to Debian wheezy' do
     let(:facts) { {
       :osfamily                  => 'Debian',
@@ -847,23 +820,6 @@ describe 'docker', :type => :class do
       end
 
     end
-  end
-
-  context 'specific to Ubuntu Precise' do
-    let(:facts) { {
-      :architecture           => 'amd64',
-      :osfamily               => 'Debian',
-      :lsbdistid              => 'Ubuntu',
-      :operatingsystem        => 'Ubuntu',
-      :lsbdistcodename        => 'precise',
-      :operatingsystemrelease => '12.04',
-      :kernelrelease          => '3.8.0-29-generic',
-      :os                     => { :distro => { :codename => 'wheezy' }, :family => 'Debian', :name => 'Debian', :release => { :major => '7', :full => '7.0' } }
-    } }
-    it { should contain_package('linux-image-generic-lts-trusty') }
-    it { should contain_package('linux-headers-generic-lts-trusty') }
-    it { should contain_service('docker').with_provider('upstart') }
-    it { should contain_package('apparmor') }
   end
 
   context 'specific to Ubuntu Trusty' do


### PR DESCRIPTION
This PR removes the manage_kernel param as it's no longer required for the supported OS versions in this module