### PR TITLE
(MODULES-9193) Revert part of MODULES-9177

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -594,7 +594,7 @@ class docker(
     }
   }
 
-  if ( $version == undef ) or ( $version !~ /^(1[7-8][.][0-1][0-9][.][0-1](~|-|\.)ce|1.\d+)/ ) {
+  if ( $version == undef ) or ( $version !~ /^(17[.][0-1][0-9][.][0-1](~|-|\.)ce|1.\d+)/ ) {
     if ( $docker_ee) {
       $package_location = $docker::docker_ee_source_location
       $package_key_source = $docker::docker_ee_key_source
@@ -660,6 +660,7 @@ class docker(
   } else {
     $root_dir_flag = '--data-root'
   }
+
 
   if $ensure != 'absent' {
     contain 'docker::repos'


### PR DESCRIPTION
The changes introduced in MODULES-9177 modified the behaviour of docker
installs using older versions. The first part of the modified regex ensured
that the correct repository was used. As such I have reverted it but
left the rest of the changes to ensure that non 17.y.z versions use the
correct repo.