### PR TITLE
fix "start a container with cpuset" acceptance test on ubuntu1404

### DIFF
--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -464,8 +464,8 @@ describe 'the Puppet Docker module' do
         # A sleep to give docker time to execute properly
         sleep 4
 
-        shell('ps -aux | grep docker') do |r|
-          expect(r.stdout).to match(/--cpuset-cpus=0/)
+        shell('docker inspect container_3_5_5') do |r|
+          expect(r.stdout).to match(/"CpusetCpus"\: "0"/)
         end
       end
 


### PR DESCRIPTION
On Ubuntu 14.04 creating containers does not spawn new processes, like it does on Ubuntu 16.04

This PR fixes the assert condition for "the Puppet Docker module clean up before each test docker::run should start a container with cpuset parameter set" acceptance test by changing the assert statement from searching for a process that belongs to a newly spawned container to using the "docker inspect" command. 