### PR TITLE
WIP: Allow use of .env configuration file when running docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,9 +628,18 @@ docker_compose { 'test':
   scale   => {
     'compose_test' => 2,
   },
-  options => '--x-networking'
+  options => ['--x-networking'],
 }
 ```
+
+To use a .env configuration file, specify a project directory.
+```puppet
+docker_compose { 'test':
+  compose_files => ['/tmp/docker-compose.yml'],
+  ensure  => present,
+  options => ['--project-directory', '/tmp']
+}
+``` 
 
 Give options to the ```docker-compose up``` command, such as ```--remove-orphans```, by using the ```up_args``` option.
 
@@ -638,7 +647,7 @@ To supply multiple overide compose files add the following to the manifest file:
 
 ```puppet
 docker_compose {'test':
-  compose_files => ['master-docker-compose.yml', 'override-compose.yml],
+  compose_files => ['master-docker-compose.yml', 'override-compose.yml'],
 }
 ```
 

--- a/lib/puppet/type/docker_compose.rb
+++ b/lib/puppet/type/docker_compose.rb
@@ -22,17 +22,17 @@ Puppet::Type.newtype(:docker_compose) do
     end
   end
 
-  newparam(:options) do
+  newparam(:options, array_matching: :all) do
     desc 'Additional options to be passed directly to docker-compose.'
     validate do |value|
-      raise _('options should be a String') unless value.is_a? String
+      raise _('options should be an array') unless value.is_a? Array
     end
   end
 
-  newparam(:up_args) do
+  newparam(:up_args, array_matching: :all) do
     desc 'Arguments to be passed directly to docker-compose up.'
     validate do |value|
-      raise _('up_args should be a String') unless value.is_a? String
+      raise _('up_args should be an array') unless value.is_a? Array
     end
   end
 


### PR DESCRIPTION
I was trying to use a .env file when running docker-compose by specifying the project directory as an `option`. I had to modify the options parameter to accept an array to get it to work.