### PR TITLE
Do not manage /etc/sysconfig/docker-storage on RedHat based systems.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,7 +173,9 @@ class docker::params {
     }
     'RedHat' : {
       $service_config = '/etc/sysconfig/docker'
-      $storage_config = '/etc/sysconfig/docker-storage'
+      # redhat based systems shall configure their storage over
+      # /etc/sysconfig/docker-storage-setup
+      $storage_config = undef
       $storage_setup_file = '/etc/sysconfig/docker-storage-setup'
       $service_hasstatus  = true
       $service_hasrestart = true


### PR DESCRIPTION
On RedHat based systems docker-storage should be managed through
/etc/sysconfig/docker-storage-setup, which will then configure
/etc/sysconfig/docker-storage on the daemon startup. However,
by managing both on RedHat based systems, we constantly wrote it
based on the template content, restarted the docker daemon,
which then overwrote the file back so on the next puppet run the
same thing happened again.