### PR TITLE
Update install.pp to Support Red Hat "yum" Package Provider

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,7 @@ class docker::install {
           $pk_provider = 'dpkg'
         }
         'RedHat' : {
-          $pk_provider = 'rpm'
+          $pk_provider = 'yum'
         }
         default : {
           $pk_provider = undef


### PR DESCRIPTION
Under Red Hat systems using the implemented change in this commit and the attribute *package_source* to *'RedHat'* value I could solve problems to install a docker specific version when you desire use the official repositories. I commented the complete "case" under the *Issue 225*.

Any comment is Welcome about errors described in issue 225 and actual suggested change.