### PR TITLE
Removing underscore characters from local_user variable before using it with stdlib's pw_hash

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -97,7 +97,7 @@ define docker::registry(
       $server_strip = regsubst($server, '/', '_', 'G')
 
       # no - with pw_hash
-      $local_user_strip = regsubst($local_user, '-', '', 'G')
+      $local_user_strip = regsubst($local_user, '[-_]', '', 'G')
 
       $_pass_hash = $pass_hash ? {
         Undef   => pw_hash($docker_auth, 'SHA-512', $local_user_strip),


### PR DESCRIPTION
We have a system user that has an underscore in the name, and trying to setup docker registry auth for that user causes the following error.

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, pw_hash(): characters in salt must be in the set [a-zA-Z0-9./] at /etc/puppetlabs/code/environments/development/modules/docker/manifests/registry.pp:105:20  at /etc/puppetlabs/code/environments/development/modules/docker/manifests/registry_auth.pp:3 on node
```
This change removes underscore characters from local_user variable before using it with stdlib's pw_hash which only allows [a-zA-Z0-9./]+


