### PR TITLE
Fix registry local_user functionalitity.

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -55,7 +55,7 @@ define docker::registry(
     $password_env = '$env:password'
     $exec_user = undef
   } else {
-    $exec_environment = ['HOME=/root']
+    $exec_environment = []
     $exec_path = ['/bin', '/usr/bin']
     $exec_timeout = 0
     $exec_provider = undef


### PR DESCRIPTION
Docker uses $HOME environment variable to determine docker.json location.
Having /root as as standard $HOME, local_user functionality is broken.