### PR TITLE
Fix dependency cycle issue

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -27,7 +27,6 @@ class docker::repos (
             id     => $package_key,
             source => $key_source,
           },
-          require      => Package['debian-keyring', 'debian-archive-keyring'],
           include      => {
             src => false,
             },


### PR DESCRIPTION
As described in https://github.com/puppetlabs/puppetlabs-docker/issues/42, a dependency cycle issue occurs. By removing this require statement this is resolved. 