### PR TITLE
Fix publish flag being erroneously added to docker service commands

### DIFF
--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -46,7 +46,7 @@ module Puppet::Parser::Functions
       opts['publish'].each do |port|
         flags << "--publish #{port}"
       end
-    elsif opts['publish'].to_s != 'undef'
+    elsif opts['publish'] && opts['publish'].to_s != 'undef'
       flags << "--publish '#{opts['publish']}'"
     end
 


### PR DESCRIPTION
Currently adding a `docker::services` resource without publishing any ports in puppet6 fails as the command is run with the invalid flag: `--publish ''`.
