### PR TITLE
Use RHSM Repo ID as the default for the extras repo name on RHEL7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -197,7 +197,7 @@ class docker::params {
 
       # repo_opt to specify install_options for docker package
       if $::operatingsystem == 'RedHat' {
-        $repo_opt = '--enablerepo=rhel7-extras'
+        $repo_opt = '--enablerepo=rhel-7-server-extras-rpms'
       } elsif $::operatingsystem == 'CentOS' {
         $repo_opt = '--enablerepo=extras'
       } else {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -382,8 +382,9 @@ describe 'docker', :type => :class do
               'ensure'          => 'present',
               'source'          => 'https://get.docker.com/rpm/1.7.0/centos-7/RPMS/x86_64/docker-engine-1.7.0-1.el7.x86_64.rpm',
               'name'            => 'docker-engine',
-              'install_options' => /--enablerepo/
+              'install_options' => '--enablerepo=rhel-7-server-extras-rpms'
             )
+
           end
         end
 


### PR DESCRIPTION
This pull is to resolve  #148, The default repository name selected for RHEL7 systems isn't a valid RHSM repository ID, causing errors without manually overriding the `repo_opt` value. This change corrects it to the RHSM default name, and the test checking for the value in a default only situation now looks for the correct name. 