### PR TITLE
docker::run: Support depend_services with full systemd unit names

### DIFF
--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -90,6 +90,16 @@ require 'spec_helper'
           it { should contain_file(initscript).with_content(/After=(.*\s+)?bar.service/) }
           it { should contain_file(initscript).with_content(/Requires=(.*\s+)?foo.service/) }
           it { should contain_file(initscript).with_content(/Requires=(.*\s+)?bar.service/) }
+
+          context 'with full systemd unit names' do
+            let(:params) { {'command' => 'command', 'image' => 'base', 'depend_services' => ['foo', 'bar.service', 'baz.target']} }
+            it { should contain_file(initscript).with_content(/After=(.*\s+)?foo.service(\s+|$)/) }
+            it { should contain_file(initscript).with_content(/After=(.*\s+)?bar.service(\s+|$)/) }
+            it { should contain_file(initscript).with_content(/After=(.*\s+)?baz.target(\s+|$)/) }
+            it { should contain_file(initscript).with_content(/Requires=(.*\s+)?foo.service(\s+|$)/) }
+            it { should contain_file(initscript).with_content(/Requires=(.*\s+)?bar.service(\s+|$)/) }
+            it { should contain_file(initscript).with_content(/Requires=(.*\s+)?baz.target(\s+|$)/) }
+          end
         else
           it { should contain_file(initscript).with_content(/Required-Start:.*\s+foo/) }
           it { should contain_file(initscript).with_content(/Required-Start:.*\s+bar/) }

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -1,12 +1,13 @@
 <%-
+	depend_services = @depend_services_array.map{|s| s =~ /\.[a-z]+$/ ? s : "#{s}.service"}
 	@after = [@service_name+".service"] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
-		@depend_services_array.map{|s| "#{s}.service"}
+		depend_services
 	@wants = @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}
 	@requires = [@service_name+".service"] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
-		@depend_services_array.map{|s| "#{s}.service"}
+		depend_services
 -%>
 # This file is managed by Puppet and local changes
 # may be overwritten


### PR DESCRIPTION
To support depending non-service systemd unit types, the docker-run
service template was modified to detect when a full systemd unit name is
passed.  This allows you to depend on targets like 'remote-fs.target' or
'network-online.target' if the container needs it.

Closes #352 