### PR TITLE
Add integration tests for Docker on Windows using vmpooler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 sudo: false
 rvm:
-  - 2.1.6
   - 2.2.5
   - 2.3.3
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ run the integration tests against RHEL, CentOS and Debian.
     bundle exec rake acceptance:pooler:ubuntu-1404
     bundle exec rake acceptance:pooler:ubuntu-1604
     bundle exec rake acceptance:pooler:ubuntu-1610
+    bundle exec rake acceptance:pooler:win-2016
     bundle exec rake acceptance:vagrant:centos-70-x64
     bundle exec rake acceptance:vagrant:debian-81-x64
     bundle exec rake acceptance:vagrant:ubuntu-1404-x64

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 group :system_tests do
   gem "beaker-puppet_install_helper", :require => false
   gem "beaker-rspec"
-  gem "beaker", "~> 2.0"
+  gem "beaker", "~> 3.13"
 end
 
 group :development do

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -39,7 +39,7 @@ define docker::image(
   if $::osfamily == 'windows' {
     $update_docker_image_template = 'docker/windows/update_docker_image.ps1.erb'
     $update_docker_image_path = 'C:/Windows/Temp/update_docker_image.ps1'
-    $exec_environment = undef
+    $exec_environment = 'PATH=C:/Program Files/Docker/'
     $exec_timeout = 3000
     $update_docker_image_owner = undef
     $exec_path = ['c:/Windows/Temp/', 'C:/Program Files/Docker/']
@@ -106,7 +106,7 @@ define docker::image(
     $image_find    = "${docker_command} images -q ${image}"
   }
   if $::osfamily == 'windows' {
-    $_image_find = "\$image_id=${image_find}; If (!\$image_id) { Exit 1 }"
+    $_image_find = "If (-not (${image_find}) ) { Exit 1 }"
   } else {
     $_image_find = "${image_find} | grep ."
   }
@@ -133,11 +133,12 @@ define docker::image(
 
   if $ensure == 'absent' {
     exec { $image_remove:
-      path      => $exec_path,
-      onlyif    => $_image_find,
-      provider  => $exec_provider,
-      timeout   => $exec_timeout,
-      logoutput => true,
+      path        => $exec_path,
+      environment => $exec_environment,
+      onlyif      => $_image_find,
+      provider    => $exec_provider,
+      timeout     => $exec_timeout,
+      logoutput   => true,
     }
   } elsif $ensure == 'latest' or $image_tag == 'latest' {
     exec { "echo 'Update of ${image_arg} complete'":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -211,7 +211,7 @@ class docker::service (
       reboot { 'pending_reboot':
         when    => 'pending',
         onlyif  => 'component_based_servicing',
-        timeout => 10,
+        timeout => 1,
       }
     }
 

--- a/rakelib/acceptance.rake
+++ b/rakelib/acceptance.rake
@@ -25,6 +25,7 @@ namespace :acceptance do
       'ubuntu-1404',
       'ubuntu-1604',
       'ubuntu-1610',
+      'win-2016',
     ]
   }.each do |ns, configs|
     namespace ns.to_sym do

--- a/spec/acceptance/compose_spec.rb
+++ b/spec/acceptance/compose_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'docker compose' do
+broken = false
+
+if fact('osfamily') == 'windows'
+  puts "Not implemented on Windows"
+  broken = true
+end
+
+describe 'docker compose', :win_broken => broken do 
   before(:all) do
     install_code = <<-code
       class { 'docker': }

--- a/spec/acceptance/compose_v2_spec.rb
+++ b/spec/acceptance/compose_v2_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'docker compose' do
+broken = false
+
+if fact('osfamily') == 'windows'
+  puts "Not implemented on Windows"
+  broken = true
+end
+
+describe 'docker compose', :win_broken => broken do 
   before(:all) do
     install_code = <<-code
       class { 'docker': }

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'docker' do
+broken = false
+
+if fact('osfamily') == 'windows'
+  puts "Not implemented on Windows"
+  broken = true
+end
+
+describe 'docker', :win_broken => broken do
   package_name = 'docker-ce'
   service_name = 'docker'
   command = 'docker'

--- a/spec/acceptance/network_spec.rb
+++ b/spec/acceptance/network_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'docker network' do
+broken = false
+
+if fact('osfamily') == 'windows'
+  puts "Not implemented on Windows"
+  broken = true
+end
+
+describe 'docker network', :win_broken => broken do
   command = 'docker'
 
   before(:all) do

--- a/spec/acceptance/nodesets/pooler/win-2016.yml
+++ b/spec/acceptance/nodesets/pooler/win-2016.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  ubuntu-1604:
+    roles:
+      - master
+      - database
+      - dashboard
+    platform: ubuntu-16.04-amd64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+  win-2016:
+    roles:
+      - default
+      - agent
+    platform: windows-2016-x86_64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2016-x86_64
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: foss

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'docker plugin' do
+broken = false
+
+if fact('osfamily') == 'windows'
+  puts "Not implemented on Windows"
+  broken = true
+end
+
+describe 'docker plugin', :win_broken => broken do
   command = 'docker'
 
   before(:all) do

--- a/spec/acceptance/volume_spec.rb
+++ b/spec/acceptance/volume_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'docker network' do
+broken = false
+
+if fact('osfamily') == 'windows'
+  puts "Not implemented on Windows"
+  broken = true
+end
+
+describe 'docker network', :win_broken => broken do
   command = 'docker'
 
   before(:all) do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,9 +8,35 @@ begin
 rescue LoadError # rubocop:disable Lint/HandleExceptions for optional loading
 end
 
+# This method allows a block to be passed in and if an exception is raised
+# that matches the 'error_matcher' matcher, the block will wait a set number
+# of seconds before retrying.
+# Params:
+# - max_retry_count - Max number of retries
+# - retry_wait_interval_secs - Number of seconds to wait before retry
+# - error_matcher - Matcher which the exception raised must match to allow retry
+# Example Usage:
+# retry_on_error_matching(3, 5, /OpenGPG Error/) do
+#   apply_manifest(pp, :catch_failures => true)
+# end
+def retry_on_error_matching(max_retry_count = 3, retry_wait_interval_secs = 5, error_matcher = nil)
+  try = 0
+  begin
+    try += 1
+    yield
+  rescue StandardError => e
+    raise unless try < max_retry_count && (error_matcher.nil? || e.message =~ error_matcher)
+    sleep retry_wait_interval_secs
+    retry
+  end
+end
+
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 
 RSpec.configure do |c|
+  # Add exclusive filter for Windows untill all the windows functionality is implemented
+  c.filter_run_excluding :win_broken => true
+
   # Project root
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
@@ -26,37 +52,47 @@ RSpec.configure do |c|
   c.before :suite do
     # Install module and dependencies
     hosts.each do |host|
-      copy_module_to(host, :source => proj_root, :module_name => 'docker')
-      # Due to RE-6764, running yum update renders the machine unable to install
-      # other software. Thus this workaround.
-      if fact_on(host, 'operatingsystem') == 'RedHat'
-        on(host, 'mv /etc/yum.repos.d/redhat.repo /etc/yum.repos.d/internal-mirror.repo')
-      end
-      on(host, 'yum update -y -q') if fact_on(host, 'osfamily') == 'RedHat'
+      if not_controller(host)
+        copy_module_to(host, :source => proj_root, :module_name => 'docker')
+        # Due to RE-6764, running yum update renders the machine unable to install
+        # other software. Thus this workaround.
+        if fact_on(host, 'operatingsystem') == 'RedHat'
+          on(host, 'mv /etc/yum.repos.d/redhat.repo /etc/yum.repos.d/internal-mirror.repo')
+        end
+        on(host, 'yum update -y -q') if fact_on(host, 'osfamily') == 'RedHat'
 
-      on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.24.0'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '4.4.1'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppetlabs-translate', '--version', '1.0.0' ), { :acceptable_exit_codes => [0,1] }
+        on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.24.0'), { :acceptable_exit_codes => [0,1] }
+        on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '4.4.1'), { :acceptable_exit_codes => [0,1] }
+        on host, puppet('module', 'install', 'puppetlabs-translate', '--version', '1.0.0' ), { :acceptable_exit_codes => [0,1] }
+        on host, puppet('module', 'install', 'puppetlabs-powershell', '--version', '2.1.5' ), { :acceptable_exit_codes => [0,1] }
+        on host, puppet('module', 'install', 'puppetlabs-reboot', '--version', '2.0.0' ), { :acceptable_exit_codes => [0,1] }
 
-      # net-tools required for netstat utility being used by some tests
-      if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease') == '7'
-        on(host, 'yum install -y net-tools device-mapper')
-      end
+        # net-tools required for netstat utility being used by some tests
+        if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease') == '7'
+          on(host, 'yum install -y net-tools device-mapper')
+        end
 
-      docker_compose_content = <<-EOS
+        docker_compose_content = <<-EOS
 compose_test:
   image: ubuntu:14.04
   command: /bin/sh -c "while true; do echo hello world; sleep 1; done"
       EOS
-      docker_compose_content_v2 = <<-EOS
+        docker_compose_content_v2 = <<-EOS
 version: "2"
 services:
   compose_test:
     image: ubuntu:14.04
     command: /bin/sh -c "while true; do echo hello world; sleep 1; done"
       EOS
-      create_remote_file(host, "/tmp/docker-compose.yml", docker_compose_content)
-      create_remote_file(host, "/tmp/docker-compose-v2.yml", docker_compose_content_v2)
+        create_remote_file(host, "/tmp/docker-compose.yml", docker_compose_content)
+        create_remote_file(host, "/tmp/docker-compose-v2.yml", docker_compose_content_v2)
+        
+        if fact_on(host, 'osfamily') == 'windows'
+          apply_manifest_on(host, "class { 'docker': docker_ee => true }")
+          puts "Waiting for box to come online"
+          sleep 300
+        end
+      end
     end
   end
 end

--- a/templates/windows/update_docker_image.ps1.erb
+++ b/templates/windows/update_docker_image.ps1.erb
@@ -5,17 +5,21 @@
 #
 
 $docker_image=$args[0]
+$docker_cmd = "C:\Program Files\Docker\docker.exe"
 
-$before=$(docker inspect --type image --format='{{.Id}}' ${docker_image} 2>$null)
-<%= @docker_command -%> pull ${DOCKER_IMAGE}
-$after=$(docker inspect --type image --format='{{.Id}}' ${DOCKER_IMAGE} 2>$null)
+Write-Host "Before - Looking for image"
+$before=$(& $docker_cmd inspect --type image --format='{{.Id}}' ${docker_image} 2>$null)
+Write-Host "Pulling image"
+& $docker_cmd pull ${docker_image}
+Write-Host "Inspecting image"
+$after=$(& $docker_cmd inspect --type image --format='{{.Id}}' ${docker_image} 2>$null)
 If (!$after) {
     Write-Host "Docker image ${docker_image} failed to pull!"
-    Write-Host "Exit 3"
+    Exit 3
 } ElseIf ($after -eq $before) {
     Write-Host "No updates to ${docker_image} available. Currently on ${after}."
-    Write-Host "Exit 2"
+    Exit 2
 } Else {
     Write-Host "${docker_image} updated. Changed from ${before} to ${after}."
-    Write-Host "Exit 0"
+    Exit 0
 }


### PR DESCRIPTION
This PR adds the functionality of running Windows Integration tests for Docker on Windows.
Implemented tests:
- docker deployment on windows
- image manipulation integration tests