### PR TITLE
(CLOUD-1850)-Restart docker container on unhealthy status

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,11 +370,21 @@ If using Hiera, you can configure the `docker::run_instance` class:
 
 To remove a running container, add the following code to the manifest file. This will also remove the systemd service file associated with the container.
 
-'''puppet
+```puppet
 docker::run { 'helloworld':
   ensure => absent,
 }
-'''
+```
+
+To enable the restart of an unhealthy container add the following code to the manifest file.
+
+```puppet
+docker::run { 'helloworld':
+  image => 'base',
+  command => 'command',
+  health_check_command => '<command_to_execute_to_check_your_containers_health>',
+  restart_on_unhealthy => true,
+```
 
 ### Networks
 

--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -46,6 +46,10 @@ module Puppet::Parser::Functions
       flags << '--detach=true'
     end
 
+    if opts['health_check_cmd']
+      flags << "--health-cmd '#{opts['health_check_command']} || exit 1'"
+    end
+
     if opts['tty']
       flags << '-t'
     end

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -728,6 +728,21 @@ describe 'the Puppet Docker module' do
         apply_manifest(pp, :catch_changes => true) unless fact('selinux') == 'true'
 
       end
+      
+      it 'should restart a unhealthy container' do
+      pp5=<<-EOS
+        docker::run { 'container_3_7_3':
+          image   => 'base',
+          command => '#{default_run_command}',
+          health_check_cmd => 'pwd',
+          restart_on_unhealthy => true,
+          }
+          EOS
+
+         apply_manifest(pp5, :catch_failures => true) do |r|
+           expect(r.stdout).to match(/docker-container_3_7_3-systemd-reload/)
+        end 
+      end
     end
 
     describe "docker::exec"  do

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -136,6 +136,20 @@ require 'spec_helper'
           end
         end
 
+        context 'When restarting an unhealthy container' do
+          let(:params) {{
+            'command' => 'command',
+            'image'   => 'base',
+            'health_check_cmd' => 'pwd',
+            'restart_on_unhealthy' => true
+          }}
+          if (systemd)
+            it { should contain_file(initscript).with_content(/ExecStop=-\/usr\/bin\/docker stop --time=0 /) } 
+            it { should contain_file(initscript).with_content(/ExecStop=-\/usr\/bin\/docker rm/) }
+            it { should contain_file(initscript).with_content(/--health-cmd/) }
+            end
+        end
+
         context 'when not removing containers on container start and stop' do
           let(:params) {{
             'command' => 'command',


### PR DESCRIPTION
This PR is to add the functionality requested in #216. This adds the ability to add Docker health check as well as restarting the container if it is reported unhealthy. 

