### PR TITLE
Added architecture to apt source

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -27,6 +27,7 @@ class docker::repos (
             id     => $package_key,
             source => $key_source,
           },
+          architecture => $facts['os']['architecture'],
           include      => {
             src => false,
             },


### PR DESCRIPTION
Fixes the issue with Ubuntu/Debian returning an warning on `apt-get update`

```
N: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'https://download.docker.com/linux/ubuntu xenial InRelease' doesn't support architecture 'i386'
```

Because without specifying architecture it attempts to retrieve i386 and amd64.