### PR TITLE
Docker::Services: Add 'mounts' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,11 +769,12 @@ docker::services {'redis':
     image => 'redis:latest',
     publish => '6379:639',
     replicas => '5',
-    extra_params => ['--update-delay 1m', '--restart-window 30s']
+    mounts => ['type=bind,source=/etc/my-redis.conf,target=/etc/redis/redis.conf,readonly'],
+    extra_params => ['--update-delay 1m', '--restart-window 30s'],
   }
 ```
 
-To base the service off an image, include the `image` parameter and include the `publish` parameter to expose the service ports. To set the amount of containers running in the service, include the `replicas` parameter. For information regarding the `extra_params` parameter, see `docker service create --help`.
+To base the service off an image, include the `image` parameter and include the `publish` parameter to expose the service ports. To set the amount of containers running in the service, include the `replicas` parameter. To attach one or multiple filesystems to the service, use the `mounts` parameter. For information regarding the `extra_params` parameter, see `docker service create --help`.
 
 To update the service, add the following code to the manifest file:
 

--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -30,6 +30,12 @@ module Puppet::Parser::Functions
       end
     end
 
+    if opts['mounts'].is_a? Array
+      opts['mounts'].each do |mount|
+        flags << "--mount #{mount}"
+      end
+    end
+
     if opts['publish'] && opts['publish'].to_s != 'undef'
       flags << "--publish '#{opts['publish']}'"
     end

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -66,6 +66,9 @@
 # [*registry_mirror*]
 #  This will allow the service to set a registry mirror.
 #  defaults to undef
+# [*mounts*]
+#  Allows attacking filesystem mounts to the service (specified as an array)
+#  defaults to []
 #
 # [*command*]
 #  Command to run on the container
@@ -89,6 +92,7 @@ define docker::services(
   Variant[String,Array,Undef] $workdir                   = undef,
   Variant[String,Array,Undef] $host_socket               = undef,
   Variant[String,Array,Undef] $registry_mirror           = undef,
+  Variant[String,Array,Undef] $mounts                    = undef,
   Variant[String,Array,Undef] $command                   = undef,
 ){
 
@@ -132,6 +136,7 @@ define docker::services(
       image           => $image,
       host_socket     => $host_socket,
       registry_mirror => $registry_mirror,
+      mounts          => $mounts,
       command         => $command,
     })
 

--- a/spec/defines/services_spec.rb
+++ b/spec/defines/services_spec.rb
@@ -21,11 +21,13 @@ describe 'docker::services', :type => :define do
       'extra_params' => ['--update-delay 1m', '--restart-window 30s'],
       'env'          => ['MY_ENV=1', 'MY_ENV2=2'],
       'label'        => ['com.example.foo="bar"', 'bar=baz'],
+      'mounts'       => ['type=bind,src=/tmp/a,dst=/tmp/a', 'type=bind,src=/tmp/b,dst=/tmp/b,readonly'],
     } }
     it { is_expected.to compile.with_all_deps }
     it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
     it { should contain_exec('test_service docker service create').with_command(/--env MY_ENV=1/) }
     it { should contain_exec('test_service docker service create').with_command(/--label bar=baz/) }
+    it { should contain_exec('test_service docker service create').with_command(/--mount type=bind,src=\/tmp\/b,dst=\/tmp\/b,readonly/) }
 
     context 'multiple services declaration' do
       let(:pre_condition) {


### PR DESCRIPTION
The --mount parameter for Docker services is the equivalent to
-v/--volume for standalone Docker containers.
This patch allows to directly specify one or multile values for
this argument directly as a Puppet parameter.
This avoids the hassle of having to go through 'extra_params', since
this is a commonly used option.

https://docs.docker.com/storage/volumes/

Please let me know if I forgot to add/edit anything (tests/...)