### PR TITLE
[CLOUD-2040]enable extras repo only in CentOS 6 or lower

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -494,6 +494,10 @@ class docker(
     }
   }
 
+  if ($::operatingsystem == 'CentOS') and (Integer($::operatingsystemmajrelease) < 7){
+    fail translate(('This module only works on CentOS version 7 and higher based systems.'))
+  }
+
   if ($default_gateway) and (!$bridge) {
     fail translate(('You must provide the $bridge parameter.'))
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -215,8 +215,6 @@ class docker::params {
       # repo_opt to specify install_options for docker package
       if $::operatingsystem == 'RedHat' {
         $repo_opt = '--enablerepo=rhel-7-server-extras-rpms'
-      } elsif $::operatingsystem == 'CentOS' {
-        $repo_opt = '--enablerepo=extras'
       } else {
         $repo_opt = undef
       }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -870,4 +870,21 @@ describe 'docker', :type => :class do
     end
   end
 
+  context 'CentOS < 7' do
+    let(:facts) { {
+      :architecture              => 'x86_64',
+      :osfamily                  => 'RedHat',
+      :operatingsystem           => 'CentOS',
+      :kernelversion             => '3.10.0',
+      :operatingsystemmajrelease => '6',
+      :os                        => { :family => 'RedHat', :name => 'CentOS', :release => { :major => '6', :full => '6.0' } }
+    } }
+
+    it do
+      expect {
+        should contain_package('docker')
+      }.to raise_error(Puppet::Error, /This module only works on CentOS version 7 and higher based systems./)
+    end
+  end
+
 end


### PR DESCRIPTION
This PR disables "extras" CentOS repo for versions greater and equal to 7.
In CentOS 7 and above the packages from the extras repo where tested by the CentOS developers and the repo has been enabled by default: https://wiki.centos.org/AdditionalResources/Repositories 

Passing the --enablerepo=extras throws a repository not found error: `Error getting repository data for extras, repository not found`. 


This PR fixes the following issue: https://github.com/puppetlabs/puppetlabs-docker/issues/289