### PR TITLE
Added option to pass a Dockerfile to $docker_dir

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -47,10 +47,6 @@ define docker::image(
     }
   )
 
-  if ($docker_file) and ($docker_dir) {
-    fail translate('docker::image must not have both $docker_file and $docker_dir set')
-  }
-
   if ($docker_file) and ($docker_tar) {
     fail translate('docker::image must not have both $docker_file and $docker_tar set')
   }
@@ -91,7 +87,9 @@ define docker::image(
     $image_find    = "${docker_command} images | cut -d ' ' -f 1 | egrep '^(docker\\.io/)?${image}$'"
   }
 
-  if $docker_dir {
+  if ($docker_dir) and ($docker_file) {
+    $image_install = "${docker_command} build -t ${image_arg} -f ${docker_file} ${docker_dir}"
+  } elsif $docker_dir {
     $image_install = "${docker_command} build -t ${image_arg} ${docker_dir}"
   } elsif $docker_file {
     $image_install = "${docker_command} build -t ${image_arg} - < ${docker_file}"

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -42,6 +42,11 @@ describe 'docker::image', :type => :define do
     it { should contain_exec('docker build -t base - < Dockerfile') }
   end
 
+  context 'with docker_dir => /tmp/docker_images/test1 and docker_file => /tmp/docker_images/test1/Dockerfile_altbuild' do
+    let(:params) { { 'docker_dir' => '/tmp/docker_images/test1', 'docker_file' => '/tmp/docker_images/test1/Dockerfile_altbuild' }}
+    it { should contain_exec('docker build -t base -f /tmp/docker_images/test1/Dockerfile_altbuild /tmp/docker_images/test1') }
+  end
+
   context 'with docker_dir => /tmp/docker_images/test1' do
     let(:params) { { 'docker_dir' => '/tmp/docker_images/test1' }}
     it { should contain_exec('docker build -t base /tmp/docker_images/test1') }
@@ -70,15 +75,6 @@ describe 'docker::image', :type => :define do
   context 'with ensure => present and image_tag => precise and docker_dir => /tmp/docker_images/test1' do
     let(:params) { { 'ensure' => 'present', 'image_tag' => 'precise', 'docker_dir' => '/tmp/docker_images/test1' } }
     it { should contain_exec('docker build -t base:precise /tmp/docker_images/test1') }
-  end
-
-  context 'with docker_file => Dockerfile and docker_dir => /tmp/docker_images/test1' do
-    let(:params) { { 'docker_file' => 'Dockerfile', 'docker_dir' => '/tmp/docker_images/test1' }}
-    it do
-      expect {
-        should have_exec_resource_count(1)
-      }.to raise_error(Puppet::Error)
-    end
   end
 
   context 'with docker_tar => /tmp/docker_tars/test1.tar' do


### PR DESCRIPTION
This was needed because some images would not build when only a
directory or only a dockerfile were specified. In paticular, this issue
cropped up when building from source and using a dockerfile with an
alternate name.