### PR TITLE
Docker::Services: Add networks parameter for swarm services

### DIFF
--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -36,6 +36,12 @@ module Puppet::Parser::Functions
       end
     end
 
+    if opts['networks'].is_a? Array
+      opts['networks'].each do |network|
+        flags << "--network #{network}"
+      end
+    end
+
     if opts['publish'].is_a? Array
       opts['publish'].each do |port|
         flags << "--publish #{port}"

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -68,7 +68,11 @@
 #  defaults to undef
 #
 # [*mounts*]
-#  Allows attacking filesystem mounts to the service (specified as an array)
+#  Allows attaching filesystem mounts to the service (specified as an array)
+#  defaults to []
+#
+# [*networks*]
+#  Allows attaching the service to networks (specified as an array)
 #  defaults to []
 #
 # [*command*]
@@ -94,6 +98,7 @@ define docker::services(
   Variant[String,Array,Undef] $host_socket               = undef,
   Variant[String,Array,Undef] $registry_mirror           = undef,
   Variant[String,Array,Undef] $mounts                    = undef,
+  Variant[Array,Undef] $networks                         = undef,
   Variant[String,Array,Undef] $command                   = undef,
 ){
 
@@ -138,6 +143,7 @@ define docker::services(
       host_socket     => $host_socket,
       registry_mirror => $registry_mirror,
       mounts          => $mounts,
+      networks        => $networks,
       command         => $command,
     })
 

--- a/spec/defines/services_spec.rb
+++ b/spec/defines/services_spec.rb
@@ -22,12 +22,14 @@ describe 'docker::services', :type => :define do
       'env'          => ['MY_ENV=1', 'MY_ENV2=2'],
       'label'        => ['com.example.foo="bar"', 'bar=baz'],
       'mounts'       => ['type=bind,src=/tmp/a,dst=/tmp/a', 'type=bind,src=/tmp/b,dst=/tmp/b,readonly'],
+      'networks'     => ['overlay'],
     } }
     it { is_expected.to compile.with_all_deps }
     it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
     it { should contain_exec('test_service docker service create').with_command(/--env MY_ENV=1/) }
     it { should contain_exec('test_service docker service create').with_command(/--label bar=baz/) }
     it { should contain_exec('test_service docker service create').with_command(/--mount type=bind,src=\/tmp\/b,dst=\/tmp\/b,readonly/) }
+    it { should contain_exec('test_service docker service create').with_command(/--network overlay/) }
 
     context 'multiple services declaration' do
       let(:pre_condition) {
@@ -42,18 +44,21 @@ describe 'docker::services', :type => :define do
       it { should contain_exec('test_service_2 docker service create').with_command(/docker service create/) }
     end
 
-    context 'multiple publish ports' do
+    context 'multiple publish ports and multiple networks' do
       let(:pre_condition) {
         "
         docker::services { 'test_service_3':
           service_name => 'foo_3',
           image        => 'foo:bar',
           publish      => ['80:8080', '9000:9000' ],
+          networks     => ['foo_1', 'foo_2'],
         }
         "
       }
       it { should contain_exec('test_service_3 docker service create').with_command(/--publish 80:8080/) }
       it { should contain_exec('test_service_3 docker service create').with_command(/--publish 9000:9000/) }
+      it { should contain_exec('test_service_3 docker service create').with_command(/--network foo_1/) }
+      it { should contain_exec('test_service_3 docker service create').with_command(/--network foo_2/) }
     end
   end
 


### PR DESCRIPTION
Allows attaching the service to one or multiple networks

Also adds spec tests to check the functionality