### PR TITLE
Update docker compose version to latest

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,7 @@ class docker::params {
     $tls_cacert                        = '/etc/docker/tls/ca.pem'
     $tls_cert                          = '/etc/docker/tls/cert.pem'
     $tls_key                           = '/etc/docker/tls/key.pem'
-    $compose_version                   = '1.9.0'
+    $compose_version                   = '1.23.2'
     $compose_install_path              = '/usr/local/bin'
   }
   $ip_forward                        = true


### PR DESCRIPTION
I havent tested it extensively so if there is a special reason you are using an old version then this PR is moot.

https://github.com/docker/compose/releases