### PR TITLE
updating acceptance tests for cve-2019-5736

### DIFF
--- a/spec/acceptance/compose_v3_spec.rb
+++ b/spec/acceptance/compose_v3_spec.rb
@@ -11,6 +11,8 @@ else
     docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
   elsif fact('os.name') == 'Centos'
     docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
+  elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+    docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
   else
     docker_args = ''
   end

--- a/spec/acceptance/docker_custom_source_spec.rb
+++ b/spec/acceptance/docker_custom_source_spec.rb
@@ -6,15 +6,19 @@ if fact('osfamily') == 'windows'
     docker_args = 'docker_ee => true, docker_ee_source_location => "https://download.docker.com/components/engine/windows-server/17.06/docker-17.06.2-ee-14.zip"'
     default_image = 'microsoft/nanoserver'
     default_image_tag = '10.0.14393.2189'
-    #The default args are set because: 
-    #restart => 'always' - there is no service created to manage containers 
+    #The default args are set because:
+    #restart => 'always' - there is no service created to manage containers
     #net => 'nat' - docker uses bridged by default when running a container. When installing docker on windows the default network is NAT.
     default_docker_run_arg = "restart => 'always', net => 'nat',"
     default_run_command = "ping 127.0.0.1 -t"
     docker_command = "\"/cygdrive/c/Program Files/Docker/docker\""
-  skip = false
+    skip = false
+elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+    docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
+    skip = true
 else
-  skip = true
+    docker_args = ''
+    skip = true
 end
 
 describe 'the Puppet Docker module' do
@@ -32,7 +36,7 @@ describe 'the Puppet Docker module' do
     end
 
     it 'should be start a docker process' do
-        if fact('osfamily') == 'windows' 
+        if fact('osfamily') == 'windows'
         shell('powershell Get-Process -Name dockerd') do |r|
             expect(r.stdout).to match(/ProcessName/)
         end

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -21,6 +21,8 @@ if fact('kernel') == 'windows'
 else
   if fact('os.family') == 'RedHat'
     docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
+  elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+    docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
   else
     docker_args = ''
   end

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -19,8 +19,10 @@ if fact('osfamily') == 'windows'
 else
   if fact('osfamily') == 'RedHat'
     docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
+  elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+    docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
   else
-    docker_arg = ''
+    docker_args = ''
   end
   docker_registry_image = 'registry'
   docker_network = 'bridge'

--- a/spec/acceptance/network_spec.rb
+++ b/spec/acceptance/network_spec.rb
@@ -6,7 +6,11 @@ if fact('osfamily') == 'windows'
   puts "Not implemented on Windows"
   broken = true
 elsif fact('osfamily') == 'RedHat'
-  docker_args = "repo_opt => '--enablerepo=localmirror-extras'" 
+  docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
+elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+  docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
+else
+  docker_args = ''
 end
 
 describe 'docker network', :win_broken => broken do

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -6,7 +6,11 @@ if fact('osfamily') == 'windows'
   puts "Not implemented on Windows"
   broken = true
 elsif fact('osfamily') == 'RedHat'
-  docker_args = "repo_opt => '--enablerepo=localmirror-extras'" 
+  docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
+elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+  docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
+else
+  docker_args = ''
 end
 
 describe 'docker plugin', :win_broken => broken do

--- a/spec/acceptance/stack_spec.rb
+++ b/spec/acceptance/stack_spec.rb
@@ -6,7 +6,11 @@ if fact('osfamily') == 'windows'
   test_container = 'nanoserver-sac2016'
   wait_for_container_seconds = 120
 else
-  docker_args = ''
+  if fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+    docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
+  else
+    docker_args = ''
+  end
   tmp_path = '/tmp'
   test_container = 'alpine'
   wait_for_container_seconds = 10

--- a/spec/acceptance/volume_spec.rb
+++ b/spec/acceptance/volume_spec.rb
@@ -8,7 +8,11 @@ if fact('osfamily') == 'windows'
 elsif ('osfamily') == 'RedHat'
   docker_args = "repo_opt => '--enablerepo=localmirror-extras'"
   command = 'docker'
+elsif fact('os.name') == 'Ubuntu' && fact('os.release.full') == '14.04'
+  docker_args = "version => '18.06.1~ce~3-0~ubuntu'"
+  command = 'docker'
 else
+  docker_args = ''
   command = 'docker'
 end
 


### PR DESCRIPTION
due to  cve-2019-5736, all patched versions of docker must run the 4.x kernel

see (here)[https://docs.docker.com/engine/release-notes/#18031-ee-6]

this ensure tests still run on 14.04 on pooler