### PR TITLE
Add docker socket group overrides for systemd (service and socket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ class { 'docker':
 }
 ```
 
+The default group ownership of the Unix control socket differs based on OS. For example, on RHEL using docker-ce packages >=18.09.1, the socket file used by /usr/lib/systemd/system/docker.socket is owned by the docker group.  To override this value in /etc/sysconfig/docker and docker.socket (e.g. to use the 'root' group):
+
+```puppet
+class {'docker':
+  socket_group => 'root',
+  socket_override => true,
+}
+```
+
+The socket_group parameter also takes a boolean for legacy cases where setting -G in /etc/sysconfig/docker is not desired:
+
+```puppet
+docker::socket_group: false
+```
+
 For more information about the configuration options for the default docker bridge, see the [Docker documentation](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/custom-docker0/).
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -224,7 +224,7 @@
 #
 # [*socket_group*]
 #   Group ownership of the unix control socket.
-#   Defaults to undefined
+#   Default is based on OS (docker, dockerroot, undef)
 #
 # [*extra_parameters*]
 #   Any extra parameters that should be passed to the docker daemon.
@@ -448,7 +448,7 @@ class docker(
   Optional[String] $tmp_dir                                 = $docker::params::tmp_dir,
   Variant[String,Array,Undef] $dns                          = $docker::params::dns,
   Variant[String,Array,Undef] $dns_search                   = $docker::params::dns_search,
-  Optional[String] $socket_group                            = $docker::params::socket_group,
+  Variant[String,Boolean,Undef] $socket_group               = $docker::params::socket_group,
   Array $labels                                             = $docker::params::labels,
   Variant[String,Array,Undef] $extra_parameters             = undef,
   Variant[String,Array,Undef] $shell_values                 = undef,
@@ -496,6 +496,8 @@ class docker(
   Variant[String,Boolean,Undef] $service_config             = $docker::params::service_config,
   Optional[String] $service_config_template                 = $docker::params::service_config_template,
   Variant[String,Boolean,Undef] $service_overrides_template = $docker::params::service_overrides_template,
+  Variant[String,Boolean,Undef] $socket_overrides_template  = $docker::params::socket_overrides_template,
+  Optional[Boolean] $socket_override                        = $docker::params::socket_override,
   Optional[Boolean] $service_hasstatus                      = $docker::params::service_hasstatus,
   Optional[Boolean] $service_hasrestart                     = $docker::params::service_hasrestart,
   Optional[String] $registry_mirror                         = $docker::params::registry_mirror,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,12 +118,16 @@ class docker::params {
             $storage_config             = '/etc/default/docker-storage'
             $service_config_template    = 'docker/etc/sysconfig/docker.systemd.erb'
             $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
+            $socket_overrides_template  = 'docker/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb'
+            $socket_override            = false
             $service_hasstatus          = true
             $service_hasrestart         = true
             include docker::systemd_reload
           } else {
             $service_config_template    = 'docker/etc/default/docker.erb'
             $service_overrides_template = undef
+            $socket_overrides_template  = undef
+            $socket_override            = false
             $service_provider           = 'upstart'
             $service_hasstatus          = true
             $service_hasrestart         = false
@@ -136,6 +140,8 @@ class docker::params {
           $storage_config             = '/etc/default/docker-storage'
           $service_config_template    = 'docker/etc/sysconfig/docker.systemd.erb'
           $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
+          $socket_overrides_template  = 'docker/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb'
+          $socket_override            = false
           $service_hasstatus          = true
           $service_hasrestart         = true
           include docker::systemd_reload
@@ -184,6 +190,8 @@ class docker::params {
       $service_provider            = 'systemd'
       $service_config_template     = 'docker/etc/sysconfig/docker.systemd.erb'
       $service_overrides_template  = 'docker/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb'
+      $socket_overrides_template   = 'docker/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb'
+      $socket_override             = false
       $use_upstream_package_source = true
 
       $package_ce_source_location  = "https://download.docker.com/linux/centos/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
@@ -254,6 +262,8 @@ class docker::params {
       $storage_setup_file                  = undef
       $service_provider                    = undef
       $service_overrides_template          = undef
+      $socket_overrides_template           = undef
+      $socket_override                     = false
       $service_hasstatus                   = undef
       $service_hasrestart                  = undef
       $detach_service_in_init              = true
@@ -280,6 +290,8 @@ class docker::params {
       $package_ee_package_name             = undef
       $use_upstream_package_source         = true
       $service_overrides_template          = undef
+      $socket_overrides_template           = undef
+      $socket_override                     = false
       $service_hasstatus                   = undef
       $service_hasrestart                  = undef
       $service_provider                    = undef

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -135,7 +135,7 @@ define docker::run(
   Optional[String]  $health_check_cmd                   = undef,
   Optional[Boolean] $restart_on_unhealthy               = false,
   Optional[Integer] $health_check_interval              = undef,
-  Optional[Array] $custom_unless                        = undef,
+  Variant[String,Array,Undef] $custom_unless            = [],
 ) {
   include docker::params
   if ($socket_connect != []) {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -441,6 +441,14 @@ describe 'docker', :type => :class do
         it { should contain_file('/etc/systemd/system/docker.service.d/service-overrides.conf').with_content(/docker.io/) }
       end
 
+      context 'with a specific socket group and override' do
+        let(:params) { { 
+           'socket_group'    => 'root',
+           'socket_override' => true,
+        } }
+        it { should contain_file('/etc/systemd/system/docker.socket.d/socket-overrides.conf').with_content(/root/) }
+      end
+
       context 'with a custom package name' do
         let(:params) { {'docker_ce_package_name' => 'docker-custom-pkg-name' } }
         it { should contain_package('docker').with_name('docker-custom-pkg-name').with_ensure('present') }

--- a/templates/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb
+++ b/templates/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb
@@ -1,0 +1,2 @@
+[Socket]
+SocketGroup=<%= @socket_group %>


### PR DESCRIPTION
This patch allows systemd overrides for the /usr/lib/systemd/system/docker.socket file (new for RHEL as of 18.09.1).  It also allows legacy configs to override setting the socket group in /etc/sysconfig/docker (i.e. no -G setting).

It also causes any changes made to the service or socket overrides.conf to notify the service to restart (before, systemd daemon-reload would occur, but the service was just ordered, not notified).