### PR TITLE
Move container name sanitisation code to puppet function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
    * [Defined types](#definedtypes)
    * [Types](#types)
    * [Parameters](#parameters)
+   * [Functions](#functions)
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
@@ -1502,6 +1503,12 @@ Auto pool extension threshold (in % of pool size).
 Extends the pool by the specified percentage when the threshold is passed.
 
 For further explanation please refer to the[PE documentation](https://puppet.com/docs/pe/2017.3/orchestrator/running_tasks.html) or [Bolt documentation](https://puppet.com/docs/bolt/latest/bolt.html) on how to execute a task.
+
+### Functions
+
+#### `docker::sanitised_name`
+
+Sanitises string or array of strings for safe usage as container name inside scripts and commands.
 
 ## Limitations
 

--- a/functions/sanitised_name.pp
+++ b/functions/sanitised_name.pp
@@ -1,0 +1,12 @@
+# == Function: docker::sanitised_name
+#
+# Function to sanitise container name.
+#
+# === Parameters
+#
+# [*name*]
+#   Name to sanitise
+#
+function docker::sanitised_name($name){
+  regsubst($name, '[^0-9A-Za-z.\-_]', '-', 'G')
+}

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -211,19 +211,19 @@ define docker::run(
     osfamily              => $::osfamily,
   })
 
-  $sanitised_title = regsubst($title, '[^0-9A-Za-z.\-_]', '-', 'G')
+  $sanitised_title = docker::sanitised_name($title)
   if empty($depends_array) {
     $sanitised_depends_array = []
   }
   else {
-    $sanitised_depends_array = regsubst($depends_array, '[^0-9A-Za-z.\-_]', '-', 'G')
+    $sanitised_depends_array = docker::sanitised_name($depends_array)
   }
 
   if empty($after_array) {
     $sanitised_after_array = []
   }
   else {
-    $sanitised_after_array = regsubst($after_array, '[^0-9A-Za-z.\-_]', '-', 'G')
+    $sanitised_after_array = docker::sanitised_name($after_array)
   }
 
   if $::osfamily == 'windows' {


### PR DESCRIPTION
Make sanitisation code available for external modules
so it can be reused when working with scripts and container names.