### PR TITLE
(maint)CLOUD-1768 Fixing incorrect cpuset flag #183

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -31,7 +31,7 @@ module Puppet::Parser::Functions
     cpusets = [opts['cpuset']].flatten.compact
     unless cpusets.empty?
       value = cpusets.join(',')
-      flags << "--cpuset=#{value}"
+      flags << "--cpuset-cpus=#{value}"
     end
 
     if opts['disable_network']

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -234,17 +234,17 @@ require 'spec_helper'
 
       context 'when passing a cpuset' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => '3'} }
-        it { should contain_file(initscript).with_content(/--cpuset=3/) }
+        it { should contain_file(initscript).with_content(/--cpuset-cpus=3/) }
       end
 
       context 'when passing a multiple cpu cpuset' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => ['0', '3']} }
-        it { should contain_file(initscript).with_content(/--cpuset=0,3/) }
+        it { should contain_file(initscript).with_content(/--cpuset-cpus=0,3/) }
       end
 
       context 'when not passing a cpuset' do
         let(:params) { {'command' => 'command', 'image' => 'base'} }
-        it { should contain_file(initscript).without_content(/--cpuset=/) }
+        it { should contain_file(initscript).without_content(/--cpuset-cpus=/) }
       end
 
       context 'when passing a links option' do


### PR DESCRIPTION
This PR is to resolve issue #183. The wrong flag was being passed to set the cpuset. I was not seeing the original warning that was reported but was seeing that when the cpuset parameter was set the container did not run. However when the flag was changed to the correct one the container started as expected. Also updated spec tests.