### PR TITLE
Add ability to override After for docker.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ class { 'docker':
 }
 ```
 
+For more information about the configuration options for the default docker bridge, see the [Docker documentation](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/custom-docker0/).
+
 The default group ownership of the Unix control socket differs based on OS. For example, on RHEL using docker-ce packages >=18.09.1, the socket file used by /usr/lib/systemd/system/docker.socket is owned by the docker group.  To override this value in /etc/sysconfig/docker and docker.socket (e.g. to use the 'root' group):
 
 ```puppet
@@ -144,8 +146,11 @@ The socket_group parameter also takes a boolean for legacy cases where setting -
 docker::socket_group: false
 ```
 
-For more information about the configuration options for the default docker bridge, see the [Docker documentation](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/custom-docker0/).
+To add another service to the After= line in the [Unit] section of the systemd /etc/systemd/system/service-overrides.conf file, use the service_after_override parameter:
 
+```puppet
+docker::service_after_override: containerd.service
+```
 
 When setting up TLS, upload the related files (CA certificate, server certificate, and key) and include their paths in the manifest file:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -498,6 +498,7 @@ class docker(
   Variant[String,Boolean,Undef] $service_overrides_template = $docker::params::service_overrides_template,
   Variant[String,Boolean,Undef] $socket_overrides_template  = $docker::params::socket_overrides_template,
   Optional[Boolean] $socket_override                        = $docker::params::socket_override,
+  Optional[String] $service_after_override                  = $docker::params::service_after_override,
   Optional[Boolean] $service_hasstatus                      = $docker::params::service_hasstatus,
   Optional[Boolean] $service_hasrestart                     = $docker::params::service_hasrestart,
   Optional[String] $registry_mirror                         = $docker::params::registry_mirror,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -120,6 +120,7 @@ class docker::params {
             $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
             $socket_overrides_template  = 'docker/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb'
             $socket_override            = false
+            $service_after_override     = undef
             $service_hasstatus          = true
             $service_hasrestart         = true
             include docker::systemd_reload
@@ -128,6 +129,7 @@ class docker::params {
             $service_overrides_template = undef
             $socket_overrides_template  = undef
             $socket_override            = false
+            $service_after_override     = undef
             $service_provider           = 'upstart'
             $service_hasstatus          = true
             $service_hasrestart         = false
@@ -142,6 +144,7 @@ class docker::params {
           $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
           $socket_overrides_template  = 'docker/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb'
           $socket_override            = false
+          $service_after_override     = undef
           $service_hasstatus          = true
           $service_hasrestart         = true
           include docker::systemd_reload
@@ -192,6 +195,7 @@ class docker::params {
       $service_overrides_template  = 'docker/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb'
       $socket_overrides_template   = 'docker/etc/systemd/system/docker.socket.d/socket-overrides.conf.erb'
       $socket_override             = false
+      $service_after_override      = undef
       $use_upstream_package_source = true
 
       $package_ce_source_location  = "https://download.docker.com/linux/centos/${::operatingsystemmajrelease}/${::architecture}/${docker_ce_channel}"
@@ -264,6 +268,7 @@ class docker::params {
       $service_overrides_template          = undef
       $socket_overrides_template           = undef
       $socket_override                     = false
+      $service_after_override              = undef
       $service_hasstatus                   = undef
       $service_hasrestart                  = undef
       $detach_service_in_init              = true
@@ -292,6 +297,7 @@ class docker::params {
       $service_overrides_template          = undef
       $socket_overrides_template           = undef
       $socket_override                     = false
+      $service_after_override              = undef
       $service_hasstatus                   = undef
       $service_hasrestart                  = undef
       $service_provider                    = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -108,6 +108,7 @@ class docker::service (
   $service_overrides_template        = $docker::service_overrides_template,
   $socket_overrides_template         = $docker::socket_overrides_template,
   $socket_override                   = $docker::socket_override,
+  $service_after_override            = $docker::service_after_override,
   $service_hasstatus                 = $docker::service_hasstatus,
   $service_hasrestart                = $docker::service_hasrestart,
   $daemon_environment_files          = $docker::daemon_environment_files,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -441,6 +441,11 @@ describe 'docker', :type => :class do
         it { should contain_file('/etc/systemd/system/docker.service.d/service-overrides.conf').with_content(/docker.io/) }
       end
 
+      context 'with an extra After entry' do
+        let(:params) {{ 'service_after_override' => 'containerd.service' }}
+        it { should contain_file('/etc/systemd/system/docker.service.d/service-overrides.conf').with_content(/containerd.service/) }
+      end
+
       context 'with a specific socket group and override' do
         let(:params) { { 
            'socket_group'    => 'root',

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -1,3 +1,8 @@
+<% if @service_after_override -%>
+[Unit]
+After=<%= @service_after_override %>
+
+<% end -%>
 [Service]
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -1,3 +1,8 @@
+<% if @service_after_override -%>
+[Unit]
+After=<%= @service_after_override %>
+
+<% end -%>
 [Service]
 EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage


### PR DESCRIPTION
There is a recent patch for docker-ce related to systemd ordering that has not made it to a stable release yet.  In order to apply the workaround, it's necessary to be able to override (add another service) to the After= line in the [Unit] section of docker.service.

Ref: https://github.com/docker/docker-ce-packaging/pull/290

Note that I added the option for Debian too but was not able to test it.