### PR TITLE
More idiomatic usage of parens for 'fail translate(('

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -490,32 +490,32 @@ class docker(
 
   if $::osfamily {
     assert_type(Pattern[/^(Debian|RedHat|windows)$/], $::osfamily) |$a, $b| {
-      fail translate(('This module only works on Debian, Red Hat or Windows based systems.'))
+      fail(translate('This module only works on Debian, Red Hat or Windows based systems.'))
     }
   }
 
   if ($::operatingsystem == 'CentOS') and (Integer($::operatingsystemmajrelease) < 7){
-    fail translate(('This module only works on CentOS version 7 and higher based systems.'))
+    fail(translate('This module only works on CentOS version 7 and higher based systems.'))
   }
 
   if ($default_gateway) and (!$bridge) {
-    fail translate(('You must provide the $bridge parameter.'))
+    fail(translate('You must provide the $bridge parameter.'))
   }
 
   if $log_level {
     assert_type(Pattern[/^(debug|info|warn|error|fatal)$/], $log_level) |$a, $b| {
-        fail translate(('log_level must be one of debug, info, warn, error or fatal'))
+        fail(translate('log_level must be one of debug, info, warn, error or fatal'))
     }
   }
 
   if $log_driver {
     if $::osfamily == 'windows' {
       assert_type(Pattern[/^(none|json-file|syslog|gelf|fluentd|splunk|etwlogs)$/], $log_driver) |$a, $b| {
-        fail translate(('log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs'))
+        fail(translate('log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs'))
       }
     } else {
       assert_type(Pattern[/^(none|json-file|syslog|journald|gelf|fluentd|splunk)$/], $log_driver) |$a, $b| {
-        fail translate(('log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk'))
+        fail(translate('log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk'))
       }
     }
   }
@@ -523,34 +523,34 @@ class docker(
   if $storage_driver {
     if $::osfamily == 'windows' {
       assert_type(Pattern[/^(windowsfilter)$/], $storage_driver) |$a, $b| {
-          fail translate(('Valid values for storage_driver on windows are windowsfilter'))
+          fail(translate('Valid values for storage_driver on windows are windowsfilter'))
       }
     } else {
       assert_type(Pattern[/^(aufs|devicemapper|btrfs|overlay|overlay2|vfs|zfs)$/], $storage_driver) |$a, $b| {
-        fail translate(('Valid values for storage_driver are aufs, devicemapper, btrfs, overlay, overlay2, vfs, zfs.'))
+        fail(translate('Valid values for storage_driver are aufs, devicemapper, btrfs, overlay, overlay2, vfs, zfs.'))
       }
     }
   }
 
   if ($bridge) and ($::osfamily == 'windows') {
       assert_type(Pattern[/^(none|nat|transparent|overlay|l2bridge|l2tunnel)$/], $bridge) |$a, $b| {
-        fail translate(('bridge must be one of none, nat, transparent, overlay, l2bridge or l2tunnel on Windows.'))
+        fail(translate('bridge must be one of none, nat, transparent, overlay, l2bridge or l2tunnel on Windows.'))
     }
   }
 
   if $dm_fs {
     assert_type(Pattern[/^(ext4|xfs)$/], $dm_fs) |$a, $b| {
-      fail translate(('Only ext4 and xfs are supported currently for dm_fs.'))
+      fail(translate('Only ext4 and xfs are supported currently for dm_fs.'))
     }
   }
 
   if ($dm_loopdatasize or $dm_loopmetadatasize) and ($dm_datadev or $dm_metadatadev) {
-    fail translate(('You should provide parameters only for loop lvm or direct lvm, not both.'))
+    fail(translate('You should provide parameters only for loop lvm or direct lvm, not both.'))
   }
 
 # lint:ignore:140chars
   if ($dm_datadev or $dm_metadatadev) and $dm_thinpooldev {
-    fail translate(('You can use the $dm_thinpooldev parameter, or the $dm_datadev and $dm_metadatadev parameter pair, but you cannot use both.'))
+    fail(translate('You can use the $dm_thinpooldev parameter, or the $dm_datadev and $dm_metadatadev parameter pair, but you cannot use both.'))
   }
 # lint:endignore
 
@@ -559,17 +559,17 @@ class docker(
   }
 
   if ($dm_datadev and !$dm_metadatadev) or (!$dm_datadev and $dm_metadatadev) {
-    fail translate(('You need to provide both $dm_datadev and $dm_metadatadev parameters for direct lvm.'))
+    fail(translate('You need to provide both $dm_datadev and $dm_metadatadev parameters for direct lvm.'))
   }
 
   if ($dm_basesize or $dm_fs or $dm_mkfsarg or $dm_mountopt or $dm_blocksize or $dm_loopdatasize or
       $dm_loopmetadatasize or $dm_datadev or $dm_metadatadev) and ($storage_driver != 'devicemapper') {
-    fail translate(('Values for dm_ variables will be ignored unless storage_driver is set to devicemapper.'))
+    fail(translate('Values for dm_ variables will be ignored unless storage_driver is set to devicemapper.'))
   }
 
   if($tls_enable) {
     if(!$tcp_bind) {
-        fail translate(('You need to provide tcp bind parameter for TLS.'))
+        fail(translate('You need to provide tcp bind parameter for TLS.'))
     }
   }
 
@@ -598,7 +598,7 @@ if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.][0-1](~|-|\.)ce|1.\d+
             $package_key_check_source = true
             }
           'windows': {
-            fail translate(('This module only work for Docker Enterprise Edition on Windows.'))
+            fail(translate('This module only work for Docker Enterprise Edition on Windows.'))
           }
           default: {}
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,7 @@ class docker::install (
   $docker_start_command = $docker::docker_start_command
   if $::osfamily {
     assert_type(Pattern[/^(Debian|RedHat|windows)$/], $::osfamily) |$a, $b| {
-      fail translate(('This module only works on Debian, RedHat or Windows.'))
+      fail(translate('This module only works on Debian, RedHat or Windows.'))
     }
   }
   if $docker::version and $docker::ensure != 'absent' {
@@ -55,7 +55,7 @@ class docker::install (
           $pk_provider = 'yum'
         }
         'windows' : {
-          fail translate('Custom package source is currently not implemented on windows.')
+          fail(translate('Custom package source is currently not implemented on windows.'))
         }
         default : {
           $pk_provider = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -119,7 +119,7 @@ class docker::service (
 ) {
 
   unless $::osfamily =~ /(Debian|RedHat|windows)/ {
-    fail translate(('The docker::service class needs a Debian, Redhat or Windows based system.'))
+    fail(translate('The docker::service class needs a Debian, Redhat or Windows based system.'))
   }
 
   $dns_array = any2array($dns)


### PR DESCRIPTION
We are using [language-puppet](https://github.com/bartavelle/language-puppet) and need to maintain a forge just because of this.