### PR TITLE
Fix docker::image to not run images

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -153,5 +153,5 @@ define docker::image(
     }
   }
 
-  Docker::Image <| title == $title |> -> Docker::Run <| image == $image_arg |>
+  Docker::Image <| title == $title |>
 }


### PR DESCRIPTION
According the documentation, the resource docker::image should just to pull an image, not properly try to run.

```
To install a Docker image, add the docker::image defined type to the manifest file:

docker::image { 'base': }
The code above is equivalent to running the docker pull base command. However, it removes the default five-minute execution timeout.
```