### PR TITLE
Allow bypassing curl package ensure if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ class { 'docker':
 }
 ```
 
+If the curl package is being managed elsewhere and the curl ensure in this module is conflicting,
+ it can be disabled by setting the following parameter globally or in compose / machine resources:
+```puppet
+class { 'docker':
+  curl_ensure => false
+}
+```
+
 ### Proxy on Windows
 
 To use docker through a proxy on Windows, a System Environment Variable HTTP_PROXY/HTTPS_PROXY must be set. See [Docker Engine on Windows](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-docker/configure-docker-daemon#proxy-configuration)

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -37,6 +37,10 @@
 #   responsible for ensuring the URL points to the correct version and
 #   architecture.
 
+# [*curl_ensure*]
+#   Whether or not the curl package is ensured by this module.
+#   Defaults to true
+#
 class docker::compose(
   Optional[Pattern[/^present$|^absent$/]] $ensure          = 'present',
   Optional[String] $version                                = $docker::params::compose_version,
@@ -44,7 +48,8 @@ class docker::compose(
   Optional[String] $symlink_name                           = $docker::params::compose_symlink_name,
   Optional[String] $proxy                                  = undef,
   Optional[String] $base_url                               = $docker::params::compose_base_url,
-  Optional[String] $raw_url                                = undef
+  Optional[String] $raw_url                                = undef,
+  Optional[Boolean] $curl_ensure                           = $docker::params::curl_ensure,
 ) inherits docker::params {
 
   if $proxy != undef {
@@ -93,7 +98,9 @@ class docker::compose(
         require => Exec["Install Docker Compose ${version}"]
       }
     } else {
-      ensure_packages(['curl'])
+      if $curl_ensure {
+        ensure_packages(['curl'])
+      }
       exec { "Install Docker Compose ${version}":
         path    => '/usr/bin/',
         cwd     => '/tmp',

--- a/manifests/machine.pp
+++ b/manifests/machine.pp
@@ -23,12 +23,17 @@
 # [*url*]
 #   The URL from which the docker machine binary should be fetched
 #   Defaults to a auto determined value based on version, kernel and OS.
+# 
+# [*curl_ensure*]
+#   Whether or not the curl package is ensured by this module.
+#   Defaults to true
 class docker::machine(
   Optional[Pattern[/^present$|^absent$/]]              $ensure       = 'present',
   Optional[String]                                     $version      = $docker::params::machine_version,
   Optional[String]                                     $install_path = $docker::params::machine_install_path,
   Optional[String]                                     $proxy        = undef,
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $url          = undef,
+  Optional[Boolean]                                    $curl_ensure  = $docker::params::curl_ensure,
 ) inherits docker::params {
 
   if $proxy != undef {
@@ -75,7 +80,9 @@ class docker::machine(
         require => Exec["Install Docker Machine ${version}"]
       }
     } else {
-      ensure_packages(['curl'])
+      if $curl_ensure {
+        ensure_packages(['curl'])
+      }
       exec { "Install Docker Machine ${version}":
         path    => '/usr/bin/',
         cwd     => '/tmp',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,6 +109,7 @@ class docker::params {
   $storage_pool_autoextend_percent   = undef
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $registry_mirror                   = undef
+  $curl_ensure                       = true
   $os_lc                             = downcase($::operatingsystem)
   $docker_msft_provider_version      = undef
   $nuget_package_provider_version    = undef


### PR DESCRIPTION
Even with ensure_packages, there can be resource duplication errors if the parameters do not match.  Add an option not to ensure the curl package (curl package is ensured by default to maintain status quo).