### PR TITLE
Add support for default-addr-pool options to swarm init

### DIFF
--- a/lib/puppet/parser/functions/docker_swarm_init_flags.rb
+++ b/lib/puppet/parser/functions/docker_swarm_init_flags.rb
@@ -24,6 +24,16 @@ module Puppet::Parser::Functions
       flags << "--cert-expiry '#{opts['cert_expiry']}'"
     end
 
+    if opts['default_addr_pool'].is_a? Array
+      opts['default_addr_pool'].each do |default_addr_pool|
+        flags << "--default-addr-pool #{default_addr_pool}"
+      end
+    end
+
+    if opts['default_addr_pool_mask_length'] && opts['default_addr_pool_mask_length'].to_s != 'undef'
+      flags << "--default-addr-pool-mask-length '#{opts['default_addr_pool_mask_length']}'"
+    end
+
     if opts['dispatcher_heartbeat'] && opts['dispatcher_heartbeat'].to_s != 'undef'
       flags << "--dispatcher-heartbeat '#{opts['dispatcher_heartbeat']}'"
     end

--- a/manifests/swarm.pp
+++ b/manifests/swarm.pp
@@ -34,6 +34,14 @@
 #  Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
 #  defaults to undef
 #
+# [*default_addr_pool*]
+#  Array of default subnet pools for global scope networks (['30.30.0.0/16','40.40.0.0/16'])
+#  defaults to undef
+#
+# [*default_addr_pool_mask_length*]
+#  Default subnet pools mask length for default-addr-pools (CIDR block number)
+#  defaults to undef
+#
 # [*dispatcher_heartbeat*]
 #  Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
 #  Defaults to undef
@@ -78,6 +86,8 @@ define docker::swarm(
   Optional[String] $advertise_addr                = undef,
   Optional[Boolean] $autolock                     = false,
   Optional[String] $cert_expiry                   = undef,
+  Optional[Array] $default_addr_pool              = undef,
+  Optional[String] $default_addr_pool_mask_length = undef,
   Optional[String] $dispatcher_heartbeat          = undef,
   Optional[String] $external_ca                   = undef,
   Optional[Boolean] $force_new_cluster            = false,
@@ -115,16 +125,18 @@ define docker::swarm(
 
   if $init {
     $docker_swarm_init_flags = docker_swarm_init_flags({
-      init                 => $init,
-      advertise_addr       => $advertise_addr,
-      autolock             => $autolock,
-      cert_expiry          => $cert_expiry,
-      dispatcher_heartbeat => $dispatcher_heartbeat,
-      external_ca          => $external_ca,
-      force_new_cluster    => $force_new_cluster,
-      listen_addr          => $listen_addr,
-      max_snapshots        => $max_snapshots,
-      snapshot_interval    => $snapshot_interval,
+      init                          => $init,
+      advertise_addr                => $advertise_addr,
+      autolock                      => $autolock,
+      cert_expiry                   => $cert_expiry,
+      dispatcher_heartbeat          => $dispatcher_heartbeat,
+      default_addr_pool             => $default_addr_pool,
+      default_addr_pool_mask_length => $default_addr_pool_mask_length,
+      external_ca                   => $external_ca,
+      force_new_cluster             => $force_new_cluster,
+      listen_addr                   => $listen_addr,
+      max_snapshots                 => $max_snapshots,
+      snapshot_interval             => $snapshot_interval,
     })
 
     $exec_init = "${docker_command} ${docker_swarm_init_flags}"

--- a/spec/defines/swarm_spec.rb
+++ b/spec/defines/swarm_spec.rb
@@ -30,7 +30,19 @@ require 'spec_helper'
         let(:params) { {
           'init'           => true,
           'advertise_addr' => '192.168.1.1',
-                'listen_addr'    => '192.168.1.1',    
+                'listen_addr'    => '192.168.1.1',
+        } }
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_exec('Swarm init').with_command(/docker swarm init/) }
+      end
+
+      context 'with ensure => present and swarm init and default-addr-pool and default_addr_pool_mask_length' do
+        let(:params) { {
+          'init'                          => true,
+          'advertise_addr'                => '192.168.1.1',
+          'listen_addr'                   => '192.168.1.1',
+          'default_addr_pool'             => ['30.30.0.0/16', '40.40.0.0/16'],
+          'default_addr_pool_mask_length' => '24',
         } }
         it { is_expected.to compile.with_all_deps }
         it { should contain_exec('Swarm init').with_command(/docker swarm init/) }


### PR DESCRIPTION
Docker API version 1.39 introduced the ability to configure the address pools and CIDR block size used for creating global scope networks. This PR adds support for the `--default-addr-pool` and the associated `--default-addr-pool-mask-length` options to `swarm init`.