### PR TITLE
Fix debian systemd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,7 +147,7 @@ class docker::params {
       $package_ee_package_name = $docker_ee_package_name
 
 
-      if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+      if ($service_provider == 'systemd') {
         $detach_service_in_init = false
       } else {
         $detach_service_in_init = true

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -218,15 +218,12 @@ define docker::run(
     case $::osfamily {
       'Debian': {
         $deprecated_initscript = "/etc/init/${service_prefix}${sanitised_title}.conf"
-        $hasstatus  = true
         if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
           ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
           $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template = 'docker/etc/systemd/system/docker-run.erb'
-          $uses_systemd = true
           $mode = '0640'
         } else {
-          $uses_systemd = false
           $initscript = "/etc/init.d/${service_prefix}${sanitised_title}"
           $init_template = 'docker/etc/init.d/docker-run.erb'
           $mode = '0750'
@@ -235,9 +232,7 @@ define docker::run(
       'RedHat': {
         $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
         $init_template  = 'docker/etc/systemd/system/docker-run.erb'
-        $hasstatus      = true
         $mode           = '0640'
-        $uses_systemd   = true
     }
       default: {
         fail translate(('Docker needs a Debian or RedHat based system.'))
@@ -255,7 +250,7 @@ define docker::run(
         service { "${service_prefix}${sanitised_title}":
           ensure    => false,
           enable    => false,
-          hasstatus => $hasstatus,
+          hasstatus => $docker::params::service_hasstatus,
         }
 
         exec {
@@ -287,7 +282,7 @@ define docker::run(
           service { "${service_prefix}${sanitised_title}":
             ensure    => $running,
             enable    => false,
-            hasstatus => $hasstatus,
+            hasstatus => $docker::params::service_hasstatus,
             require   => File[$initscript],
           }
         }
@@ -313,17 +308,11 @@ define docker::run(
             -> File[$initscript]
           }
 
-          if $uses_systemd {
-            $provider = 'systemd'
-          } else {
-            $provider = undef
-          }
-
           service { "${service_prefix}${sanitised_title}":
             ensure    => $running,
             enable    => true,
-            provider  => $provider,
-            hasstatus => $hasstatus,
+            provider  => $docker::params::service_provider,
+            hasstatus => $docker::params::service_hasstatus,
             require   => File[$initscript],
           }
         }
@@ -342,7 +331,7 @@ define docker::run(
           }
         }
       }
-      if $uses_systemd {
+      if $docker::params::service_provider == 'systemd' {
         exec { "docker-${sanitised_title}-systemd-reload":
           path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
           command     => 'systemctl daemon-reload',

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -217,7 +217,6 @@ define docker::run(
 
     case $::osfamily {
       'Debian': {
-        $deprecated_initscript = "/etc/init/${service_prefix}${sanitised_title}.conf"
         if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
           ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
           $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -215,24 +215,17 @@ define docker::run(
     }
   } else {
 
-    case $::osfamily {
-      'Debian': {
-        if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
-          ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
-          $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
-          $init_template = 'docker/etc/systemd/system/docker-run.erb'
-          $mode = '0640'
-        } else {
-          $initscript = "/etc/init.d/${service_prefix}${sanitised_title}"
-          $init_template = 'docker/etc/init.d/docker-run.erb'
-          $mode = '0750'
-        }
+    case $docker::params::service_provider {
+      'systemd': {
+        $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
+        $init_template = 'docker/etc/systemd/system/docker-run.erb'
+        $mode = '0640'
       }
-      'RedHat': {
-        $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
-        $init_template  = 'docker/etc/systemd/system/docker-run.erb'
-        $mode           = '0640'
-    }
+      'upstart': {
+        $initscript = "/etc/init.d/${service_prefix}${sanitised_title}"
+        $init_template = 'docker/etc/init.d/docker-run.erb'
+        $mode = '0750'
+      }
       default: {
         fail translate(('Docker needs a Debian or RedHat based system.'))
       }


### PR DESCRIPTION
Hi,

This PR fix `docker::run` on debian with systemd.
The container need to not be detached when running systemd.

I removed a unused variable, some duplicate code and replaced a few variables by using `docker::params` instead.

Let me know if you have any question/review on this PR.