### PR TITLE
Removing value in the --prune parameter for docker stack deploy

### DIFF
--- a/lib/puppet/parser/functions/docker_stack_flags.rb
+++ b/lib/puppet/parser/functions/docker_stack_flags.rb
@@ -1,11 +1,9 @@
-# frozen_string_literal: true
-
 require 'shellwords'
 #
 # docker_stack_flags.rb
 #
 module Puppet::Parser::Functions
-  # Transforms a hash into a string of docker swarm init flags
+  # Transforms a hash into a string of docker stack flags
   newfunction(:docker_stack_flags, type: :rvalue) do |args|
     opts = args[0] || {}
     flags = []
@@ -25,7 +23,7 @@ module Puppet::Parser::Functions
     end
 
     if opts['prune'] && opts['prune'].to_s != 'undef'
-      flags << "--prune '#{opts['prune']}'"
+      flags << '--prune'
     end
 
     if opts['with_registry_auth'] && opts['with_registry_auth'].to_s != 'undef'

--- a/lib/puppet/parser/functions/docker_stack_flags.rb
+++ b/lib/puppet/parser/functions/docker_stack_flags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shellwords'
 #
 # docker_stack_flags.rb

--- a/manifests/stack.pp
+++ b/manifests/stack.pp
@@ -40,7 +40,7 @@ define docker::stack(
   Optional[String] $stack_name                                   = undef,
   Optional[String] $bundle_file                                  = undef,
   Optional[Array] $compose_files                                 = undef,
-  Optional[String] $prune                                        = undef,
+  Optional[Boolean] $prune                                       = false,
   Optional[Boolean] $with_registry_auth                          = false,
   Optional[Pattern[/^always$|^changed$|^never$/]] $resolve_image = undef,
 ){

--- a/spec/defines/stack_spec.rb
+++ b/spec/defines/stack_spec.rb
@@ -54,7 +54,7 @@ require 'spec_helper'
       } }
       it { should contain_exec('docker stack create foo').with_command(/docker stack deploy/) }
       it { should contain_exec('docker stack create foo').with_command(/--compose-file '\/tmp\/docker-compose.yaml'/) }
-      it { should contain_exec('docker stack create foo').with_command(/--prune'/) }
+      it { should contain_exec('docker stack create foo').with_command(/--prune/) }
     end
 
     context 'with ensure => absent'  do

--- a/spec/defines/stack_spec.rb
+++ b/spec/defines/stack_spec.rb
@@ -46,6 +46,17 @@ require 'spec_helper'
       it { should contain_exec('docker stack create foo').with_command(/--compose-file '\/tmp\/docker-compose-2.yaml'/) }
     end
 
+    context 'with prune' do
+      let(:params) { {
+        'stack_name' => 'foo', 	
+        'compose_files' => ['/tmp/docker-compose.yaml'],
+        'prune' => true,
+      } }
+      it { should contain_exec('docker stack create foo').with_command(/docker stack deploy/) }
+      it { should contain_exec('docker stack create foo').with_command(/--compose-file '\/tmp\/docker-compose.yaml'/) }
+      it { should contain_exec('docker stack create foo').with_command(/--prune'/) }
+    end
+
     context 'with ensure => absent'  do
       let(:params) { {
         'ensure' => 'absent',


### PR DESCRIPTION
Removing value in the --prune parameter for docker stack deploy as the cli doesn't have a value as per the documentation. (see https://docs.docker.com/engine/reference/commandline/stack_deploy/)

With the existing code, if we use the `prune` option as follows, the `docker stack deploy` command fails.

```
  docker::stack { 'proxy': 
    ensure        => present,
    stack_name    => 'proxy',
    compose_files => '/tmp/proxy-compose.yml',
    prune         => true
  }
```