### PR TITLE
Add service_provider parameter to docker::run

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -502,13 +502,14 @@ class docker(
   Optional[Boolean] $service_hasstatus                      = $docker::params::service_hasstatus,
   Optional[Boolean] $service_hasrestart                     = $docker::params::service_hasrestart,
   Optional[String] $registry_mirror                         = $docker::params::registry_mirror,
+  Boolean $acknowledge_unsupported_os                       = false,
   # Windows specific parameters
   Optional[String] $docker_msft_provider_version            = $docker::params::docker_msft_provider_version,
   Optional[String] $nuget_package_provider_version          = $docker::params::nuget_package_provider_version,
 ) inherits docker::params {
 
 
-  if $::osfamily {
+  if $::osfamily and !$acknowledge_unsupported_os {
     assert_type(Pattern[/^(Debian|RedHat|windows)$/], $::osfamily) |$a, $b| {
       fail(translate('This module only works on Debian, Red Hat or Windows based systems.'))
     }
@@ -620,7 +621,11 @@ class docker(
         'windows': {
           fail(translate('This module only work for Docker Enterprise Edition on Windows.'))
         }
-        default: {}
+        default: {
+          $package_location = $docker_package_location
+          $package_key_source = $docker_package_key_source
+          $package_key_check_source = $docker_package_key_check_source
+        }
       }
       $docker_start_command = $docker_ce_start_command
       $docker_package_name = $docker_ce_package_name
@@ -640,7 +645,11 @@ class docker(
         $package_key_source = $docker_package_key_source
         $package_key_check_source = $docker_package_key_check_source
       }
-      default : {}
+      default : {
+        $package_location = $docker_package_location
+        $package_key_source = $docker_package_key_source
+        $package_key_check_source = $docker_package_key_check_source
+      }
     }
     $docker_start_command = $docker_engine_start_command
     $docker_package_name = $docker_engine_package_name

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,7 @@ class docker::install (
 
 ) {
   $docker_start_command = $docker::docker_start_command
-  if $::osfamily {
+  if $::osfamily and !::docker::acknowledge_unsupported_os {
     assert_type(Pattern[/^(Debian|RedHat|windows)$/], $::osfamily) |$a, $b| {
       fail(translate('This module only works on Debian, RedHat or Windows.'))
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -121,7 +121,7 @@ class docker::service (
   $root_dir_flag                     = $docker::root_dir_flag,
 ) {
 
-  unless $::osfamily =~ /(Debian|RedHat|windows)/ {
+  unless $::osfamily =~ /(Debian|RedHat|windows)/ or $::docker::acknowledge_unsupported_os {
     fail(translate('The docker::service class needs a Debian, Redhat or Windows based system.'))
   }
 
@@ -137,6 +137,8 @@ class docker::service (
   } else {
     if $::osfamily == 'Debian' {
       $_service_config = "/etc/default/${service_name}"
+    } else {
+      $_service_config = undef
     }
   }
 


### PR DESCRIPTION
I originally tried to contribute this in #86, but it was rejected due to some planned changes to OS handling logic.  I believe those changes were made in #129 so I thought I'd rebase my work a year later and try again.

This MR unlocks existing functionality in the module.  It does not add new features or increase the complexity of the module.  It simply exposes a variable to the user that is already there.  Specifically, the `$service_provider` parameter is exposed in the `docker::run` defined type, just as it is in the main `docker` class.  I've taken care to write good unit tests for the behavior added by this change.  I think you'll find the diff is quite clean.

This allows users of other systemd-based distributions to use this module in an explicitly unsupported fashion.  For example, this module works 100% on Gentoo just by supplying some simple parameters, like in https://github.com/iamjamestl/puppet-nest/blob/9b097dcab71365fbbfc584d719119cc4aa1ec5d1/manifests/docker.pp#L7.