### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.24.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 4.4.1"},
-    {"name":"puppetlabs/translate","version_requirement":">= 0.0.1 < 1.1.0"},
+    {"name":"puppetlabs/translate","version_requirement":">= 0.0.1 <=1.1.0"},
     {"name":"puppetlabs/powershell","version_requirement":">= 2.1.4"},
     {"name":"puppetlabs/reboot","version_requirement":">= 2.0.0"}
   ],


### PR DESCRIPTION
fixes #280 which locks translate to an older version. 