### PR TITLE
Fix the docker_compose options parameter position

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -64,7 +64,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
 
   def create
     Puppet.info("Running compose project #{name}")
-    args = [compose_files, '-p', name, 'up', '-d', '--remove-orphans'].insert(2, resource[:options]).insert(5, resource[:up_args]).compact
+    args = [compose_files, '-p', name, 'up', '-d', '--remove-orphans'].insert(3, resource[:options]).insert(5, resource[:up_args]).compact
     dockercompose(args)
     return unless resource[:scale]
     instructions = resource[:scale].map { |k, v| "#{k}=#{v}" }


### PR DESCRIPTION
This fix move the potion of docker-compose options from this:
`/usr/local/bin/docker-compose -p --project-directory /path name up -d --remove-orphans`
to this:
`/usr/local/bin/docker-compose -p name --project-directory /path up -d --remove-orphans`