### PR TITLE
docker::compose proxy accepts http proxy

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -28,7 +28,7 @@ class docker::compose(
 ) inherits docker::params {
 
   if $proxy != undef {
-      validate_re($proxy, '^(https?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([\da-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
+      validate_re($proxy, '^((http[s]?)?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([\da-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
   }
 
   if $ensure == 'present' {


### PR DESCRIPTION
we have cntlm running on proxy: `http://127.0.0.1:3128`
Regex didn't support `http://localhost:3128`