### PR TITLE
add docker run tests for Windows

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -53,10 +53,11 @@ module Puppet::Parser::Functions
     if opts['read_only']
       flags << '--read-only=true'
     end
+    params_join_char = Facter.value(:osfamily).casecmp('windows') ? ' ' : " \\\n"
 
     multi_flags = lambda { |values, format|
       filtered = [values].flatten.compact
-      filtered.map { |val| sprintf(format + " \\\n", val) }
+      filtered.map { |val| sprintf(format + params_join_char, val) }
     }
 
     [
@@ -89,6 +90,6 @@ module Puppet::Parser::Functions
 
     # Some software (inc systemd) will truncate very long lines using glibc's
     # max line length. Wrap options across multiple lines with '\' to avoid
-    flags.flatten.join(" \\\n        ")
+    flags.flatten.join(params_join_char)
   end
 end


### PR DESCRIPTION
This PR contains:
- docker run integration tests for Docker on Windows
- make docker::run - ensure => "absent" idempotent
- fix for docker::run - running => "true"/"false"