### PR TITLE
Support refreshonly flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ docker::exec { 'cron_allow_root':
   command      => '/bin/echo root >> /usr/lib/cron/cron.allow',
   tty          => true,
   unless       => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
+  refreshonly  => true,
 }
 ```
 

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -10,6 +10,7 @@ define docker::exec(
   Optional[String] $command        = undef,
   Optional[String] $unless         = undef,
   Optional[Boolean] $sanitise_name = true,
+  Optional[Boolean] $refreshonly   = false,
 ) {
   include docker::params
 
@@ -37,6 +38,7 @@ define docker::exec(
   exec { $exec:
     environment => 'HOME=/root',
     path        => ['/bin', '/usr/bin'],
+    refreshonly => $refreshonly,
     timeout     => 0,
     unless      => $unless_command,
   }

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -662,6 +662,55 @@ describe 'the Puppet Docker module' do
           expect(r.stdout).to match(/test_command_file.txt/)
         end
       end
+
+      it 'should only run if notified when refreshonly is true' do
+        container_name = 'container_4_2'
+        pp=<<-EOS
+          class { 'docker': }
+
+          docker::image { 'ubuntu': }
+
+          docker::run { '#{container_name}':
+            image   => 'ubuntu',
+            command => 'init',
+          }
+
+          docker::exec { 'test_command':
+            container   => '#{container_name}',
+            command     => 'touch /root/test_command_file.txt',
+            refreshonly => true,
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true) unless fact('selinux') == 'true'
+
+        # A sleep to give docker time to execute properly
+        sleep 4
+
+        shell("docker exec #{container_name} ls /root") do |r|
+          expect(r.stdout).to_not match(/test_command_file.txt/)
+        end
+
+        pp_extra=<<-EOS
+          file { '/tmp/dummy_file':
+            ensure => 'present',
+            notify => Docker::Exec['test_command'],
+          }
+        EOS
+
+        pp2 = pp + pp_extra
+
+        apply_manifest(pp2, :catch_failures => true)
+        apply_manifest(pp2, :catch_changes => true) unless fact('selinux') == 'true'
+
+        # A sleep to give docker time to execute properly
+        sleep 4
+
+        shell("docker exec #{container_name} ls /root") do |r|
+          expect(r.stdout).to match(/test_command_file.txt/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Allow for the refreshonly flag to be passed through to the underlying
exec resource.

This allows for Docker::Exec resources to be defined to only run when
notified, which allows for construction of manifests that can check
whether updated configuration made available to running containers
(provided they are using directory mount binds) are valid before
triggering a service restart.

Use case for this is to test generated nginx configuration for the
running nginx container using a Docker::Exec call that is notified by
the file resource and in turn will notify the service resource to
restart.