### PR TITLE
Allow custom docker_group and service_name values in run.pp

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -134,8 +134,14 @@ define docker::run(
   }else {
     $docker_command = $docker::params::docker_command
   }
-  $service_name = $docker::params::service_name
-  $docker_group = $docker::params::docker_group
+
+  if defined('docker') {
+    $service_name = $docker::service_name
+    $docker_group = $docker::docker_group
+  } else {
+    $service_name = $docker::params::service_name
+    $docker_group = $docker::params::docker_group
+  }
 
   if $restart {
     assert_type(Pattern[/^(no|always|unless-stopped|on-failure)|^on-failure:[\d]+$/], $restart)

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 ['Debian', 'RedHat'].each do |osfamily|
   describe 'docker::run', :type => :define do
     let(:title) { 'sample' }
+    let(:pre_condition) { "class { 'docker': docker_group => 'docker', service_name => 'docker' }" }
     context "on #{osfamily}" do
 
       initscript = '/etc/systemd/system/docker-sample.service'
@@ -616,7 +617,9 @@ require 'spec_helper'
 
       context 'when `docker_service` is true' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => true} }
-        let(:pre_condition) { "service { 'docker': }" }
+        let(:pre_condition) {
+          [ "service { 'docker': }",
+            "class { 'docker': docker_group => 'docker', service_name => 'docker' }" ] }
         it { should compile.with_all_deps }
         it { should contain_service('docker').that_comes_before('Service[docker-sample]') }
         it { should contain_service('docker').that_notifies('Service[docker-sample]') }
@@ -624,14 +627,18 @@ require 'spec_helper'
 
       context 'when `docker_service` is true and `restart_service_on_docker_refresh` is false' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => true, 'restart_service_on_docker_refresh' => false} }
-        let(:pre_condition) { "service { 'docker': }" }
+        let(:pre_condition) {
+          [ "service { 'docker': }",
+            "class { 'docker': docker_group => 'docker', service_name => 'docker' }" ] }
         it { should compile.with_all_deps }
         it { should contain_service('docker').that_comes_before('Service[docker-sample]') }
       end
 
       context 'when `docker_service` is `my-docker`' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => 'my-docker'} }
-        let(:pre_condition) { "service{ 'my-docker': }" }
+        let(:pre_condition) {
+          [ "service { 'my-docker': }",
+            "class { 'docker': docker_group => 'docker', service_name => 'docker' }" ] }
         it { should compile.with_all_deps }
         it { should contain_service('my-docker').that_comes_before('Service[docker-sample]') }
         it { should contain_service('my-docker').that_notifies('Service[docker-sample]') }
@@ -639,7 +646,9 @@ require 'spec_helper'
 
       context 'when `docker_service` is `my-docker` and `restart_service_on_docker_refresh` is false' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => 'my-docker', 'restart_service_on_docker_refresh' => false} }
-        let(:pre_condition) { "service{ 'my-docker': }" }
+        let(:pre_condition) {
+          [ "service { 'my-docker': }",
+            "class { 'docker': docker_group => 'docker', service_name => 'docker' }" ] }
         it { should compile.with_all_deps }
         it { should contain_service('my-docker').that_comes_before('Service[docker-sample]') }
       end

--- a/spec/defines/run_windows_spec.rb
+++ b/spec/defines/run_windows_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'docker::run', :type => :define do
   let(:title) { 'sample' }
+  let(:pre_condition) { 'class { \'docker\': docker_ee => true }' }
   let(:facts) { {
     :architecture              => 'amd64',
     :osfamily                  => 'windows',


### PR DESCRIPTION
The default docker_group can be overridden in init.pp, but run.pp only uses the default params values.  Also updated service_name the same way.

I could have moved the parameters into the override specific to docker::run, but I assumed that they were kept more global on purpose.  I'm happy to update the PR if the preference is to override them per docker run.

There are a number of other cases in run.pp where it's pointing at params directly for a parameter that can be overridden in init.  I wanted to keep this use case small / specific to what I needed, but would it make sense to revise those other parameters if an override exists in init.pp?

Please let me know if a spec test is needed.