### PR TITLE
[CLOUD-1981] docker image update script runs in noop mode

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -140,17 +140,7 @@ define docker::image(
       timeout     => $exec_timeout,
       logoutput   => true,
     }
-  } elsif $ensure == 'latest' or $image_tag == 'latest' {
-    exec { "echo 'Update of ${image_arg} complete'":
-      environment => $exec_environment,
-      path        => $exec_path,
-      timeout     => $exec_timeout,
-      onlyif      => $image_install,
-      require     => File[$update_docker_image_path],
-      provider    => $exec_provider,
-      logoutput   => true,
-    }
-  } elsif $ensure == 'present' {
+  } elsif $ensure == 'latest' or $image_tag == 'latest' or $ensure == 'present' {
     exec { $image_install:
       unless      => $_image_find,
       environment => $exec_environment,

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -134,17 +134,17 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => latest' do
     let(:params) { { 'ensure' => 'latest' } }
-    it { should contain_exec("echo 'Update of base complete'").with_onlyif('/usr/local/bin/update_docker_image.sh base') }
+    it { should contain_exec("/usr/local/bin/update_docker_image.sh base") }
   end
 
   context 'with ensure => latest and image_tag => precise' do
     let(:params) { { 'ensure' => 'latest', 'image_tag' => 'precise' } }
-    it { should contain_exec("echo 'Update of base:precise complete'") }
+    it { should contain_exec("/usr/local/bin/update_docker_image.sh base:precise") }
   end
 
   context 'with ensure => latest and image_digest => sha256:deadbeef' do
     let(:params) { { 'ensure' => 'latest', 'image_digest' => 'sha256:deadbeef' } }
-    it { should contain_exec("echo 'Update of base@sha256:deadbeef complete'") }
+    it { should contain_exec("/usr/local/bin/update_docker_image.sh base@sha256:deadbeef") }
   end
 
   context 'with an invalid image name' do

--- a/spec/defines/image_windows_spec.rb
+++ b/spec/defines/image_windows_spec.rb
@@ -44,7 +44,7 @@ describe 'docker::image', :type => :define do
     
     context 'with ensure => latest' do
         let(:params) { { 'ensure' => 'latest' } }
-        it { should contain_exec("echo 'Update of base complete'").with_onlyif('& C:/Windows/Temp/update_docker_image.ps1 base') }
+        it { should contain_exec("& C:/Windows/Temp/update_docker_image.ps1 base") }
     end
 
 end


### PR DESCRIPTION
The --noop flag tells Puppet to determine which resources are out of sync, and to report them without actually synchronizing them.  The 'onlyif' and 'unless' commands of an Exec are used in the process of determining whether the Exec is already in sync, therefore they must be run during a --noop Puppet run. 

This PR changes the 'onlyif' command for ensure == 'latest' or $image_tab == 'latest' from a script that takes action (downloads images) to a command that only check the state. 

Fixes: https://github.com/puppetlabs/puppetlabs-docker/issues/241
