### PR TITLE
Do not use = for to set storage driver - fixes starting of docker-sto…

### DIFF
--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -340,7 +340,7 @@ describe 'docker', :type => :class do
             'storage_driver' => 'devicemapper',
             'dm_basesize'  => '3G'
           }}
-          it { should contain_file('/etc/sysconfig/docker-storage').with_content(/^(DOCKER_STORAGE_OPTIONS=" --storage-driver=devicemapper --storage-opt dm.basesize=3G)/) }
+          it { should contain_file('/etc/sysconfig/docker-storage').with_content(/^(DOCKER_STORAGE_OPTIONS=" --storage-driver devicemapper --storage-opt dm.basesize=3G)/) }
         end
 
         context 'It should include default prerequired_packages' do
@@ -485,7 +485,7 @@ describe 'docker', :type => :class do
       ['aufs', 'devicemapper', 'btrfs', 'overlay', 'overlay2', 'vfs', 'zfs'].each do |driver|
         context "with #{driver} storage driver" do
           let(:params) { { 'storage_driver' => driver }}
-          it { should contain_file(storage_config_file).with_content(/ --storage-driver=#{driver}/) }
+          it { should contain_file(storage_config_file).with_content(/ --storage-driver #{driver}/) }
         end
       end
 

--- a/templates/etc/sysconfig/docker-storage.erb
+++ b/templates/etc/sysconfig/docker-storage.erb
@@ -15,7 +15,7 @@
 # DOCKER_STORAGE_OPTIONS = --storage-opt dm.metadatadev=/dev/mylogvol/my-docker-metadata --storage-opt dm.datadev=/dev/mylogvol/my-docker-data
 
 DOCKER_STORAGE_OPTIONS="<% -%>
-<% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
+<% if @storage_driver %> --storage-driver <%= @storage_driver %><% end -%>
 <% if @storage_driver == 'devicemapper' -%>
   <%- if @dm_basesize %> --storage-opt dm.basesize=<%= @dm_basesize %><% end -%>
   <%- if @dm_fs %> --storage-opt dm.fs=<%= @dm_fs %><% end -%>


### PR DESCRIPTION
…rage-setup service

On RedHat based systems the sysconfig file is parsed by
container-storage-setup, which does not expect an equal sign when
looking for the storage-driver ( https://github.com/projectatomic/container-storage-setup/blob/413b4080c0b9346a242d88137bb3e9e0a6aa25f9/container-storage-setup.sh#L1193 ).

This makes the docker-storage-setup service failing on startup:

Jul 20 20:49:05 docker.example.com systemd[1]: Starting Docker Storage Setup...
Jul 20 20:49:06 docker.example.com container-storage-setup[781]: ERROR: Failed to determine existing storage driver.
Jul 20 20:49:07 docker.example.com systemd[1]: docker-storage-setup.service: main process exited, code=exited, status=1/FAILURE
Jul 20 20:49:07 docker.example.com systemd[1]: Failed to start Docker Storage Setup.

Removing the = sign makes everybody happy.