### PR TITLE
Allow images tagged latest to update on each run

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -140,7 +140,21 @@ define docker::image(
       timeout     => $exec_timeout,
       logoutput   => true,
     }
-  } elsif $ensure == 'latest' or $image_tag == 'latest' or $ensure == 'present' {
+  } elsif $ensure == 'latest' or $image_tag == 'latest' {
+    notify { "Check if image ${image_arg} is in-sync":
+      noop      => false,
+    }
+    ~> exec { "echo 'Update of ${image_arg} complete'":
+      environment => $exec_environment,
+      path        => $exec_path,
+      timeout     => $exec_timeout,
+      onlyif      => $image_install,
+      require     => File[$update_docker_image_path],
+      provider    => $exec_provider,
+      logoutput   => true,
+      refreshonly => true,
+    }
+  } elsif $ensure == 'present' {
     exec { $image_install:
       unless      => $_image_find,
       environment => $exec_environment,

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -134,17 +134,17 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => latest' do
     let(:params) { { 'ensure' => 'latest' } }
-    it { should contain_exec("/usr/local/bin/update_docker_image.sh base") }
+    it { should contain_exec("echo 'Update of base complete'").with_onlyif('/usr/local/bin/update_docker_image.sh base') }
   end
 
   context 'with ensure => latest and image_tag => precise' do
     let(:params) { { 'ensure' => 'latest', 'image_tag' => 'precise' } }
-    it { should contain_exec("/usr/local/bin/update_docker_image.sh base:precise") }
+    it { should contain_exec("echo 'Update of base:precise complete'") }
   end
 
   context 'with ensure => latest and image_digest => sha256:deadbeef' do
     let(:params) { { 'ensure' => 'latest', 'image_digest' => 'sha256:deadbeef' } }
-    it { should contain_exec("/usr/local/bin/update_docker_image.sh base@sha256:deadbeef") }
+    it { should contain_exec("echo 'Update of base@sha256:deadbeef complete'") }
   end
 
   context 'with an invalid image name' do

--- a/spec/defines/image_windows_spec.rb
+++ b/spec/defines/image_windows_spec.rb
@@ -48,7 +48,7 @@ describe 'docker::image', :type => :define do
     
     context 'with ensure => latest' do
         let(:params) { { 'ensure' => 'latest' } }
-        it { should contain_exec("& C:/Users/Administrator/AppData/Local/Temp/update_docker_image.ps1 -DockerImage base") }
+        it { should contain_exec("echo 'Update of base complete'").with_onlyif('& C:/Users/Administrator/AppData/Local/Temp/update_docker_image.ps1 -DockerImage base') }
     end
 
 end


### PR DESCRIPTION
Restore the code to update images tagged with 'latest' on each run,
moving this to be guarded by a refreshonly meta-parameter that is
triggered by a notify resource that is disabled for 'noop'.

Because the original code to update images was run via 'onlyif' to
indicate if the image was in sync by performing a pull and testing the
new digest against the old, this meant that simply applying 'noop' to
this exec resource would not work. 'noop' does not affect running the
components of a resource to validate if it is in-sync, which is the
purpose of the 'onlyif' & 'unless' settings for an exec.

To support 'noop' mode, previously the code to update the image on each
run was dropped to prevent it accidentally refreshing the local image
and then skipping an image restart because there was no update event on
a subsequent real run.

To resolve, it is necessary to have a prior resource that is used as a
proxy, and only when it notifies the image update resource, will the
'onlyif' action be tested to determine if in sync. This prior resource
can be disabled from a noop run, and subsequently although puppet
records that it would send a refresh event in 'noop' mode, none are
actually sent during a 'noop' run thus preventing the image from being
updated by a side effect of checking if the notified exec was in-sync.

Fixes #316