### PR TITLE
docker::services: Fix using multiple published ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ docker::services {'redis':
   }
 ```
 
-To base the service off an image, include the `image` parameter and include the `publish` parameter to expose the service ports. To set the amount of containers running in the service, include the `replicas` parameter. To attach one or multiple filesystems to the service, use the `mounts` parameter. For information regarding the `extra_params` parameter, see `docker service create --help`.
+To base the service off an image, include the `image` parameter and include the `publish` parameter to expose the service port (use an array to specify multiple published ports). To set the amount of containers running in the service, include the `replicas` parameter. To attach one or multiple filesystems to the service, use the `mounts` parameter. For information regarding the `extra_params` parameter, see `docker service create --help`.
 
 To update the service, add the following code to the manifest file:
 

--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -36,7 +36,11 @@ module Puppet::Parser::Functions
       end
     end
 
-    if opts['publish'] && opts['publish'].to_s != 'undef'
+    if opts['publish'].is_a? Array
+      opts['publish'].each do |port|
+        flags << "--publish #{port}"
+      end
+    elsif opts['publish'].to_s != 'undef'
       flags << "--publish '#{opts['publish']}'"
     end
 

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -26,7 +26,7 @@
 #  Defaults to []
 #
 # [*publish*]
-#  Publish a port as a node port.
+#  Publish port(s) as node ports.
 #  Defaults to undef
 #
 # [*replicas*]
@@ -66,6 +66,7 @@
 # [*registry_mirror*]
 #  This will allow the service to set a registry mirror.
 #  defaults to undef
+#
 # [*mounts*]
 #  Allows attacking filesystem mounts to the service (specified as an array)
 #  defaults to []

--- a/spec/defines/services_spec.rb
+++ b/spec/defines/services_spec.rb
@@ -41,6 +41,20 @@ describe 'docker::services', :type => :define do
       it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
       it { should contain_exec('test_service_2 docker service create').with_command(/docker service create/) }
     end
+
+    context 'multiple publish ports' do
+      let(:pre_condition) {
+        "
+        docker::services { 'test_service_3':
+          service_name => 'foo_3',
+          image        => 'foo:bar',
+          publish      => ['80:8080', '9000:9000' ],
+        }
+        "
+      }
+      it { should contain_exec('test_service_3 docker service create').with_command(/--publish 80:8080/) }
+      it { should contain_exec('test_service_3 docker service create').with_command(/--publish 9000:9000/) }
+    end
   end
 
   context 'with ensure => present and service update' do


### PR DESCRIPTION
While the class docker::services already allowed arrays to be
specified for `publish` ports, it didn't handle this correctly since
this array was simply converted to a string and passed onto Docker,
like so:

    --publish '["80:80", "443:443"]'

To correctly publish multiple ports, the `--publish` parameter has to
be called specified for each port.

    --publish '80:80' --publish '443:443'

This patch also introduces a new spec test to check this behavior