### PR TITLE
Fix shared scripts on non systemd systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ This is equivalent to running the  `docker run -d base /bin/sh -c "while true; d
 ```puppet
 docker::run { 'helloworld':
   image            => 'base',
+  detach           => true,
   service_prefix   => 'docker-',
   command          => '/bin/sh -c "while true; do echo hello world; sleep 1; done"',
   ports            => ['4444', '4555'],

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -109,6 +109,7 @@ define docker::run(
   Variant[String,Boolean] $docker_service               = false,
   Optional[Boolean] $disable_network                    = false,
   Optional[Boolean] $privileged                         = false,
+  Optional[Boolean] $detach                             = undef,
   Variant[String,Array[String],Undef] $extra_parameters = undef,
   Optional[String] $systemd_restart                     = 'on-failure',
   Variant[String,Hash,Undef] $extra_systemd_parameters  = {},
@@ -167,6 +168,12 @@ define docker::run(
 
   if $systemd_restart {
     assert_type(Pattern[/^(no|always|on-success|on-failure|on-abnormal|on-abort|on-watchdog)$/], $systemd_restart)
+  }
+
+  if $detach == undef {
+    $valid_detach = $docker::params::detach_service_in_init
+  } else {
+    $valid_detach = $detach
   }
 
   $extra_parameters_array = any2array($extra_parameters)

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -379,6 +379,11 @@ require 'spec_helper'
         end
       end
 
+      context 'should be able to override detached' do
+        let(:params) { {'command' => 'command', 'image' => 'base', 'detach' => false} }
+        it { should contain_file(startscript_or_init).without_content(/--detach=true/) }
+      end
+
       context 'when running with a tty' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'tty' => true} }
         it { should contain_file(startscript_or_init).with_content(/-t/) }


### PR DESCRIPTION
This reverts upstream commit "removed $::docker::run::detach parameter".

Problem was introduced with PR #367