### PR TITLE
Add Docker EE support for Windows Server 2016

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,7 @@ fixtures:
     stdlib: 'puppetlabs-stdlib'
     apt: 'puppetlabs-apt'
     translate: 'puppetlabs-translate'
+    powershell: 'puppetlabs-powershell'
+    reboot: 'puppetlabs-reboot'
   symlinks:
     docker: "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,9 @@
 # == Class: docker::config
 #
 class docker::config {
-  docker::system_user { $docker::docker_users: }
+  if $::osfamily != 'windows' {
+    docker::system_user { $docker::docker_users: }
+  } else {
+    docker::windows_account { $docker::docker_users: }
+  }
 }

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -108,7 +108,7 @@ define docker::image(
   if $::osfamily == 'windows' {
     $_image_find = "\$image_id=${image_find}; If (!\$image_id) { Exit 1 }"
   } else {
-    $_image_find = $image_find
+    $_image_find = "${image_find} | grep ."
   }
 
   if ($docker_dir) and ($docker_file) {

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -36,14 +36,32 @@ define docker::image(
   include docker::params
   $docker_command = $docker::params::docker_command
 
+  if $::osfamily == 'windows' {
+    $update_docker_image_template = 'docker/windows/update_docker_image.ps1.erb'
+    $update_docker_image_path = 'c:/Windows/Temp/update_docker_image.ps1'
+    $exec_environment = undef
+    $exec_timeout = 3000
+    $update_docker_image_owner = undef
+    $exec_path = ['c:/Windows/Temp/', 'C:/Program Files/Docker/']
+    $exec_provider = 'powershell'
+  } else {
+    $update_docker_image_template = 'docker/update_docker_image.sh.erb'
+    $update_docker_image_path = '/usr/local/bin/update_docker_image.sh'
+    $update_docker_image_owner = 'root'
+    $exec_environment = 'HOME=/root'
+    $exec_path = ['/bin', '/usr/bin']
+    $exec_timeout = 0
+    $exec_provider = undef
+  }
+
   # Wrapper used to ensure images are up to date
-  ensure_resource('file', '/usr/local/bin/update_docker_image.sh',
+  ensure_resource('file', $update_docker_image_path,
     {
       ensure  => $docker::params::ensure,
-      owner   => 'root',
-      group   => 'root',
+      owner   => $update_docker_image_owner,
+      group   => $update_docker_image_owner,
       mode    => '0555',
-      content => template('docker/update_docker_image.sh.erb'),
+      content => template($update_docker_image_template),
     }
   )
 
@@ -76,15 +94,21 @@ define docker::image(
   if $image_tag {
     $image_arg     = "${image}:${image_tag}"
     $image_remove  = "${docker_command} rmi ${image_force}${image}:${image_tag}"
-    $image_find    = "${docker_command} images | egrep '^(docker.io/)?${image} ' | awk '{ print \$2 }' | grep ^${image_tag}$"
+    $image_find    = "${docker_command} images -q ${image}:${image_tag}"
   } elsif $image_digest {
     $image_arg     = "${image}@${image_digest}"
     $image_remove  = "${docker_command} rmi ${image_force}${image}:${image_digest}"
-    $image_find    = "${docker_command} images --digests | egrep '^(docker.io/)?${image} ' | awk '{ print \$3 }' | grep ^${image_digest}$"
+    $image_find    = "${docker_command} images -q ${image}@${image_digest}"
+
   } else {
     $image_arg     = $image
     $image_remove  = "${docker_command} rmi ${image_force}${image}"
-    $image_find    = "${docker_command} images | cut -d ' ' -f 1 | egrep '^(docker\\.io/)?${image}$'"
+    $image_find    = "${docker_command} images -q ${image}"
+  }
+  if $::osfamily == 'windows' {
+    $_image_find = "\$image_id=${image_find}; If (!\$image_id) { Exit 1 }"
+  } else {
+    $_image_find = $image_find
   }
 
   if ($docker_dir) and ($docker_file) {
@@ -92,35 +116,49 @@ define docker::image(
   } elsif $docker_dir {
     $image_install = "${docker_command} build -t ${image_arg} ${docker_dir}"
   } elsif $docker_file {
-    $image_install = "${docker_command} build -t ${image_arg} - < ${docker_file}"
+    if $::osfamily == windows {
+      $image_install = "Get-Content ${docker_file} | ${docker_command} build -t ${image_arg} -"
+    } else {
+      $image_install = "${docker_command} build -t ${image_arg} - < ${docker_file}"
+    }
   } elsif $docker_tar {
     $image_install = "${docker_command} load -i ${docker_tar}"
   } else {
-    $image_install = "/usr/local/bin/update_docker_image.sh ${image_arg}"
+    if $::osfamily == 'windows' {
+      $image_install = "& ${update_docker_image_path} ${image_arg}"
+    } else {
+      $image_install = "${update_docker_image_path} ${image_arg}"
+    }
   }
 
   if $ensure == 'absent' {
     exec { $image_remove:
-      path    => ['/bin', '/usr/bin'],
-      onlyif  => $image_find,
-      timeout => 0,
+      path      => $exec_path,
+      onlyif    => $_image_find,
+      provider  => $exec_provider,
+      timeout   => $exec_timeout,
+      logoutput => true,
     }
   } elsif $ensure == 'latest' or $image_tag == 'latest' {
     exec { "echo 'Update of ${image_arg} complete'":
-      environment => 'HOME=/root',
-      path        => ['/bin', '/usr/bin'],
-      timeout     => 0,
+      environment => $exec_environment,
+      path        => $exec_path,
+      timeout     => $exec_timeout,
       onlyif      => $image_install,
-      require     => File['/usr/local/bin/update_docker_image.sh'],
+      require     => File[$update_docker_image_path],
+      provider    => $exec_provider,
+      logoutput   => true,
     }
   } elsif $ensure == 'present' {
     exec { $image_install:
-      unless      => $image_find,
-      environment => 'HOME=/root',
-      path        => ['/bin', '/usr/bin'],
-      timeout     => 0,
+      unless      => $_image_find,
+      environment => $exec_environment,
+      path        => $exec_path,
+      timeout     => $exec_timeout,
       returns     => ['0', '2'],
-      require     => File['/usr/local/bin/update_docker_image.sh'],
+      require     => File[$update_docker_image_path],
+      provider    => $exec_provider,
+      logoutput   => true,
     }
   }
 

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -38,7 +38,7 @@ define docker::image(
 
   if $::osfamily == 'windows' {
     $update_docker_image_template = 'docker/windows/update_docker_image.ps1.erb'
-    $update_docker_image_path = 'c:/Windows/Temp/update_docker_image.ps1'
+    $update_docker_image_path = 'C:/Windows/Temp/update_docker_image.ps1'
     $exec_environment = undef
     $exec_timeout = 3000
     $update_docker_image_owner = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -363,6 +363,14 @@
 #   Sets the prefered container registry mirror.
 #   Default: undef
 #
+# [*nuget_package_provider_version*]
+#   The version of the NuGet Package provider
+#   Default: undef
+#
+# [*docker_msft_provider_version*]
+#   The version of the Microsoft Docker Provider Module
+#   Default: undef
+
 class docker(
   Optional[String] $version                                 = $docker::params::version,
   String $ensure                                            = $docker::params::ensure,
@@ -474,12 +482,15 @@ class docker(
   Optional[Boolean] $service_hasstatus                      = $docker::params::service_hasstatus,
   Optional[Boolean] $service_hasrestart                     = $docker::params::service_hasrestart,
   Optional[String] $registry_mirror                         = $docker::params::registry_mirror,
+  # Windows specific parameters
+  Optional[String] $docker_msft_provider_version            = $docker::params::docker_msft_provider_version,
+  Optional[String] $nuget_package_provider_version          = $docker::params::nuget_package_provider_version,
 ) inherits docker::params {
 
 
   if $::osfamily {
-    assert_type(Pattern[/^(Debian|RedHat)$/], $::osfamily) |$a, $b| {
-      fail translate(('This module only works on Debian or Red Hat based systems.'))
+    assert_type(Pattern[/^(Debian|RedHat|windows)$/], $::osfamily) |$a, $b| {
+      fail translate(('This module only works on Debian, Red Hat or Windows based systems.'))
     }
   }
 
@@ -563,6 +574,9 @@ class docker(
             $package_location = "https://download.docker.com/linux/centos/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
             $package_key_source = $docker_ce_key_source
             $package_key_check_source = true
+            }
+          'windows': {
+            fail translate(('This module only work for Docker Enterprise Edition on Windows'))
           }
           default: {}
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,13 +1,29 @@
 # == Class: docker
 #
 # Module to install an up-to-date version of Docker from a package repository.
-# This module works only on Debian and Red Hat based distributions.
+# This module works only on Debian Red Hat and Windows based distributions.
 #
-class docker::install {
+# === Parameters
+# [*version*]
+#   The package version to install, used to set the package name.
+#
+# [*nuget_package_provider_version*]
+#   The version of the NuGet Package provider
+#   Default: undef
+#
+# [*docker_msft_provider_version*]
+#   The version of the Microsoft Docker Provider Module
+#   Default: undef
+
+class docker::install (
+  $version                        = $docker::version,
+  $nuget_package_provider_version = $docker::nuget_package_provider_version,
+  $docker_msft_provider_version   = $docker::docker_msft_provider_version
+) {
   $docker_start_command = $docker::docker_start_command
   if $::osfamily {
-    assert_type(Pattern[/^(Debian|RedHat)$/], $::osfamily) |$a, $b| {
-      fail translate(('This module only works on Debian or RedHat.'))
+    assert_type(Pattern[/^(Debian|RedHat|windows)$/], $::osfamily) |$a, $b| {
+      fail translate(('This module only works on Debian, RedHat or Windows.'))
     }
   }
   if $docker::version and $docker::ensure != 'absent' {
@@ -17,7 +33,6 @@ class docker::install {
   }
 
   if $docker::manage_package {
-
     if empty($docker::repo_opt) {
       $docker_hash = {}
     } else {
@@ -36,7 +51,6 @@ class docker::install {
           $pk_provider = undef
         }
       }
-
       case $docker::package_source {
         /docker-engine/ : {
           ensure_resource('package', 'docker', merge($docker_hash, {
@@ -54,14 +68,34 @@ class docker::install {
             name     => $docker::docker_ce_package_name,
           }))
         }
+        #TODO: Windows with download URL
         default : {}
       }
 
+
     } else {
-      ensure_resource('package', 'docker', merge($docker_hash, {
-        ensure => $ensure,
-        name   => $docker::docker_package_name,
-      }))
+      if $::osfamily != 'windows' {
+        ensure_resource('package', 'docker', merge($docker_hash, {
+          ensure => $ensure,
+          name   => $docker::docker_package_name,
+        }))
+      } else {
+        $install_script_path = 'c:/Windows/Temp/install_powershell_provider.ps1'
+        file{ $install_script_path:
+          ensure  => present,
+          force   => true,
+          content => template('docker/windows/install_powershell_provider.ps1.erb'),
+        }
+        exec { 'install-docker-package':
+          command   => "& ${install_script_path}",
+          provider  => powershell,
+          logoutput => true,
+        }
+        exec { 'service-restart-on-failure':
+          command => 'cmd /c "SC failure Docker reset= 432000 actions= restart/30000/restart/60000/restart/60000"',
+          path    => 'c:/Windows/System32/'
+        }
+      }
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,6 +47,9 @@ class docker::install (
         'RedHat' : {
           $pk_provider = 'rpm'
         }
+        'windows' : {
+          fail translate('Custom package source is currently not implemented on windows.')
+        }
         default : {
           $pk_provider = undef
         }
@@ -80,7 +83,7 @@ class docker::install (
           name   => $docker::docker_package_name,
         }))
       } else {
-        $install_script_path = 'c:/Windows/Temp/install_powershell_provider.ps1'
+        $install_script_path = 'C:/Windows/Temp/install_powershell_provider.ps1'
         file{ $install_script_path:
           ensure  => present,
           force   => true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,11 +14,17 @@
 # [*docker_msft_provider_version*]
 #   The version of the Microsoft Docker Provider Module
 #   Default: undef
+#
+# [*docker_ee_package_name*]
+#   The name of the Docker Enterprise Edition package
+#   Default: Docker
+
 
 class docker::install (
   $version                        = $docker::version,
   $nuget_package_provider_version = $docker::nuget_package_provider_version,
-  $docker_msft_provider_version   = $docker::docker_msft_provider_version
+  $docker_msft_provider_version   = $docker::docker_msft_provider_version,
+  $docker_ee_package_name         = $docker::docker_ee_package_name
 ) {
   $docker_start_command = $docker::docker_start_command
   if $::osfamily {
@@ -71,7 +77,6 @@ class docker::install (
             name     => $docker::docker_ce_package_name,
           }))
         }
-        #TODO: Windows with download URL
         default : {}
       }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,8 @@ class docker::params {
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
   $os_lc                             = downcase($::operatingsystem)
+  $docker_msft_provider_version      = undef
+  $nuget_package_provider_version    = undef
 
   case $::osfamily {
     'Debian' : {
@@ -206,6 +208,14 @@ class docker::params {
       } else {
         $repo_opt = undef
       }
+    }
+    'windows' : {
+      $msft_nuget_package_provider_version = $nuget_package_provider_version
+      $msft_provider_version = $docker_msft_provider_version
+      $msft_package_version = $version
+      $service_config_template = 'docker/windows/config/daemon.json.erb'
+      $service_config = 'C:/ProgramData/docker/config/daemon.json'
+      $docker_group = 'docker'
     }
     default: {
       $docker_group = $docker_group_default

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -237,7 +237,7 @@ class docker::params {
       $package_key_source = undef
       $package_key_check_source = undef
       $package_ee_source_location = undef
-      $package_ee_package_name = $docker_ee_package_name #TODO: add in install.ps1
+      $package_ee_package_name = $docker_ee_package_name
       $package_ee_key_source = undef
       $package_ee_key_id = undef
       $package_ee_repos = undef
@@ -246,7 +246,7 @@ class docker::params {
       $pin_upstream_package_source = undef
       $apt_source_pin_level= undef
       $socket_group = undef
-      $service_name = $service_name_default #TODO: use this
+      $service_name = $service_name_default
       $repo_opt = undef
       $storage_config = undef
       $storage_setup_file = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,11 @@ class docker::params {
   $docker_ce_channel                 = stable
   $docker_ee                         = false
   $docker_ee_start_command           = 'dockerd'
-  $docker_ee_package_name            = 'docker-ee'
+  if ($::osfamily == 'windows') {
+    $docker_ee_package_name          = 'Docker'
+  } else {
+    $docker_ee_package_name          = 'docker-ee'
+  }
   $docker_ee_source_location         = undef
   $docker_ee_key_source              = undef
   $docker_ee_key_id                  = undef
@@ -20,9 +24,15 @@ class docker::params {
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
-  $tls_cacert                        = '/etc/docker/tls/ca.pem'
-  $tls_cert                          = '/etc/docker/tls/cert.pem'
-  $tls_key                           = '/etc/docker/tls/key.pem'
+  if ($::osfamily == 'windows') {
+    $tls_cacert                        = 'C:/ProgramData/docker/certs.d/ca.pem'
+    $tls_cert                          = 'C:/ProgramData/docker/certs.d/server-cert.pem'
+    $tls_key                           = 'C:/ProgramData/docker/certs.d/server-key.pem'
+  } else {
+    $tls_cacert                        = '/etc/docker/tls/ca.pem'
+    $tls_cert                          = '/etc/docker/tls/cert.pem'
+    $tls_key                           = '/etc/docker/tls/key.pem'
+  }
   $ip_forward                        = true
   $iptables                          = true
   $ipv6                              = false
@@ -216,6 +226,34 @@ class docker::params {
       $service_config_template = 'docker/windows/config/daemon.json.erb'
       $service_config = 'C:/ProgramData/docker/config/daemon.json'
       $docker_group = 'docker'
+      $package_ce_source_location = undef
+      $package_ce_key_source = undef
+      $package_ce_key_id = undef
+      $package_ce_repos = undef
+      $package_ce_release = undef
+      $package_key_id = undef
+      $package_release = undef
+      $package_source_location = undef
+      $package_key_source = undef
+      $package_key_check_source = undef
+      $package_ee_source_location = undef
+      $package_ee_package_name = $docker_ee_package_name #TODO: add in install.ps1
+      $package_ee_key_source = undef
+      $package_ee_key_id = undef
+      $package_ee_repos = undef
+      $package_ee_release = undef
+      $use_upstream_package_source = undef
+      $pin_upstream_package_source = undef
+      $apt_source_pin_level= undef
+      $socket_group = undef
+      $service_name = $service_name_default #TODO: use this
+      $repo_opt = undef
+      $storage_config = undef
+      $storage_setup_file = undef
+      $service_provider = undef
+      $service_overrides_template = undef
+      $service_hasstatus = undef
+      $service_hasrestart = undef
     }
     default: {
       $docker_group = $docker_group_default

--- a/manifests/windows_account.pp
+++ b/manifests/windows_account.pp
@@ -1,0 +1,9 @@
+# == Define: docker::windows_account
+#
+# Define the Windows account that owns the docker services
+#
+
+
+define docker::windows_account () {
+    notice('TODO:Not implemented')
+}

--- a/manifests/windows_account.pp
+++ b/manifests/windows_account.pp
@@ -5,5 +5,5 @@
 
 
 define docker::windows_account () {
-    notice('TODO:Not implemented')
+    notice('Not implemented')
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,9 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.24.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 4.4.1"},
-    {"name":"puppetlabs/translate","version_requirement":">= 0.0.1 < 1.1.0"}
+    {"name":"puppetlabs/translate","version_requirement":">= 0.0.1 < 1.1.0"},
+    {"name":"puppetlabs/powershell","version_requirement":">= 2.1.4"},
+    {"name":"puppetlabs/reboot","version_requirement":">= 2.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [
@@ -38,6 +40,12 @@
       "operatingsystemrelease": [
         "8.0",
         "9.0"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2016"
       ]
     }
   ],

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -867,7 +867,7 @@ describe 'docker', :type => :class do
     it do
       expect {
         should contain_package('docker')
-      }.to raise_error(Puppet::Error, /This module only works on Debian or Red Hat based systems./)
+      }.to raise_error(Puppet::Error, /This module only works on Debian, Red Hat or Windows based systems./)
     end
   end
 

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -638,7 +638,7 @@ describe 'docker', :type => :class do
       end
 
       context 'with an invalid log_driver' do
-        let(:params) { { 'log_driver' => 'verbose'} }
+        let(:params) { { 'log_driver' => 'etwlogs'} }
         it do
           expect {
             should contain_package('docker')

--- a/spec/classes/docker_windows_spec.rb
+++ b/spec/classes/docker_windows_spec.rb
@@ -23,6 +23,8 @@ describe 'docker', :type => :class do
           'ensure' => 'present'
       })}
       it { should contain_file('C:/ProgramData/docker/config/')}
+      it { should contain_exec('service-restart-on-failure') }
+      it { should contain_exec('install-docker-package').with_command('& C:/Windows/Temp/install_powershell_provider.ps1') }
       it { should contain_class('docker::repos').that_comes_before('Class[docker::install]') }
       it { should contain_class('docker::install').that_comes_before('Class[docker::config]') }
       it { should contain_class('docker::service').that_subscribes_to('Class[docker::config]') }

--- a/spec/classes/docker_windows_spec.rb
+++ b/spec/classes/docker_windows_spec.rb
@@ -1,0 +1,253 @@
+require 'spec_helper'
+
+describe 'docker', :type => :class do
+    osfamily = "windows"
+    context "on #{osfamily}" do
+      let(:facts) { {
+          :architecture              => 'amd64',
+          :osfamily                  => 'windows',
+          :operatingsystem           => 'windows',
+          :kernelrelease             => '10.0.14393',
+          :operatingsystemrelease    => '2016',
+          :operatingsystemmajrelease => '2016',
+          :os                        => { :family => 'windows', :name => 'windows', :release => { :major => '2016', :full => '2016' } }
+        } }
+      service_config_file = 'C:/ProgramData/docker/config/daemon.json'
+      let(:params) {{ 'docker_ee' => true }}
+
+      it { should compile.with_all_deps }
+      it { should contain_file('C:/ProgramData/docker/').with({
+          'ensure' => 'directory'
+      } ) }
+      it { should contain_file('C:/Windows/Temp/install_powershell_provider.ps1').with({
+          'ensure' => 'present'
+      })}
+      it { should contain_file('C:/ProgramData/docker/config/')}
+      it { should contain_class('docker::repos').that_comes_before('Class[docker::install]') }
+      it { should contain_class('docker::install').that_comes_before('Class[docker::config]') }
+      it { should contain_class('docker::service').that_subscribes_to('Class[docker::config]') }
+      it { should contain_class('docker::config') }
+
+      it { should contain_file(service_config_file).without_content(/icc=/) }
+      
+      context 'with dns' do
+        let(:params) { { 
+            'dns' => '8.8.8.8',
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"dns": \["8.8.8.8"\],/) }
+      end
+
+      context 'with multi dns' do
+        let(:params) { { 
+            'dns' => ['8.8.8.8', '8.8.4.4'],
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"dns": \["8.8.8.8","8.8.4.4"\],/) }
+      end
+
+      context 'with dns search' do
+        let(:params) { { 
+            'dns_search' => ['my.domain.local'],
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"dns-search": \["my.domain.local"\],/) }
+      end
+
+      context 'with multi dns search' do
+        let(:params) { { 
+            'dns_search' => ['my.domain.local', 'other-domain.de'],
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"dns-search": \["my.domain.local","other-domain.de"\],/) }
+      end
+
+      context 'with log_driver' do
+        let(:params) { { 
+            'log_driver' => 'etwlogs',
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"log-driver": "etwlogs"/) }
+      end
+
+      context 'with invalid log_driver' do
+        let(:params) { { 
+            'log_driver' => 'invalid',
+            'docker_ee'  => true
+        } }
+        it do
+            expect {
+              should contain_package('docker')
+            }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs/)
+        end
+      end
+
+      context 'with invalid journald log_driver' do
+        let(:params) { { 
+            'log_driver' => 'journald',
+            'docker_ee'  => true
+        } }
+        it do
+            expect {
+              should contain_package('docker')
+            }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs/)
+        end
+      end
+
+      context 'with mtu' do
+        let(:params) { { 
+            'mtu' => '1450',
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"mtu": 1450/) }
+      end
+
+      context 'with log_level' do
+        let(:params) { { 
+            'log_level' => 'debug',
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"log-level": "debug"/) }
+      end
+
+      context 'with invalid log_level' do
+        let(:params) { { 
+            'log_level' => 'verbose',
+            'docker_ee'  => true
+        } }
+        it do
+            expect {
+              should contain_package('docker')
+            }.to raise_error(Puppet::Error, /log_level must be one of debug, info, warn, error or fatal/)
+        end
+      end
+      
+      context 'with tcp_bind' do
+        let(:params) { { 
+            'tcp_bind'   => "tcp://0.0.0.0:2376",
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"hosts": \["tcp:\/\/0.0.0.0:2376"\]/) }
+      end
+
+      context 'with multiple tcp_bind' do
+        let(:params) { { 
+            'tcp_bind'   => ["tcp://0.0.0.0:2376", "npipe://"],
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"hosts": \["tcp:\/\/0.0.0.0:2376","npipe:\/\/"\]/) }
+      end
+
+      context 'with tls_enable, tcp_bind and tls configuration' do
+        let(:params) { { 
+            'tls_enable' => true,
+            'tcp_bind'   => ["tcp://0.0.0.0:2376"],
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(
+            /"hosts": \["tcp:\/\/0.0.0.0:2376"]/).with_content(
+                /"tlsverify": true/).with_content(
+                    /"tlscacert": "C:\/ProgramData\/docker\/certs.d\/ca.pem"/).with_content(
+                        /"tlscert": "C:\/ProgramData\/docker\/certs.d\/server-cert.pem"/).with_content(
+                            /"tlskey": "C:\/ProgramData\/docker\/certs.d\/server-key.pem"/)
+            }
+      end
+
+      context 'with tls_enable, tcp_bind and custom tls cacert' do
+        let(:params) { { 
+            'tls_enable' => true,
+            'tcp_bind'   => ["tcp://0.0.0.0:2376"],
+            'tls_cacert' => 'C:/certs/ca.pem',
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(
+                    /"tlscacert": "C:\/certs\/ca.pem"/)
+            }
+      end
+
+      context 'with tls_enable, tcp_bind and custom tls cert' do
+        let(:params) { { 
+            'tls_enable' => true,
+            'tcp_bind'   => ["tcp://0.0.0.0:2376"],
+            'tls_cert'   => 'C:/certs/server-cert.pem',
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(
+                    /"tlscert": "C:\/certs\/server-cert.pem"/)
+            }
+      end
+
+      context 'with tls_enable, tcp_bind and custom tls key' do
+        let(:params) { { 
+            'tls_enable' => true,
+            'tcp_bind'   => ["tcp://0.0.0.0:2376"],
+            'tls_key'   => 'C:/certs/server-key.pem',
+            'docker_ee'  => true
+        } }
+        it { should contain_file(service_config_file).with_content(
+                    /"tlskey": "C:\/certs\/server-key.pem"/)
+            }
+      end
+
+      context 'with custom socket group' do
+        let(:params) { { 
+            'socket_group' => "custom",
+            'docker_ee'    => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"group": "custom"/)}
+      end
+
+      context 'with custom bridge' do
+        let(:params) { { 
+            'bridge'    => "l2bridge",
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"bridge": "l2bridge"/)}
+      end
+
+      context 'with invalid bridge' do
+        let(:params) { { 
+            'bridge'    => "invalid",
+            'docker_ee' => true
+        } }
+        it do
+            expect {
+              should contain_package('docker')
+            }.to raise_error(Puppet::Error, /bridge must be one of none, nat, transparent, overlay, l2bridge or l2tunnel on Windows./)
+        end
+      end
+
+      context 'with custom fixed cidr' do
+        let(:params) { { 
+            'fixed_cidr'=> "10.0.0.0/24",
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"fixed-cidr": "10.0.0.0\/24"/)}
+      end
+
+      context 'with custom registry mirror' do
+        let(:params) { { 
+            'registry_mirror'=> "https://mirror.gcr.io",
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"registry-mirrors": \["https:\/\/mirror.gcr.io"\]/)}
+      end
+
+      context 'with custom label' do
+        let(:params) { { 
+            'labels'=> ["mylabel"],
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_config_file).with_content(/"labels": \["mylabel"\]/)}
+      end
+
+      context 'without docker_ee' do
+        let(:params) {{ 'docker_ee' => false }}
+        it do
+            expect {
+              should contain_package('docker')
+            }.to raise_error(Puppet::Error, /This module only work for Docker Enterprise Edition on Windows./)
+        end
+      end
+    end
+end

--- a/spec/classes/docker_windows_spec.rb
+++ b/spec/classes/docker_windows_spec.rb
@@ -13,18 +13,19 @@ describe 'docker', :type => :class do
           :os                        => { :family => 'windows', :name => 'windows', :release => { :major => '2016', :full => '2016' } }
         } }
       service_config_file = 'C:/ProgramData/docker/config/daemon.json'
+      service_install_file = 'C:/Windows/Temp/install_powershell_provider.ps1'
       let(:params) {{ 'docker_ee' => true }}
 
       it { should compile.with_all_deps }
       it { should contain_file('C:/ProgramData/docker/').with({
           'ensure' => 'directory'
       } ) }
-      it { should contain_file('C:/Windows/Temp/install_powershell_provider.ps1').with({
+      it { should contain_file(service_install_file).with({
           'ensure' => 'present'
       })}
       it { should contain_file('C:/ProgramData/docker/config/')}
       it { should contain_exec('service-restart-on-failure') }
-      it { should contain_exec('install-docker-package').with_command('& C:/Windows/Temp/install_powershell_provider.ps1') }
+      it { should contain_exec('install-docker-package').with_command("& #{service_install_file}") }
       it { should contain_class('docker::repos').that_comes_before('Class[docker::install]') }
       it { should contain_class('docker::install').that_comes_before('Class[docker::config]') }
       it { should contain_class('docker::service').that_subscribes_to('Class[docker::config]') }
@@ -241,6 +242,21 @@ describe 'docker', :type => :class do
             'docker_ee' => true
         } }
         it { should contain_file(service_config_file).with_content(/"labels": \["mylabel"\]/)}
+      end
+
+      context 'with default package name' do
+        let(:params) { { 
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_install_file).with_content(/ Docker /)}
+      end
+
+      context 'with custom package name' do
+        let(:params) { { 
+            'docker_ee_package_name'=> "mydockerpackage",
+            'docker_ee' => true
+        } }
+        it { should contain_file(service_install_file).with_content(/ mydockerpackage /)}
       end
 
       context 'without docker_ee' do

--- a/spec/defines/image_windows_spec.rb
+++ b/spec/defines/image_windows_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'docker::image', :type => :define do
+  let(:title) { 'base' }
+  let(:facts) { {
+      :architecture              => 'amd64',
+      :osfamily                  => 'windows',
+      :operatingsystem           => 'windows',
+      :kernelrelease             => '10.0.14393',
+      :operatingsystemrelease    => '2016',
+      :operatingsystemmajrelease => '2016',
+      :os                        => { :family => 'windows', :name => 'windows', :release => { :major => '2016', :full => '2016' } }
+  } }
+  context 'with ensure => present' do
+      let(:params) { { 'ensure' => 'present' } }
+      it { should contain_file('C:/Windows/Temp/update_docker_image.ps1') }
+      it { should contain_exec('& C:/Windows/Temp/update_docker_image.ps1 base') }
+  end
+
+  context 'with docker_file => Dockerfile' do
+      let(:params) { { 'docker_file' => 'Dockerfile' }}
+      it { should contain_exec('Get-Content Dockerfile | docker build -t base -') }
+    end
+
+    context 'with ensure => present and docker_file => Dockerfile' do
+        let(:params) { { 'ensure' => 'present', 'docker_file' => 'Dockerfile' } }
+        it { should contain_exec('Get-Content Dockerfile | docker build -t base -') }
+    end
+
+    context 'with ensure => present and image_tag => nanoserver' do
+        let(:params) { { 'ensure' => 'present', 'image_tag' => 'nanoserver' } }
+        it { should contain_exec('& C:/Windows/Temp/update_docker_image.ps1 base:nanoserver') }
+    end
+
+    context 'with ensure => present and image_digest => sha256:deadbeef' do
+        let(:params) { { 'ensure' => 'present', 'image_digest' => 'sha256:deadbeef' } }
+        it { should contain_exec('& C:/Windows/Temp/update_docker_image.ps1 base@sha256:deadbeef') }
+    end
+
+    context 'with ensure => present and image_tag => nanoserver and docker_file => Dockerfile' do
+        let(:params) { { 'ensure' => 'present', 'image_tag' => 'nanoserver', 'docker_file' => 'Dockerfile' } }
+        it { should contain_exec('Get-Content Dockerfile | docker build -t base:nanoserver -') }
+    end
+    
+    context 'with ensure => latest' do
+        let(:params) { { 'ensure' => 'latest' } }
+        it { should contain_exec("echo 'Update of base complete'").with_onlyif('& C:/Windows/Temp/update_docker_image.ps1 base') }
+    end
+
+end

--- a/templates/windows/config/daemon.json.erb
+++ b/templates/windows/config/daemon.json.erb
@@ -1,18 +1,8 @@
 {
-    <%# TODO: get "authorization-plugins": [],%>
     <% if @dns %> "dns": <%= @dns_array.to_json %>,<% end -%>
-    <%# TODO: "dns-opts": [],%>
     <% if @dns_search %> "dns-search": <%= @dns_search_array.to_json %>,<% end -%>
-    <%# TODO: "exec-opts": [],%>
-    <%# TODO: "storage-driver": "", %>
-    <%# TODO: "storage-opts": [], %>
     <% if @log_driver %> "log-driver": "<%= @log_driver %>", <% end -%>
     <% if @mtu %> "mtu": <%= @mtu %>, <% end -%>
-    <%# TODO: "pidfile": "", %>
-    <%# TODO: "data-root": "", %>
-    <%# TODO: "cluster-store": "", %>
-    <%# TODO: "cluster-advertise": "", %>
-    <%# TODO: "debug": true, %>
     <% if @tcp_bind %> "hosts": <%= @tcp_bind_array.to_json %>, <% end -%>
     <% if @log_level %> "log-level": "<%= @log_level %>", <% end -%>
     <% if @tls_enable %> "tlsverify": true, 
@@ -21,11 +11,8 @@
     "tlskey": "<%= @tls_key %>",
     <% end -%>
     <% if @socket_group %>"group": "<%= @socket_group %>",<% end -%>
-    <%# "default-ulimit": {}, %>
     <% if @bridge %>"bridge": "<%= @bridge %>",<% end -%>
     <% if @fixed_cidr %>"fixed-cidr": "<%= @fixed_cidr %>",<% end -%>
-    <%# "raw-logs": false, %>
     <% if @registry_mirror %>"registry-mirrors": ["<%= @registry_mirror%>"], <% end -%>
-    <%# "insecure-registries": []%>
     "labels": <%= @labels_array.to_json %>
 }

--- a/templates/windows/config/daemon.json.erb
+++ b/templates/windows/config/daemon.json.erb
@@ -13,19 +13,19 @@
     <%# TODO: "cluster-store": "", %>
     <%# TODO: "cluster-advertise": "", %>
     <%# TODO: "debug": true, %>
-    <%# TODO: "hosts": [], %>
+    <% if @tcp_bind %> "hosts": <%= @tcp_bind_array.to_json %>, <% end -%>
     <% if @log_level %> "log-level": "<%= @log_level %>", <% end -%>
     <% if @tls_enable %> "tlsverify": true, 
     "tlscacert": "<%= @tls_cacert %>",
     "tlscert": "<%= @tls_cert %>",
     "tlskey": "<%= @tls_key %>",
     <% end -%>
-    <% if @socket_group %>"group": <%= @socket_group %>,<% end -%>
+    <% if @socket_group %>"group": "<%= @socket_group %>",<% end -%>
     <%# "default-ulimit": {}, %>
     <% if @bridge %>"bridge": "<%= @bridge %>",<% end -%>
     <% if @fixed_cidr %>"fixed-cidr": "<%= @fixed_cidr %>",<% end -%>
     <%# "raw-logs": false, %>
     <% if @registry_mirror %>"registry-mirrors": ["<%= @registry_mirror%>"], <% end -%>
     <%# "insecure-registries": []%>
-    "labels": <%= @labels.to_json %>
+    "labels": <%= @labels_array.to_json %>
 }

--- a/templates/windows/config/daemon.json.erb
+++ b/templates/windows/config/daemon.json.erb
@@ -1,0 +1,31 @@
+{
+    <%# TODO: get "authorization-plugins": [],%>
+    <% if @dns %> "dns": <%= @dns_array.to_json %>,<% end -%>
+    <%# TODO: "dns-opts": [],%>
+    <% if @dns_search %> "dns-search": <%= @dns_search_array.to_json %>,<% end -%>
+    <%# TODO: "exec-opts": [],%>
+    <%# TODO: "storage-driver": "", %>
+    <%# TODO: "storage-opts": [], %>
+    <% if @log_driver %> "log-driver": "<%= @log_driver %>", <% end -%>
+    <% if @mtu %> "mtu": <%= @mtu %>, <% end -%>
+    <%# TODO: "pidfile": "", %>
+    <%# TODO: "data-root": "", %>
+    <%# TODO: "cluster-store": "", %>
+    <%# TODO: "cluster-advertise": "", %>
+    <%# TODO: "debug": true, %>
+    <%# TODO: "hosts": [], %>
+    <% if @log_level %> "log-level": "<%= @log_level %>", <% end -%>
+    <% if @tls_enable %> "tlsverify": true, 
+    "tlscacert": "<%= @tls_cacert %>",
+    "tlscert": "<%= @tls_cert %>",
+    "tlskey": "<%= @tls_key %>",
+    <% end -%>
+    <% if @socket_group %>"group": <%= @socket_group %>,<% end -%>
+    <%# "default-ulimit": {}, %>
+    <% if @bridge %>"bridge": "<%= @bridge %>",<% end -%>
+    <% if @fixed_cidr %>"fixed-cidr": "<%= @fixed_cidr %>",<% end -%>
+    <%# "raw-logs": false, %>
+    <% if @registry_mirror %>"registry-mirrors": ["<%= @registry_mirror%>"], <% end -%>
+    <%# "insecure-registries": []%>
+    "labels": <%= @labels.to_json %>
+}

--- a/templates/windows/install_powershell_provider.ps1.erb
+++ b/templates/windows/install_powershell_provider.ps1.erb
@@ -1,0 +1,36 @@
+# this file install the Windows Docker package using the DockerMsftProvider powershell provider
+$dockerProviderName="DockerMsftProvider"
+
+Write-Information "Installing Package Provider"
+$module = Install-PackageProvider NuGet -Force `
+<% if @nuget_package_provider_version -%>
+-RequiredVersion <%= @nuget_package_provider_version %>
+<% end -%>
+
+If ($module -eq $null) {
+    Write-Error "Failed to install NuGet PackagePrivider"
+    Exit 1
+}
+
+Write-Information "Installing Docker Provider"
+Install-Module $dockerProviderName -Force `
+<% if @docker_msft_provider_version -%>
+-RequiredVersion <%= @docker_msft_provider_version %>
+<% end -%>
+
+$provider = Get-Module -ListAvailable -Name $dockerProviderName
+If ($provider -eq $null) {
+    Write-Error "Failed to install Docker Microsoft Provider"
+    Exit 1
+}
+
+Write-Information "Installing Docker Package"
+$package=Install-Package Docker -ProviderName $dockerProviderName -Force `
+<% if @version -%>
+-RequiredVersion <%= @version %>
+<% end -%>
+
+If ($package -eq $null) { 
+    Write-Error "Failed to install Docker Package"
+    Exit 1
+}

--- a/templates/windows/install_powershell_provider.ps1.erb
+++ b/templates/windows/install_powershell_provider.ps1.erb
@@ -25,7 +25,7 @@ If ($provider -eq $null) {
 }
 
 Write-Information "Installing Docker Package"
-$package=Install-Package Docker -ProviderName $dockerProviderName -Force `
+$package=Install-Package <%= @docker_ee_package_name %> -ProviderName $dockerProviderName -Force `
 <% if @version -%>
 -RequiredVersion <%= @version %>
 <% end -%>

--- a/templates/windows/update_docker_image.ps1.erb
+++ b/templates/windows/update_docker_image.ps1.erb
@@ -1,0 +1,21 @@
+# Pulls a docker image.
+# Returns 0 if there a change.
+# Returns 2 if there is no change.
+# Returns 3 if something when wrong.
+#
+
+$docker_image=$args[0]
+
+$before=$(docker inspect --type image --format='{{.Id}}' ${docker_image} 2>$null)
+<%= @docker_command -%> pull ${DOCKER_IMAGE}
+$after=$(docker inspect --type image --format='{{.Id}}' ${DOCKER_IMAGE} 2>$null)
+If (!$after) {
+    Write-Host "Docker image ${docker_image} failed to pull!"
+    Write-Host "Exit 3"
+} ElseIf ($after -eq $before) {
+    Write-Host "No updates to ${docker_image} available. Currently on ${after}."
+    Write-Host "Exit 2"
+} Else {
+    Write-Host "${docker_image} updated. Changed from ${before} to ${after}."
+    Write-Host "Exit 0"
+}


### PR DESCRIPTION
This PR adds the functionality to deploy Docker Enterprise Edition on Windows Server 2016. The deployment is done using the Docker module available in the online Powershell gallery.

This PR also adds the functionality to deploy Docker images on Windows.