### PR TITLE
Fixing create_resources for volumes

### DIFF
--- a/manifests/volumes.pp
+++ b/manifests/volumes.pp
@@ -1,4 +1,4 @@
 # docker::volumes
 class docker::volumes($volumes) {
-  create_resources(docker_volumes, $volumes)
+  create_resources(docker_volume, $volumes)
 }


### PR DESCRIPTION
The provider is named docker_volume, however the class here is referencing docker_volumes.

This commit corrects the class. 