### PR TITLE
parameterized package_location for osfamily==RedHat

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -604,7 +604,7 @@ class docker(
           $release = $docker_ce_release
         }
         'Redhat' : {
-          $package_location = "https://download.docker.com/linux/centos/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
+          $package_location = $docker_ce_source_location
           $package_key_source = $docker_ce_key_source
           $package_key_check_source = true
         }


### PR DESCRIPTION
Value of `$docker_ce_source_location` is manufactured in `params.pp` for `osfamily==RedHat` to the exact same URL template.
I suggest using the variable instead, as `$docker_ce_source_location` may be overridden for AmazonLinux for example.