### PR TITLE
Limit Image -> Run dependencies to those used

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -124,4 +124,5 @@ define docker::image(
     }
   }
 
+  Docker::Image <| title == $title |> -> Docker::Run <| image == $image_arg |>
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -596,8 +596,8 @@ class docker(
   contain 'docker::service'
 
   Class['docker::repos'] -> Class['docker::install'] -> Class['docker::config'] ~> Class['docker::service']
-  Class['docker'] -> Docker::Registry <||> -> Docker::Image <||> -> Docker::Run <||>
-  Class['docker'] -> Docker::Image <||> -> Docker::Run <||>
+  Class['docker'] -> Docker::Registry <||> -> Docker::Image <||>
+  Class['docker'] -> Docker::Image <||>
   Class['docker'] -> Docker::Run <||>
 
 }


### PR DESCRIPTION
Use searching in the resource collection to limit adding dependencies on
Docker::Image for only those Docker::Run resources defined to use the
specific image.

This reduces the likelihood of accidental cyclical dependencies where
consumers defined a manifest per service containing an image and run,
and then try to add a dependency from one service class onto another.