### PR TITLE
Docker::Services:: fix command parameter used with an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,10 +801,11 @@ docker::services {'redis':
     replicas => '5',
     mounts => ['type=bind,source=/etc/my-redis.conf,target=/etc/redis/redis.conf,readonly'],
     extra_params => ['--update-delay 1m', '--restart-window 30s'],
+    command => ['redis-server', '--appendonly', 'yes'],
   }
 ```
 
-To base the service off an image, include the `image` parameter and include the `publish` parameter to expose the service port (use an array to specify multiple published ports). To set the amount of containers running in the service, include the `replicas` parameter. To attach one or multiple filesystems to the service, use the `mounts` parameter. For information regarding the `extra_params` parameter, see `docker service create --help`.
+To base the service off an image, include the `image` parameter and include the `publish` parameter to expose the service port (use an array to specify multiple published ports). To set the amount of containers running in the service, include the `replicas` parameter. To attach one or multiple filesystems to the service, use the `mounts` parameter. For information regarding the `extra_params` parameter, see `docker service create --help`. The `command` parameter can either be specified as an array or a string.
 
 To update the service, add the following code to the manifest file:
 

--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -84,7 +84,9 @@ module Puppet::Parser::Functions
       flags << "'#{opts['image']}'"
     end
 
-    if opts['command'] && opts['command'].to_s != 'undef'
+    if opts['command'].is_a? Array
+      flags << opts['command'].join(' ')
+    elsif opts['command'] && opts['command'].to_s != 'undef'
       flags << opts['command'].to_s
     end
 

--- a/spec/defines/services_spec.rb
+++ b/spec/defines/services_spec.rb
@@ -23,6 +23,7 @@ describe 'docker::services', :type => :define do
       'label'        => ['com.example.foo="bar"', 'bar=baz'],
       'mounts'       => ['type=bind,src=/tmp/a,dst=/tmp/a', 'type=bind,src=/tmp/b,dst=/tmp/b,readonly'],
       'networks'     => ['overlay'],
+      'command'      => 'echo hello world',
     } }
     it { is_expected.to compile.with_all_deps }
     it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
@@ -30,6 +31,7 @@ describe 'docker::services', :type => :define do
     it { should contain_exec('test_service docker service create').with_command(/--label bar=baz/) }
     it { should contain_exec('test_service docker service create').with_command(/--mount type=bind,src=\/tmp\/b,dst=\/tmp\/b,readonly/) }
     it { should contain_exec('test_service docker service create').with_command(/--network overlay/) }
+    it { should contain_exec('test_service docker service create').with_command(/echo hello world/) }
 
     context 'multiple services declaration' do
       let(:pre_condition) {
@@ -37,11 +39,13 @@ describe 'docker::services', :type => :define do
         docker::services { 'test_service_2':
           service_name => 'foo_2',
           image        => 'foo:bar',
+          command      => ['echo', 'hello', 'world'],
         }
         "
       }
       it { should contain_exec('test_service docker service create').with_command(/docker service create/) }
       it { should contain_exec('test_service_2 docker service create').with_command(/docker service create/) }
+      it { should contain_exec('test_service_2 docker service create').with_command(/echo hello world/) }
     end
 
     context 'multiple publish ports and multiple networks' do
@@ -60,6 +64,7 @@ describe 'docker::services', :type => :define do
       it { should contain_exec('test_service_3 docker service create').with_command(/--network foo_1/) }
       it { should contain_exec('test_service_3 docker service create').with_command(/--network foo_2/) }
     end
+
   end
 
   context 'with ensure => present and service update' do


### PR DESCRIPTION
The module previously allowed specifying the command parameter to
docker::services as an array, but did not correctly parse it as
such (output with square brackets and quotations marks to docker).
This patch fixes this behavior.