### PR TITLE
Use versioncmp instead of  type casting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -494,7 +494,7 @@ class docker(
     }
   }
 
-  if ($::operatingsystem == 'CentOS') and ($::operatingsystemmajrelease < 7){
+  if ($::operatingsystem == 'CentOS') and (versioncmp($::operatingsystemmajrelease, '7') < 0) {
     fail(translate('This module only works on CentOS version 7 and higher based systems.'))
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -494,7 +494,7 @@ class docker(
     }
   }
 
-  if ($::operatingsystem == 'CentOS') and (Integer($::operatingsystemmajrelease) < 7){
+  if ($::operatingsystem == 'CentOS') and ($::operatingsystemmajrelease < 7){
     fail(translate('This module only works on CentOS version 7 and higher based systems.'))
   }
 


### PR DESCRIPTION
I would like to request the removal of this particular type annotation.

The annotation is what remains from the fork of `puppetlabs-docker` I maintain to make the module work with [language-puppet](https://github.com/bartavelle/language-puppet). Language-puppet helps us tremendously when writing puppet configuration.

The annotation itself does not seem to bring any kind of type safety. I would argue it is not the right place to check the type of this particular global fact if such a check is at all necessary.

[language-puppet](https://github.com/bartavelle/language-puppet) is making great effort to be as compatible with the puppet language as possible. See recent commit. This particular idiom might be supported in the future but for now I am just requesting this change because all in all it seems to make sense.

Thanks you.