### PR TITLE
(MODULES-9177) Fix version validation regex

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -594,7 +594,7 @@ class docker(
     }
   }
 
-  if ( $version == undef ) or ( $version !~ /^(17[.]0[0-5][.][0-1](~|-|\.)ce|1.\d+)/ ) {
+  if ( $version == undef ) or ( $version !~ /^(1[7-8][.][0-1][0-9][.][0-1](~|-|\.)ce|1.\d+)/ ) {
     if ( $docker_ee) {
       $package_location = $docker::docker_ee_source_location
       $package_key_source = $docker::docker_ee_key_source

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -847,11 +847,11 @@ describe 'docker', type: :class do
         it { is_expected.to contain_file(service_config_file).with_content(%r{-g \/mnt\/docker}) }
       end
 
-      context 'with custom root dir && Docker version > 17.05' do
+      context 'with custom root dir && Docker version > 18.09' do
         let(:params) do
           {
             'root_dir' => '/mnt/docker',
-            'version' => '18.03',
+            'version' => '19.09',
           }
         end
 


### PR DESCRIPTION
The regexes used in init.pp assumed that the supplied docker version
would have to start with 17, however docker is now at 18.