### PR TITLE
Check for empty IPAM Config

### DIFF
--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
       ipam_driver = unless obj['IPAM']['Driver'].nil?
                       obj['IPAM']['Driver']
                     end
-      subnet = unless obj['IPAM']['Config'].nil?
+      subnet = unless obj['IPAM']['Config'].nil? || obj['IPAM']['Config'].empty?
                  if obj['IPAM']['Config'].first.key? 'Subnet'
                    obj['IPAM']['Config'].first['Subnet']
                  end


### PR DESCRIPTION
obj['IPAM']['Config'] can be an empty array that can lead to obj['IPAM']['Config'].first.key? throwing an exception:
undefined method `key?' for nil:NilClass