### PR TITLE
CLOUD-2046-Add logic for root dir flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -622,6 +622,12 @@ if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.][0-1](~|-|\.)ce|1.\d+
     $docker_package_name = $docker_engine_package_name
   }
 
+  if ( $version != undef ) and ( $version =~ /^(17[.]0[0-4]|1.\d+)/ ) {
+    $root_dir_flag = '-g'
+  } else {
+    $root_dir_flag = '--data-root'
+  }
+
   contain 'docker::repos'
   contain 'docker::install'
   contain 'docker::config'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -115,6 +115,7 @@ class docker::service (
   $tls_cert                          = $docker::tls_cert,
   $tls_key                           = $docker::tls_key,
   $registry_mirror                   = $docker::registry_mirror,
+  $root_dir_flag                     = $docker::root_dir_flag,
 ) {
 
   unless $::osfamily =~ /(Debian|RedHat|windows)/ {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -699,10 +699,22 @@ describe 'docker', :type => :class do
         end
       end
 
-      context 'with custom root dir' do
-        let(:params) { {'root_dir' => '/mnt/docker'} }
+      context 'with custom root dir && Docker version < 17.06' do
+        let(:params) { {
+          'root_dir' => '/mnt/docker',
+          'version'  => '17.03',
+        } }
         it { should contain_file(service_config_file).with_content(/-g \/mnt\/docker/) }
       end
+  
+      context 'with custom root dir && Docker version > 17.05' do
+        let(:params) { {
+          'root_dir' => '/mnt/docker',
+          'version'  => '18.03',
+        } }
+        it { should contain_file(service_config_file).with_content(/--data-root \/mnt\/docker/) }
+      end
+       
 
       context 'with ensure absent' do
         let(:params) { {'ensure' => 'absent' } }

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -4,7 +4,7 @@
 DOCKER="/usr/bin/<%= @docker_start_command %>"
 
 other_args="<% -%>
-<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @root_dir %><%= @root_dir_flag %> <%= @root_dir %><% end -%>
 <% if @tcp_bind %><% @tcp_bind_array.each do |param| %> -H <%= param %><% end %> <% end -%>
 <% if @tls_enable %> --tls<% if @tls_verify -%> --tlsverify<% end -%> --tlscacert=<%= @tls_cacert %> --tlscert=<%= @tls_cert %> --tlskey=<%= @tls_key %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -19,7 +19,7 @@ export TMPDIR="<%= @tmp_dir %>"
 
 # # Use DOCKER_OPTS to modify the daemon startup options.
 DOCKER_OPTS="\
-<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @root_dir %><%= @root_dir_flag %> <%= @root_dir %><% end -%>
 <% if @tcp_bind %><% @tcp_bind_array.each do |param| %> -H <%= param %><% end %> <% end -%>
 <% if @tls_enable %> --tls<% if @tls_verify -%> --tlsverify<% end -%> --tlscacert=<%= @tls_cacert %> --tlscert=<%= @tls_cert %> --tlskey=<%= @tls_key %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -4,7 +4,7 @@
 DOCKER="/usr/bin/<%= @docker_command %>"
 
 other_args="<% -%>
-<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @root_dir %><%= @root_dir_flag %> <%= @root_dir %><% end -%>
 <% if @tcp_bind %><% @tcp_bind_array.each do |param| %> -H <%= param %><% end %> <% end -%>
 <% if @tls_enable %> --tls<% if @tls_verify -%> --tlsverify<% end -%> --tlscacert=<%= @tls_cacert %> --tlscert=<%= @tls_cert %> --tlskey=<%= @tls_key %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>

--- a/templates/etc/sysconfig/docker.systemd.erb
+++ b/templates/etc/sysconfig/docker.systemd.erb
@@ -1,7 +1,7 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
+OPTIONS="<% if @root_dir %><%= @root_dir_flag %> <%= @root_dir %><% end -%>
 <% if @tcp_bind %><% @tcp_bind_array.each do |param| %> -H <%= param %><% end %> <% end -%>
 <% if @tls_enable %> --tls<% if @tls_verify -%> --tlsverify<% end -%> --tlscacert=<%= @tls_cacert %> --tlscert=<%= @tls_cert %> --tlskey=<%= @tls_key %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>


### PR DESCRIPTION
This PR adds logic to use the new --data-root flag for versions > 17.05 and the -g flag for versions <= 17.05