### PR TITLE
Close placeholders in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Docker provides a enterprise addition of the [Docker Engine](https://www.docker.
 ```puppet
 class { 'docker':
   docker_ee => true,
-  docker_ee_source_location => 'https://<docker_ee_repo_url',
-  docker_ee_key_source => 'https://<docker_ee_key_source_url',
+  docker_ee_source_location => 'https://<docker_ee_repo_url>',
+  docker_ee_key_source => 'https://<docker_ee_key_source_url>',
   docker_ee_key_id => '<key id>',
 }
 ```
@@ -80,8 +80,8 @@ To install Docker EE on RHEL/CentOS:
 ```puppet
 class { 'docker':
   docker_ee => true,
-  docker_ee_source_location => 'https://<docker_ee_repo_url',
-  docker_ee_key_source => 'https://<docker_ee_key_source_url',
+  docker_ee_source_location => 'https://<docker_ee_repo_url>',
+  docker_ee_key_source => 'https://<docker_ee_key_source_url>',
 }
 ```
 


### PR DESCRIPTION
This PR fixes a minor issue in the README where some of the placeholder values weren't terminated with `>`.