### PR TITLE
Increase apt pin from 10 to 500

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,7 +147,7 @@ class docker::params {
       $socket_group                  = $socket_group_default
       $use_upstream_package_source   = true
       $pin_upstream_package_source   = true
-      $apt_source_pin_level          = 10
+      $apt_source_pin_level          = 500
       $repo_opt                      = undef
       $service_config                = undef
       $storage_setup_file            = undef

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -53,7 +53,11 @@ describe 'docker', :type => :class do
         it { should contain_class('apt') }
         it { should contain_package('docker').with_name('docker-ce').with_ensure('present') }
         it { should contain_apt__source('docker').with_location('https://download.docker.com/linux/ubuntu') }
-        it { should contain_apt__pin('docker').with_origin('download.docker.com') }
+        it { should contain_apt__pin('docker')
+          .with_ensure('present')
+          .with_origin('download.docker.com')
+          .with_priority(500)
+        }
         it { should contain_package('docker').with_install_options(nil) }
 
         it { should contain_file('/etc/default/docker').without_content(/icc=/) }
@@ -64,7 +68,11 @@ describe 'docker', :type => :class do
         it { should contain_class('apt') }
         it { should contain_package('docker').with_name('docker-ce').with_ensure('present') }
         it { should contain_apt__source('docker').with_location('https://download.docker.com/linux/debian') }
-        it { should contain_apt__pin('docker').with_origin('download.docker.com') }
+        it { should contain_apt__pin('docker')
+          .with_ensure('present')
+          .with_origin('download.docker.com')
+          .with_priority(500)
+        }
         it { should contain_package('docker').with_install_options(nil) }
 
         it { should contain_file('/etc/default/docker').without_content(/icc=/) }


### PR DESCRIPTION
As the default of this module is to install Docker from the offical
Docker repository, we should also configure the pin accordingly.

Fixes #424.