### PR TITLE
Handle compose files with services that have no image

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -1,3 +1,5 @@
+require 'deep_merge'
+
 Puppet::Type.type(:docker_compose).provide(:ruby) do
   desc 'Support for Puppet running Docker Compose'
 
@@ -8,6 +10,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
   def exists?
     Puppet.info("Checking for compose project #{name}")
     compose_services = {}
+    compose_containers = []
     resource[:compose_files].each do |file|
       compose_file = YAML.safe_load(File.read(file))
       containers = docker([
@@ -17,36 +20,38 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
                             '--filter',
                             "label=com.docker.compose.project=#{name}",
                           ]).split("\n")
+      compose_containers.push(*containers)
+      compose_containers.uniq!
       case compose_file['version']
       when %r{^2(\.[0-3])?$}, %r{^3(\.[0-6])?$}
-        compose_services = compose_services.merge(compose_file['services'])
+        compose_services = compose_services.deep_merge(compose_file['services'])
       # in compose v1 "version" parameter is not specified
       when nil
-        compose_services = compose_services.merge(compose_file)
+        compose_services = compose_services.deep_merge(compose_file)
       else
         raise(Puppet::Error, "Unsupported docker compose file syntax version \"#{compose_file['version']}\"!")
       end
+    end
 
-      if compose_services.count != containers.count
-        return false
-      end
+    if compose_services.count != compose_containers.count
+      return false
+    end
 
-      counts = Hash[*compose_services.each.map { |key, array|
-                      image = (array['image']) ? array['image'] : get_image(key, compose_services)
-                      Puppet.info("Checking for compose service #{key} #{image}")
-                      ["#{key}-#{image}", containers.count("#{key}-#{image}")]
-                    }.flatten]
+    counts = Hash[*compose_services.each.map { |key, array|
+                    image = (array['image']) ? array['image'] : get_image(key, compose_services)
+                    Puppet.info("Checking for compose service #{key} #{image}")
+                    ["#{key}-#{image}", compose_containers.count("#{key}-#{image}")]
+                  }.flatten]
 
-      # No containers found for the project
-      if counts.empty? ||
-         # Containers described in the compose file are not running
-         counts.any? { |_k, v| v.zero? } ||
-         # The scaling factors in the resource do not match the number of running containers
-         resource[:scale] && counts.merge(resource[:scale]) != counts
-        false
-      else
-        true
-      end
+    # No containers found for the project
+    if counts.empty? ||
+       # Containers described in the compose file are not running
+       counts.any? { |_k, v| v.zero? } ||
+       # The scaling factors in the resource do not match the number of running containers
+       resource[:scale] && counts.merge(resource[:scale]) != counts
+      false
+    else
+      true
     end
   end
 


### PR DESCRIPTION
I ran into this issue when using Puppet to deploy Harbor. Harbor (https://github.com/goharbor/harbor/releases/tag/v1.6.1) comes with multiple compose files and some of them contain services that do not have images associated with them. I needed to build a deep-merged hash of compose services and a array of unique containers from all compose files and move the service vs. container count checking outside of the compose_files.each loop in order to get an accurate comparison of services and their related images.