### PR TITLE
Docker login Receipt is now removed if login fails and added acceptance tests

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -77,6 +77,7 @@ define docker::registry(
 
     # server may be an URI, which can contain /
     $server_strip = regsubst($server, '/', '_', 'G')
+    $_auth_command = "${auth_cmd} || rm -f \"/root/registry-auth-puppet_receipt_${server_strip}_${local_user}\""
 
     file { "/root/registry-auth-puppet_receipt_${server_strip}_${local_user}":
       ensure  => $ensure,
@@ -84,10 +85,13 @@ define docker::registry(
       notify  => Exec["${title} auth"],
     }
   }
+  else {
+    $_auth_command = $auth_cmd
+  }
 
   exec { "${title} auth":
     environment => $auth_environment,
-    command     => $auth_cmd,
+    command     => $_auth_command,
     user        => $local_user,
     cwd         => '/root',
     path        => ['/bin', '/usr/bin'],

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -10,7 +10,7 @@ describe 'docker::registry', :type => :define do
 		:kernelrelease             => '3.2.0-4-amd64',
 		:operatingsystemmajrelease => '8',
 	} }
-  let(:params) { { 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => 'false' } }
+  let(:params) { { 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
   it { should contain_exec('localhost:5000 auth') }
 
   context 'with ensure => present' do

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -14,47 +14,47 @@ describe 'docker::registry', :type => :define do
   it { should contain_exec('localhost:5000 auth') }
 
   context 'with ensure => present' do
-    let(:params) { { 'ensure' => 'absent', 'version' => '17.06', 'pass_hash' => 'test1234' } }
+    let(:params) { { 'ensure' => 'absent', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command('docker logout localhost:5000') }
   end
 
   context 'with ensure => present' do
-    let(:params) { { 'ensure' => 'present', 'version' => '17.06', 'pass_hash' => 'test1234' } }
+    let(:params) { { 'ensure' => 'present', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and username => user1' do
-    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'version' => '17.06', 'pass_hash' => 'test1234'  } }
+    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and password => secret' do
-    let(:params) { { 'ensure' => 'present', 'password' => 'secret', 'version' => '17.06', 'pass_hash' => 'test1234'  } }
+    let(:params) { { 'ensure' => 'present', 'password' => 'secret', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and email => user1@example.io' do
-    let(:params) { { 'ensure' => 'present', 'email' => 'user1@example.io', 'version' => '17.06', 'pass_hash' => 'test1234'  } }
+    let(:params) { { 'ensure' => 'present', 'email' => 'user1@example.io', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and username => user1, and password => secret and email => user1@example.io' do
-    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '17.06', 'pass_hash' => 'test1234'  } }
+    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_environment('password=secret') }
   end
 
  context 'with ensure => present and username => user1, and password => secret and email => user1@example.io and version < 1.11.0' do
-    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '1.9.0', 'pass_hash' => 'test1234' } }
+    let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '1.9.0', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
   end
 
   context 'with username => user1, and password => secret' do
-    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'version' => '17.06', 'pass_hash' => 'test1234'  } }
+    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_environment('password=secret') }
   end
 
   context 'with username => user1, and password => secret and local_user => testuser' do
-    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'local_user' => 'testuser', 'version' => '17.06', 'pass_hash' => 'test1234'  } }
+    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'local_user' => 'testuser', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
     it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_user('testuser').with_environment('password=secret') }
   end
 

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -10,7 +10,7 @@ describe 'docker::registry', :type => :define do
 		:kernelrelease             => '3.2.0-4-amd64',
 		:operatingsystemmajrelease => '8',
 	} }
-  let(:params) { { 'version' => '17.06', 'pass_hash' => 'test1234' } }
+  let(:params) { { 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => 'false' } }
   it { should contain_exec('localhost:5000 auth') }
 
   context 'with ensure => present' do


### PR DESCRIPTION
An attempt to resolve #167 in a clean way