### PR TITLE
Add missing apostrophe in array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ docker::run { 'helloworld':
   ports            => ['4444', '4555'],
   expose           => ['4666', '4777'],
   links            => ['mysql:db'],
-  net              => ['my-user-def-net','my-user-def-net-2],
+  net              => ['my-user-def-net','my-user-def-net-2'],
   disable_network  => false,
   volumes          => ['/var/lib/couchdb', '/var/log'],
   volumes_from     => '6446ea52fbc9',


### PR DESCRIPTION
The net array was missing an apostrophe after the second element, which led to a corruption in the syntax display.