### PR TITLE
Health fix

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -47,7 +47,7 @@ module Puppet::Parser::Functions
     end
 
     if opts['health_check_cmd'].to_s != 'undef'
-      flags << "--health-cmd #{opts['health_check_cmd']}"
+      flags << "--health-cmd '#{opts['health_check_cmd']}'"
     end
 
     if opts['tty']

--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -47,7 +47,7 @@ module Puppet::Parser::Functions
     end
 
     if opts['health_check_cmd'].to_s != 'undef'
-      flags << "--health-cmd '#{opts['health_check_cmd']}'"
+      flags << "--health-cmd='#{opts['health_check_cmd']}'"
     end
 
     if opts['tty']


### PR DESCRIPTION
fixes issue where health check commands with spaces were not captured in quotes, and stop contaienrs from starting due to an error in the docker run command