### PR TITLE
WIP: Support for docker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
    * [Private registries](#privateregistries)
    * [Exec](#exec)
    * [Plugins](#plugins)
+   * [Configs](#configs)
 4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
    * [Classes](#classes)
    * [Defined types](#definedtypes)
@@ -113,7 +114,7 @@ To use the CE packages, add the following code to the manifest file:
 ```puppet
 class { 'docker':
   use_upstream_package_source => false,
-  repo_opt => '',  
+  repo_opt => '',
 }
 ```
 
@@ -204,7 +205,7 @@ class { 'docker':
 }
 ```
 
-Only Docker EE is supported on Windows. To install docker on Windows 2016 and above the `docker_ee` parameter must be specified: 
+Only Docker EE is supported on Windows. To install docker on Windows 2016 and above the `docker_ee` parameter must be specified:
 ```puppet
 class { 'docker':
   docker_ee => true
@@ -368,9 +369,9 @@ The `extra_parameters` parameter, which contains an array of command line argume
 
 By default, automatic restarting of the service on failure is enabled by the service file for systemd based systems.
 
-It's recommended that an image tag is used at all times with the `docker::run` define type. If not, the latest image ise used, whether it be in a remote registry or installed on the server already by the `docker::image` define type. 
+It's recommended that an image tag is used at all times with the `docker::run` define type. If not, the latest image ise used, whether it be in a remote registry or installed on the server already by the `docker::image` define type.
 
-NOTE: As of v3.0.0, if the latest tag is used, the image will be the latest at the time the of the initial puppet run. Any subsequent puppet runs will always reference the latest local image. For this this reason it highly recommended that an alternative tag be used, or the image be removed before pulling latest again. 
+NOTE: As of v3.0.0, if the latest tag is used, the image will be the latest at the time the of the initial puppet run. Any subsequent puppet runs will always reference the latest local image. For this this reason it highly recommended that an alternative tag be used, or the image be removed before pulling latest again.
 
 To use an image tag, add the following code to the manifest file:
 
@@ -604,7 +605,7 @@ To deploy the stack, add the following code to the manifest file:
 
 To remove the stack, set `ensure  => absent`.
 
-If you are using a v3.2compose file or above on a Docker Swarm cluster, include the `docker::stack` class. Similar to using older versions of Docker, compose the file resource before running the stack command. 
+If you are using a v3.2compose file or above on a Docker Swarm cluster, include the `docker::stack` class. Similar to using older versions of Docker, compose the file resource before running the stack command.
 
 To deploy the stack, add the following code to the manifest file.
 
@@ -812,7 +813,7 @@ docker::registry_auth::registries:
     version: '<docker_version>'
 ```
 
-If using Docker V1.11 or later, the docker login email flag has been deprecated [docker_change_log](https://docs.docker.com/release-notes/docker-engine/#1110-2016-04-13). 
+If using Docker V1.11 or later, the docker login email flag has been deprecated [docker_change_log](https://docs.docker.com/release-notes/docker-engine/#1110-2016-04-13).
 
 Add the following code to the manifest file:
 
@@ -893,6 +894,37 @@ docker::plugin {'foo/fooplugin:latest'
 thub.com
 ```
 
+### Configs
+
+Docker 17.06 introduces swarm service configs. To expose the `docker_config` type that is used to manage configs, add the following code to the manifest file:
+
+```puppet
+docker_config { 'my-conf':
+  ensure => present,
+  name   => 'my-conf',
+  file   => '/tmp/my-conf.yaml',
+}
+```
+
+The name and file values are required.
+
+If using Hiera, configure the `docker::configs` class in the manifest file:
+
+```yaml
+---
+  classes:
+    - docker::configs
+
+docker::configs::configs:
+  my-conf:
+    ensure: 'present'
+    name: 'my-conf'
+    file: '/tmp/my-conf.yaml'
+```
+
+A defined config can be used on a `docker::services` resource with the `volumes` parameter.
+
+
 ## Reference
 
 ### Classes
@@ -935,6 +967,7 @@ thub.com
 * docker_compose: A type that represents a docker compose file.
 * docker_network: A type that represents a docker network.
 * docker_volume: A type that represents a docker volume.
+* docker_config: A type that represents a docker config.
 
 ### Parameters
 
@@ -1487,6 +1520,20 @@ Auto pool extension threshold (in % of pool size).
 #### `storage_pool_autoextend_percent`
 
 Extends the pool by the specified percentage when the threshold is passed.
+
+The following parameters are available in the `docker_config` type:
+
+#### `name`
+
+The name of the config'
+
+#### `file`
+
+The file path used to create the config.
+
+#### `id`
+
+The ID of the config provided by Docker.
 
 For further explanation please refer to the[PE documentation](https://puppet.com/docs/pe/2017.3/orchestrator/running_tasks.html) or [Bolt documentation](https://puppet.com/docs/bolt/latest/bolt.html) on how to execute a task.
 

--- a/lib/puppet/provider/docker_config/ruby.rb
+++ b/lib/puppet/provider/docker_config/ruby.rb
@@ -1,0 +1,51 @@
+require 'json'
+
+Puppet::Type.type(:docker_config).provide(:ruby) do
+  desc 'Support for Docker configs'
+
+  mk_resource_methods
+  commands docker: 'docker'
+
+  def config_conf
+    flags = %w[config create]
+    flags << resource[:name]
+    flags << resource[:file]
+  end
+
+  def self.instances
+    output = docker(%w[config ls --format {{.Name}}])
+    lines = output.split("\n")
+    lines.map do |name|
+      inspect = docker(['config', 'inspect', name])
+      obj = JSON.parse(inspect).first
+      new(
+        :id => obj['Id'],
+        :name => obj['Spec']['Name'],
+        :ensure  => :present,
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if docker network #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating docker config #{name}")
+    docker(config_conf)
+  end
+
+  def destroy
+    Puppet.info("Removing docker config #{name}")
+    docker(['config', 'rm', name])
+  end
+end

--- a/lib/puppet/type/docker_config.rb
+++ b/lib/puppet/type/docker_config.rb
@@ -1,0 +1,20 @@
+Puppet::Type.newtype(:docker_config) do
+  @doc = 'A type representing a Docker config'
+  ensurable
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the config'
+  end
+
+  newproperty(:file) do
+    desc 'The file with the content of the config'
+  end
+
+  newproperty(:id) do
+    desc 'The ID of the config provided by Docker'
+    validate do |value|
+      raise(Puppet::ParseError, "#{value} is read-only and is only available via puppet resource.")
+    end
+  end
+end

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -1,0 +1,4 @@
+# docker::configs
+class docker::configs($configs) {
+  create_resources(docker_configs, $configs)
+}

--- a/spec/unit/docker_config_spec.rb
+++ b/spec/unit/docker_config_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+config = Puppet::Type.type(:docker_config)
+
+describe config do
+  let :params do
+    [
+      :name,
+      :file,
+    ]
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(config.parameters).to be_include(param)
+    end
+  end
+end


### PR DESCRIPTION
This PR add a new type `docker_config` to create configs in docker swarm. It could be used as a volumes in docker services/stacks.

Since docker config cannot update the content of the config, this type can just create or remove it.
