### PR TITLE
Added support for awslogs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,8 @@
 #                Writes log messages to fluentd (forward input).
 #     splunk   : Splunk logging driver for Docker.
 #                Writes log messages to Splunk (HTTP Event Collector).
+#     awslogs  : AWS Cloudwatch Logs logging driver for Docker.
+#                Write log messages to Cloudwatch API
 #
 # [*log_opt*]
 #   Set the log driver specific options
@@ -152,6 +154,15 @@
 #     splunk   :
 #                splunk-token=<splunk_http_event_collector_token>
 #                splunk-url=https://your_splunk_instance:8088
+#     awslogs  :
+#                awslogs-group=<Cloudwatch Log Group>
+#                awslogs-stream=<Cloudwatch Log Stream>
+#                awslogs-create-group=true|false
+#                awslogs-datetime-format=<Date format> - strftime expression
+#                awslogs-multiline-pattern=multiline start pattern using a regular expression
+#                tag={{.ID}} - short container id (12 characters)|
+#                    {{.FullID}} - full container id
+#                    {{.Name}} - container name
 #
 # [*selinux_enabled*]
 #   Enable selinux support. Default is false. SELinux does  not  presently
@@ -510,12 +521,12 @@ class docker(
 
   if $log_driver {
     if $::osfamily == 'windows' {
-      assert_type(Pattern[/^(none|json-file|syslog|gelf|fluentd|splunk|etwlogs)$/], $log_driver) |$a, $b| {
-        fail(translate('log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs'))
+      assert_type(Pattern[/^(none|json-file|syslog|gelf|fluentd|splunk|awslogs|etwlogs)$/], $log_driver) |$a, $b| {
+        fail(translate('log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk, awslogs or etwlogs'))
       }
     } else {
-      assert_type(Pattern[/^(none|json-file|syslog|journald|gelf|fluentd|splunk)$/], $log_driver) |$a, $b| {
-        fail(translate('log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk'))
+      assert_type(Pattern[/^(none|json-file|syslog|journald|gelf|fluentd|splunk|awslogs)$/], $log_driver) |$a, $b| {
+        fail(translate('log_driver must be one of none, json-file, syslog, journald, gelf, fluentd, splunk or awslogs'))
       }
     }
   }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -641,7 +641,7 @@ describe 'docker', :type => :class do
         it do
           expect {
             should contain_package('docker')
-          }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk/)
+          }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, journald, gelf, fluentd, splunk or awslogs/)
         end
       end
 

--- a/spec/classes/docker_windows_spec.rb
+++ b/spec/classes/docker_windows_spec.rb
@@ -77,7 +77,7 @@ describe 'docker', :type => :class do
         it do
             expect {
               should contain_package('docker')
-            }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs/)
+            }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk, awslogs or etwlogs/)
         end
       end
 
@@ -89,7 +89,7 @@ describe 'docker', :type => :class do
         it do
             expect {
               should contain_package('docker')
-            }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk or etwlogs/)
+            }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, gelf, fluentd, splunk, awslogs or etwlogs/)
         end
       end
 


### PR DESCRIPTION
AWSlogs which is AWS Cloudwatch logging support was not included, this is a standard log driver shipped with docker and as such should be supported.

Minimal changes have been made to the code to enable this support, essentially allowing `awslogs` for `log_driver` in `init.pp`.

The `docker_spec.rb` and `docker_windows_spec.rb` have also been updated, but no specific `log_opts` checks have been put in place for awslogs.

Sample usage is
```
docker::log_level: info
docker::log_driver: awslogs
docker::log_opt:
  - awslogs-region=ap-southeast-2
  - awslogs-group=%{facts.puppet_project}-%{facts.puppet_env}
  - awslogs-create-group=true
  - tag='%{facts.hostname}-{{.Name}}-{{.ID}}'
```