### PR TITLE
Fix incompatiblity with puppet4

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -48,7 +48,7 @@ define docker::registry(
   $docker_command = $docker::params::docker_command
 
   if $ensure == 'present' {
-    if $username != undef and $password != undef and $email != undef and $version =~ /1[.][1-9]0?/ {
+    if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/ {
       $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     }


### PR DESCRIPTION
By default $version is undef unless a specific version is specified.
In Puppet 4.x regular expression comparisions against non-strings raises
an error.
Thus using the default value for $version will raise an error when using
the registry class in puppet 4.x.
To work around this issue, we first need to check that $version has not
an undef value.