### PR TITLE
Create shared start/stop scripts for better extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,6 @@ This is equivalent to running the  `docker run -d base /bin/sh -c "while true; d
 ```puppet
 docker::run { 'helloworld':
   image            => 'base',
-  detach           => true,
   service_prefix   => 'docker-',
   command          => '/bin/sh -c "while true; do echo hello world; sleep 1; done"',
   ports            => ['4444', '4555'],

--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -42,10 +42,6 @@ module Puppet::Parser::Functions
       flags << '--privileged'
     end
 
-    if opts['detach']
-      flags << '--detach=true'
-    end
-
     if opts['health_check_cmd'] && opts['health_check_cmd'].to_s != 'undef'
       flags << "--health-cmd='#{opts['health_check_cmd']}'"
     end

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -178,7 +178,6 @@ define docker::run(
 
   $docker_run_flags = docker_run_flags({
     cpuset                => any2array($cpuset),
-    detach                => $valid_detach,
     disable_network       => $disable_network,
     dns                   => any2array($dns),
     dns_search            => any2array($dns_search),

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -109,7 +109,6 @@ define docker::run(
   Variant[String,Boolean] $docker_service               = false,
   Optional[Boolean] $disable_network                    = false,
   Optional[Boolean] $privileged                         = false,
-  Optional[Boolean] $detach                             = undef,
   Variant[String,Array[String],Undef] $extra_parameters = undef,
   Optional[String] $systemd_restart                     = 'on-failure',
   Variant[String,Hash,Undef] $extra_systemd_parameters  = {},
@@ -168,12 +167,6 @@ define docker::run(
 
   if $systemd_restart {
     assert_type(Pattern[/^(no|always|on-success|on-failure|on-abnormal|on-abort|on-watchdog)$/], $systemd_restart)
-  }
-
-  if $detach == undef {
-    $valid_detach = $docker::params::detach_service_in_init
-  } else {
-    $valid_detach = $detach
   }
 
   $extra_parameters_array = any2array($extra_parameters)

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -395,6 +395,16 @@ define docker::run(
           ensure => absent,
           path   => "/etc/systemd/system/${service_prefix}${sanitised_title}.service",
         }
+        if ($startscript) {
+          file { $startscript:
+            ensure => absent
+          }
+        }
+        if ($stopscript) {
+          file { $stopscript:
+            ensure => absent
+          }
+        }
       }
       else {
         file { $cidfile:

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -345,6 +345,9 @@ define docker::run(
       }
     }
 
+    $docker_run_inline_start = template('docker/docker-run-start.erb')
+    $docker_run_inline_stop = template('docker/docker-run-stop.erb')
+
     if $syslog_identifier {
       $_syslog_identifier = $syslog_identifier
     } else {

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -76,6 +76,10 @@
 # (optional) Specify an additional unless for the Docker run command when using restart.
 # Default: undef
 #
+# [*after_create*]
+# (optional) Specifies the command to execute after container is created but before it is started.
+# Default: undef
+#
 define docker::run(
   Optional[Pattern[/^[\S]*$/]] $image,
   Optional[Pattern[/^present$|^absent$/]] $ensure       = 'present',
@@ -120,6 +124,7 @@ define docker::run(
   Optional[String] $restart                             = undef,
   Variant[String,Boolean] $before_start                 = false,
   Variant[String,Boolean] $before_stop                  = false,
+  Optional[String]  $after_create                       = undef,
   Optional[Boolean] $remove_container_on_start          = true,
   Optional[Boolean] $remove_container_on_stop           = true,
   Optional[Boolean] $remove_volume_on_start             = false,

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -440,6 +440,11 @@ require 'spec_helper'
         it { should_not contain_file(stopscript_or_init).with_content(/before_stop/) }
       end
 
+      context 'when `after_create` is set' do
+        let(:params) { {'command' => 'command', 'image' => 'base', 'after_create' => "echo after_create" } }
+        it { should contain_file(startscript_or_init).with_content(/after_create/) }
+      end
+
       context 'with an title that will not format into a path' do
         let(:title) { 'this/that' }
         let(:params) { {'image' => 'base'} }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -369,11 +369,6 @@ require 'spec_helper'
         end
       end
 
-      context 'should be able to override detached' do
-        let(:params) { {'command' => 'command', 'image' => 'base', 'detach' => false} }
-        it { should contain_file(startscript_or_init).without_content(/--detach=true/) }
-      end
-
       context 'when running with a tty' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'tty' => true} }
         it { should contain_file(startscript_or_init).with_content(/-t/) }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -45,7 +45,7 @@ require 'spec_helper'
         it { should contain_service('docker-sample') }
         it { should contain_file(initscript).with_content(/#{Regexp.escape(startscript)}/) }
         it { should contain_file(initscript).with_content(/#{Regexp.escape(stopscript)}/) }
-        it { should contain_file(startscript_or_init).with_content(/docker run/).with_content(/command/).with_content(/base/)}
+        it { should contain_file(startscript_or_init).with_content(/docker start/).with_content(/command/).with_content(/base/)}
 
         if systemd
           it { should contain_file(initscript).with_content(/^SyslogIdentifier=docker-sample$/) }

--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -3,22 +3,16 @@
 <% end -%>
 <% if @remove_container_on_start -%>
     /usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %> >/dev/null 2>&1
-<% else %>
-    /usr/bin/<%= @docker_command %> create \
-    <%= @docker_run_flags %> \
-    --name <%= @sanitised_title %> \
-    <%= @image %> \
-    <% if @command %> <%= @command %><% end %>
 <% end -%>
+
 <% if @pull_on_start -%>
     /usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
-<% if @remove_container_on_start -%>
-/usr/bin/<%= @docker_command %> run \
+
+/usr/bin/<%= @docker_command %> create \
 <%= @docker_run_flags %> \
 --name <%= @sanitised_title %> \
 <%= @image %> \
 <% if @command %> <%= @command %><% end %>
-<% else %>
-/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
-<% end -%>
+
+/usr/bin/<%= @docker_command %> start <% if ! @valid_detach %>-a<% end %> <%= @sanitised_title %>

--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -1,0 +1,24 @@
+<% if @before_start -%>
+    <%= @before_start %>
+<% end -%>
+<% if @remove_container_on_stop -%>
+    $docker rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %> >/dev/null 2>&1
+<% else %>
+    $docker create \
+    <%= @docker_run_flags %> \
+    --name <%= @sanitised_title %> \
+    <%= @image %> \
+    <% if @command %> <%= @command %><% end %>
+<% end -%>
+<% if @pull_on_start -%>
+    $docker pull <%= @image %>
+<% end -%>
+<% if @remove_container_on_stop -%>
+$docker run \
+<%= @docker_run_flags %> \
+--name <%= @sanitised_title %> \
+<%= @image %> \
+<% if @command %> <%= @command %><% end %>
+<% else %>
+$docker start -a <%= @sanitised_title %>
+<% end -%>

--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -1,7 +1,7 @@
 <% if @before_start -%>
     <%= @before_start %>
 <% end -%>
-<% if @remove_container_on_stop -%>
+<% if @remove_container_on_start -%>
     /usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %> >/dev/null 2>&1
 <% else %>
     /usr/bin/<%= @docker_command %> create \
@@ -13,7 +13,7 @@
 <% if @pull_on_start -%>
     /usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
-<% if @remove_container_on_stop -%>
+<% if @remove_container_on_start -%>
 /usr/bin/<%= @docker_command %> run \
 <%= @docker_run_flags %> \
 --name <%= @sanitised_title %> \

--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -15,4 +15,6 @@
 <%= @image %> \
 <% if @command %> <%= @command %><% end %>
 
+<% if @after_create %><%= @after_create %><% end %>
+
 /usr/bin/<%= @docker_command %> start <% if ! @valid_detach %>-a<% end %> <%= @sanitised_title %>

--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -2,23 +2,23 @@
     <%= @before_start %>
 <% end -%>
 <% if @remove_container_on_stop -%>
-    $docker rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %> >/dev/null 2>&1
+    /usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %> >/dev/null 2>&1
 <% else %>
-    $docker create \
+    /usr/bin/<%= @docker_command %> create \
     <%= @docker_run_flags %> \
     --name <%= @sanitised_title %> \
     <%= @image %> \
     <% if @command %> <%= @command %><% end %>
 <% end -%>
 <% if @pull_on_start -%>
-    $docker pull <%= @image %>
+    /usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
 <% if @remove_container_on_stop -%>
-$docker run \
+/usr/bin/<%= @docker_command %> run \
 <%= @docker_run_flags %> \
 --name <%= @sanitised_title %> \
 <%= @image %> \
 <% if @command %> <%= @command %><% end %>
 <% else %>
-$docker start -a <%= @sanitised_title %>
+/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
 <% end -%>

--- a/templates/docker-run-stop.erb
+++ b/templates/docker-run-stop.erb
@@ -1,7 +1,7 @@
 <% if @before_stop -%>
     <%= @before_stop %>
 <% end -%>
-$docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
+/usr/bin/<%= @docker_command %> stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
 <% if @remove_container_on_stop -%>
-    $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
+    /usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
 <% end -%>

--- a/templates/docker-run-stop.erb
+++ b/templates/docker-run-stop.erb
@@ -1,0 +1,7 @@
+<% if @before_stop -%>
+    <%= @before_stop %>
+<% end -%>
+$docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
+<% if @remove_container_on_stop -%>
+    $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
+<% end -%>

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -74,30 +74,7 @@ start() {
     fi
 
     printf "Starting $prog:\t"
-    <% if @before_start -%>
-        <%= @before_start %>
-    <% end -%>
-    <% if @remove_container_on_stop -%>
-        $docker rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %> >/dev/null 2>&1
-    <% else %>
-        $docker create \
-        <%= @docker_run_flags %> \
-        --name <%= @sanitised_title %> \
-        <%= @image %> \
-        <% if @command %> <%= @command %><% end %>
-    <% end -%>
-    <% if @pull_on_start -%>
-        $docker pull <%= @image %>
-    <% end -%>
-    <% if @remove_container_on_stop -%>
-    $docker run \
-    <%= @docker_run_flags %> \
-    --name <%= @sanitised_title %> \
-    <%= @image %> \
-    <% if @command %> <%= @command %><% end %>
-    <% else %>
-    $docker start -a <%= @sanitised_title %>
-    <% end -%>
+    <%= @docker_run_inline_start %>
 
     retval=$?
     echo
@@ -110,13 +87,8 @@ start() {
 
 stop() {
     echo -n "Stopping $prog: "
-    <% if @before_stop -%>
-        <%= @before_stop %>
-    <% end -%>
-    $docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
-    <% if @remove_container_on_stop -%>
-        $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
-    <% end -%>
+    <%= @docker_run_inline_stop %>
+
     return $?
 }
 

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -27,30 +27,8 @@ Environment="HOME=/root"
 <%- if @_syslog_identifier -%>
 SyslogIdentifier=<%= @_syslog_identifier %>
 <%- end -%>
-<%- if @before_start %>ExecStartPre=-<%= @before_start %>
-<% end -%>
-ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
-<%- if @remove_container_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_start %>-v<% end %> <%= @sanitised_title %>
-<% else %>ExecStartPre=-/usr/bin/<%= @docker_command %> create \
-    <%= @docker_run_flags %> \
-    --name <%= @sanitised_title %> \
-    <%= @image %> \
-    <% if @command %> <%= @command %><% end %>
-<% end -%>
-<% @extra_systemd_parameters.each do |key, value| -%><%= key %>=<%= value %>
-<% end -%>
-<%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull <%= @image %>
-<% end -%>
-<%- if @remove_container_on_start %>
-ExecStart=/usr/local/bin/docker-run-<%= @sanitised_title %>.sh
-<% else %>
-ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
-<% end -%>
-<%- if @before_stop %>ExecStop=-<%= @before_stop %>
-<% end -%>
-ExecStop=-/usr/bin/<%= @docker_command %> stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
-<%- if @remove_container_on_stop %>ExecStop=-/usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
-<% end -%>
+ExecStart=/usr/local/bin/docker-run-<%= @sanitised_title %>-start.sh
+ExecStop=-/usr/local/bin/docker-run-<%= @sanitised_title %>-stop.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/usr/local/bin/docker-run.sh.epp
+++ b/templates/usr/local/bin/docker-run.sh.epp
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+<%= $script %>
+
+exit $?

--- a/templates/usr/local/bin/docker-run.sh.erb
+++ b/templates/usr/local/bin/docker-run.sh.erb
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-/usr/bin/<%= @docker_command %> run \
-        <%= @docker_run_flags %> \
-        --name <%= @sanitised_title %> \
-        <%= @image %> \
-        <% if @command %> <%= @command %><% end %>


### PR DESCRIPTION
This PR replaces current docker-runscript with scripts for service start and stop actions - used by systems with and without systemd.
There is not much added functionality for end-user, just singular new parameter - `after_create` in `docker::run`. In my current use case it will allow to easily add connecting container to multiple networks (since `docker create` is now always used).
Additionally this PR opens a way to add handling for named user/group from host system, eg. `--user $(id -u user):$(id -g group)`. (PR's for both will come later)

Currently the first one is possible by overusing `extra_systemd_parameters` parameter and second one is not even possible because of systemd `$()` handling.

Main changes:
- no ExecStartPre/ExecStop(Post) in systemd service
- shared logic for start/stop actions  (shell script), based on existing upstart code
- `docker create` is now always used in init scripts, no `docker run`
