### PR TITLE
(cloud-1693) Modue v1.0.5 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# Version 1.0.5
+Various fixes for github issues
+
+ - 124
+ - 98
+ - 73
+ - 38
+ - 14
+
+Adding in the following fetures/functionality:
+
+ - Adding resource type and provider for docker_volumes
+ - Fixing docker registry $pass_hash condition and allowing $server param to contain slashes
+ - Remove docker_cs param
+ - Spec test updates
+ - Add facts from docker version and info
+ - Adding registry mirror flag for docker daemon
+ - Removing deprecated supported Operating systems
+ - Fixing systemd escaping
+ - Add docker::compose accepting http proxy
+ - Allow deactivation of service_config management
+ - Fixingtypedef of storage_config , service_config and overides template
+ - Replacing variant Tuple with Array[String]
+ - updating apt module to the latest version
+ - Replaced validate functions with datatypes and assert_type function.
+
 # Version 1.0.4
 
 Correcting changelog

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-docker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Puppet Labs",
   "summary": "Module for installing and managing docker",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR is for the supported release prep for v.1.0.5 of the module. I have updated the version to 1.0.5 in the metadata.json and also added the change log information. When this ticket is merged I will finish the module release.