### PR TITLE
docker::stack unless and onlyif were doing "docker stack deploy ls"

### DIFF
--- a/manifests/stack.pp
+++ b/manifests/stack.pp
@@ -59,7 +59,7 @@ define docker::stack(
       })
 
       $exec_stack = "${docker_command} deploy ${docker_stack_flags} ${stack_name}"
-      $unless_stack = "${docker_command} deploy ls | grep ${stack_name}"
+      $unless_stack = "${docker_command} ls | grep ${stack_name}"
 
       exec { "docker stack create ${stack_name}":
       command => $exec_stack,
@@ -72,7 +72,7 @@ define docker::stack(
 
   exec { "docker stack ${stack_name}":
     command => "${docker_command} rm ${stack_name}",
-    onlyif  => "${docker_command} deploy ls | grep ${stack_name}",
+    onlyif  => "${docker_command} ls | grep ${stack_name}",
     path    => ['/bin', '/usr/bin'],
     }
   }


### PR DESCRIPTION
Both execs are running "docker stack deploy ls" in their unless and onlyif. This is not a command so it would fail every time, returning exit code of 1. This means one exec runs every puppet run and one will never run. 

The docker stack deploy that creates the stack will always run. This may have a positive side-effect b/c docker stack deploy will create or update the stack, so maybe if the compose file has changed it will detect that and recreate it? It doesn't fail even if the stack is already created and leaves the stack alone (as far as I can tell). Maybe the unless should just be removed so it will create/update every puppet run? Or maybe it should be refreshonly and another exec could notify it if the stack doesn't exist? That way the refreshonly exec could be notified by whoever is managing the docker-compose.yaml file?

I assume the onlyif on exec that does "docker stack rm ${stackname}" will never run because the onlyif (doing "docker stack deploy ls") will always return 1 due to invalid command.