### PR TITLE
Configure Docker Swarm on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc
 log
 Gemfile.lock
 coverage/*
+/vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ RSpec/BeforeAfterAll:
     A necessary evil in acceptance testing.
   Exclude:
   - spec/acceptance/**/*.rb
+  - spec/acceptance_swarm/**/*.rb
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each

--- a/Guardfile
+++ b/Guardfile
@@ -15,3 +15,9 @@ group :acceptance do
     watch(%r{^spec\/acceptance\/.+\.rb$})
   end
 end
+
+group :acceptance_swarm do
+  guard :rake, :task => 'acceptance_swarm' do
+    watch(%r{^spec\/acceptance_swarm\/.+\.rb$})
+  end
+end

--- a/lib/puppet/parser/functions/docker_swarm_join_flags.rb
+++ b/lib/puppet/parser/functions/docker_swarm_join_flags.rb
@@ -17,7 +17,7 @@ module Puppet::Parser::Functions
     end
 
     if opts['listen_addr'].to_s != 'undef'
-      flags << "--listen-addr '#{opts['listen_addr']}'"
+      flags << "--listen-addr \"#{opts['listen_addr']}\""
     end
 
     if opts['token'].to_s != 'undef'

--- a/rakelib/acceptance_swarm.rake
+++ b/rakelib/acceptance_swarm.rake
@@ -1,0 +1,33 @@
+require 'rake'
+require 'parallel_tests'
+
+# We clear the Beaker rake tasks from spec_helper as they assume
+# rspec-puppet and a certain filesystem layout
+Rake::Task[:beaker_nodes].clear
+Rake::Task[:beaker].clear
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance_swarm => [:spec_prep]) do |t|
+  t.pattern = 'spec/acceptance_swarm'
+end
+
+namespace :acceptance_swarm do
+  {
+    :pooler => [
+      'ubuntu-1604',
+      'win-2016',
+    ]
+  }.each do |ns, configs|
+    namespace ns.to_sym do
+      configs.each do |config|
+        desc "Run acceptance tests for #{ns}:#{config}"
+        RSpec::Core::RakeTask.new("#{config}".to_sym => [:spec_prep]) do |t|
+          ENV['BEAKER_keyfile'] = '~/.ssh/id_rsa-acceptance' if ns == :pooler
+          ENV['BEAKER_setdir'] = 'spec/acceptance_swarm/nodesets'
+          ENV['BEAKER_set'] = "#{ns}/#{config}"
+          t.pattern = 'spec/acceptance_swarm'
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance_swarm/default.yml
+++ b/spec/acceptance_swarm/default.yml
@@ -1,0 +1,22 @@
+HOSTS:
+  ubuntu-1604:
+    roles:
+      - default
+      - swarm-manager
+    platform: ubuntu-16.04-amd64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+  ubuntu-1604-a:
+    roles:
+      - swarm-worker
+    platform: ubuntu-16.04-amd64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: foss

--- a/spec/acceptance_swarm/nodesets/pooler/ubuntu-1604.yml
+++ b/spec/acceptance_swarm/nodesets/pooler/ubuntu-1604.yml
@@ -1,0 +1,22 @@
+HOSTS:
+  ubuntu-1604:
+    roles:
+      - default
+      - swarm-manager
+    platform: ubuntu-16.04-amd64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+  ubuntu-1604-a:
+    roles:
+      - swarm-worker
+    platform: ubuntu-16.04-amd64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: foss

--- a/spec/acceptance_swarm/nodesets/pooler/win-2016.yml
+++ b/spec/acceptance_swarm/nodesets/pooler/win-2016.yml
@@ -1,0 +1,32 @@
+HOSTS:
+  ubuntu-1604:
+    roles:
+      - master
+      - database
+      - dashboard
+    platform: ubuntu-16.04-amd64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+  win-2016:
+    roles:
+      - default
+      - agent
+      - swarm-manager
+    platform: windows-2016-x86_64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2016-x86_64
+  win-2016-a:
+    roles:
+      - agent
+      - swarm-worker
+    platform: windows-2016-x86_64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2016-x86_64
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: foss

--- a/spec/acceptance_swarm/swarm_spec.rb
+++ b/spec/acceptance_swarm/swarm_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper_acceptance'
+
+if fact('osfamily') == 'windows'
+  install_dir = '/cygdrive/c/Program Files/Docker'
+  file_extension = '.exe'
+  docker_args = 'docker_ee => true'
+  tmp_path = 'C:/cygwin64/tmp'
+  test_docker_image = 'hello-world:nanoserver'
+  test_docker_command = 'cmd.exe /C "ping /t 8.8.8.8"'
+else
+  install_dir = '/usr/local/bin'
+  file_extension = ''
+  docker_args = ''
+  tmp_path = '/tmp'
+  test_docker_image = 'ubuntu:16.04'
+  test_docker_command = '/bin/sh -c "while true; do echo hello world; sleep 1; done"'
+end
+
+skip_tests = false
+
+begin
+  swarm_manager = only_host_with_role(hosts, 'swarm-manager')
+  swarm_worker = only_host_with_role(hosts, 'swarm-worker')
+  manager_ip = swarm_manager.ip
+rescue ArgumentError
+  skip_tests = true
+end
+
+describe 'docker swarm', :skip => skip_tests do
+  before(:all) do
+    retry_on_error_matching(60, 5, /connection failure running/) do
+      @install_code = <<-code
+        class { 'docker': #{docker_args} }
+      code
+      apply_manifest_on(swarm_manager, @install_code, :catch_failures=>true)
+    end
+    retry_on_error_matching(60, 5, /connection failure running/) do
+      apply_manifest_on(swarm_worker, @install_code, :catch_failures=>true)
+    end
+  end
+
+  context 'Creating a swarm master' do
+    before(:all) do
+      @setup_manager = <<-code
+      docker::swarm {'cluster_manager':
+        init           => true,
+        advertise_addr => '#{manager_ip}',
+        listen_addr    => '#{manager_ip}',
+      ensure => 'present',
+      }
+      code
+
+      retry_on_error_matching(60, 5, /connection failure running/) do
+        apply_manifest_on(swarm_manager, @setup_manager, :catch_failures=>true)
+      end
+
+      if fact('osfamily') == 'windows'
+        on swarm_manager, 'netsh advfirewall firewall add rule name="Swarm mgmgt" dir=in action=allow protocol=TCP localport=2377', :acceptable_exit_codes => [0]
+        on swarm_manager, 'netsh advfirewall firewall add rule name="Swarm comm tcp" dir=in action=allow protocol=TCP localport=7946', :acceptable_exit_codes => [0]
+        on swarm_manager, 'netsh advfirewall firewall add rule name="Swarm comm udp" dir=in action=allow protocol=UDP localport=7946', :acceptable_exit_codes => [0]
+        on swarm_manager, 'netsh advfirewall firewall add rule name="Swarm network" dir=in action=allow protocol=UDP localport=4789', :acceptable_exit_codes => [0]
+      end
+    end
+
+    it 'should be idempotent' do
+      apply_manifest_on(swarm_manager, @setup_manager, :catch_failures=>true)
+    end
+
+    it 'should display nodes' do
+      on swarm_manager, 'docker node ls', :acceptable_exit_codes => [0] do |result|
+        expect(result.stdout).to match(/Leader/)
+      end
+    end
+
+    it 'should join a node' do
+      token = shell('docker swarm join-token -q worker').stdout.strip
+      @setup_slave = <<-code
+      docker::swarm {'cluster_worker':
+        join           => true,
+        advertise_addr => '#{swarm_worker.ip}',
+        listen_addr    => '#{swarm_worker.ip}',
+        manager_ip     => '#{manager_ip}',
+        token          => '#{token}',
+        }
+      code
+      retry_on_error_matching(60, 5, /connection failure running/) do
+        apply_manifest_on(swarm_worker, @setup_slave, :catch_failures=>true)
+      end
+
+      retry_on_error_matching(60, 5, /connection failure running/) do
+        on swarm_worker, 'docker info' do |result|
+          expect(result.stdout).to match(/Swarm: active/)
+        end
+      end
+
+      if fact('osfamily') == 'windows'
+        on swarm_worker, 'netsh advfirewall firewall add rule name="Swarm mgmgt" dir=in action=allow protocol=TCP localport=2377', :acceptable_exit_codes => [0]
+        on swarm_worker, 'netsh advfirewall firewall add rule name="Swarm comm tcp" dir=in action=allow protocol=TCP localport=7946', :acceptable_exit_codes => [0]
+        on swarm_worker, 'netsh advfirewall firewall add rule name="Swarm comm udp" dir=in action=allow protocol=UDP localport=7946', :acceptable_exit_codes => [0]
+        on swarm_worker, 'netsh advfirewall firewall add rule name="Swarm network" dir=in action=allow protocol=UDP localport=4789', :acceptable_exit_codes => [0]
+      end
+
+      on swarm_manager, 'docker network create --driver=overlay swarmnet', :acceptable_exit_codes => [0]
+    end
+
+    it 'should start a container' do
+      on swarm_manager, "docker service create --name=helloworld --endpoint-mode dnsrr --network=swarmnet #{test_docker_image} #{test_docker_command}", :acceptable_exit_codes => [0]
+      on swarm_manager, 'docker service ps helloworld', :acceptable_exit_codes => [0] do |result|
+        expect(result.stdout).to match(/Running/)
+      end
+    end
+
+    after(:all) do
+      remove_worker = <<-code
+      docker::swarm {'cluster_worker':
+        ensure => 'absent',
+      }
+      code
+      retry_on_error_matching(60, 5, /connection failure running/) do
+        apply_manifest_on(swarm_worker, remove_worker, :catch_failures=>true)
+      end
+      remove_mgr = <<-code
+      docker::swarm {'cluster_manager':
+        ensure => 'absent',
+      }
+      code
+      retry_on_error_matching(60, 5, /connection failure running/) do
+        apply_manifest_on(swarm_manager, remove_mgr, :catch_failures=>true)
+      end
+    end
+  end
+end

--- a/spec/defines/swarm_spec.rb
+++ b/spec/defines/swarm_spec.rb
@@ -1,48 +1,61 @@
 require 'spec_helper'
 
-describe 'docker::swarm', :type => :define do
-  let(:title) { 'create swarm' }
-	let(:facts) { {
-		:osfamily                  => 'Debian',
-		:operatingsystem           => 'Debian',
-		:lsbdistid                 => 'Debian',
-		:lsbdistcodename           => 'jessie',
-		:kernelrelease             => '3.2.0-4-amd64',
-		:operatingsystemmajrelease => '8',
-	} }
+['Debian', 'Windows'].each do |osfamily|
+  describe 'docker::swarm', :type => :define do
+    let(:title) { 'create swarm' }
+    context "on #{osfamily}" do
+      if osfamily == 'Debian'
+        let(:facts) { {
+          :osfamily                  => 'Debian',
+          :operatingsystem           => 'Debian',
+          :lsbdistid                 => 'Debian',
+          :lsbdistcodename           => 'jessie',
+          :kernelrelease             => '3.2.0-4-amd64',
+          :operatingsystemmajrelease => '8',
+        } }
+      elsif osfamily == 'Windows'
+        let(:facts) { {
+          :osfamily                  => 'Windows',
+          :operatingsystem           => 'Windows',
+          :kernelrelease             => '10.0.14393',
+          :operatingsystemmajrelease => '2016',
+        } }
+      end
 
-  context 'with ensure => present and swarm init' do
-    let(:params) { {
-	    'init'           => true,
-	    'advertise_addr' => '192.168.1.1',
-            'listen_addr'    => '192.168.1.1',    
-    } }
-    it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Swarm init').with_command(/docker swarm init/) }
-  end
+      context 'with ensure => present and swarm init' do
+        let(:params) { {
+          'init'           => true,
+          'advertise_addr' => '192.168.1.1',
+                'listen_addr'    => '192.168.1.1',    
+        } }
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_exec('Swarm init').with_command(/docker swarm init/) }
+      end
 
-  context 'with ensure => present and swarm join' do
-    let(:params) { {
-	    'join'           => true,
-	    'advertise_addr' => '192.168.1.1',
-            'listen_addr'    => '192.168.1.1',
-	    'token'          => 'foo',
-	    'manager_ip'     => '192.168.1.2'
-    } }
-    it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Swarm join').with_command(/docker swarm join/) }
-  end
+      context 'with ensure => present and swarm join' do
+        let(:params) { {
+          'join'           => true,
+          'advertise_addr' => '192.168.1.1',
+                'listen_addr'    => '192.168.1.1',
+          'token'          => 'foo',
+          'manager_ip'     => '192.168.1.2'
+        } }
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_exec('Swarm join').with_command(/docker swarm join/) }
+      end
 
-  context 'with ensure => absent' do
-    let(:params) { {
-	    'ensure'         => 'absent',
-	    'join'           => true,
-	    'advertise_addr' => '192.168.1.1',
-            'listen_addr'    => '192.168.1.1',
-	    'token'          => 'foo',
-	    'manager_ip'     => '192.168.1.2'
-    } }
-    it { is_expected.to compile.with_all_deps }
-    it { should contain_exec('Leave swarm').with_command(/docker swarm leave --force/) }
+      context 'with ensure => absent' do
+        let(:params) { {
+          'ensure'         => 'absent',
+          'join'           => true,
+          'advertise_addr' => '192.168.1.1',
+                'listen_addr'    => '192.168.1.1',
+          'token'          => 'foo',
+          'manager_ip'     => '192.168.1.2'
+        } }
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_exec('Leave swarm').with_command(/docker swarm leave --force/) }
+      end
+    end
   end
 end


### PR DESCRIPTION
- add ability to create a docker swarm on windows (firewall ports need to be opened)
- add some docker swarm acceptance tests in a different test suite since it takes a while to run on windows and needs 2 vms