### PR TITLE
Fix for registry password not being inserted due to single quotes

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -65,11 +65,11 @@ define docker::registry(
 
   if $ensure == 'present' {
     if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/ {
-      $auth_cmd = "${docker_command} login -u '${username}' -p '${password_env}' -e '${email}' ${server}"
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"${password_env}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     }
     elsif $username != undef and $password != undef {
-      $auth_cmd = "${docker_command} login -u '${username}' -p '${password_env}' ${server}"
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"${password_env}\" ${server}"
       $auth_environment = "password=${password}"
     }
     else {

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -40,22 +40,22 @@ describe 'docker::registry', :type => :define do
 
   context 'with ensure => present and username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
-    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p '${password}' localhost:5000").with_environment(/password=secret/) }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_environment(/password=secret/) }
   end
 
  context 'with ensure => present and username => user1, and password => secret and email => user1@example.io and version < 1.11.0' do
     let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'version' => '1.9.0', 'pass_hash' => 'test1234', 'receipt' => false } }
-    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p '${password}' -e 'user1@example.io' localhost:5000").with_environment(/password=secret/) }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment(/password=secret/) }
   end
 
   context 'with username => user1, and password => secret' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
-    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p '${password}' localhost:5000").with_environment(/password=secret/) }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_environment(/password=secret/) }
   end
 
   context 'with username => user1, and password => secret and local_user => testuser' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'local_user' => 'testuser', 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }
-    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p '${password}' localhost:5000").with_user('testuser').with_environment(/password=secret/) }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" localhost:5000").with_user('testuser').with_environment(/password=secret/) }
   end
 
   context 'with an invalid ensure value' do


### PR DESCRIPTION
The insertion of the single quotes before the 2.0.0 release has caused anything that uses the registry to no longer work. With the single quotes you end up with the login command looking like:
```
docker login -u '<USERNAME>' -p '${password}' <SERVER>
```

The problem is with `'$password'`, as single quotes prevent the variable from being changed into the environment variable. You can only insert like this with double quotes.