### PR TITLE
Fix #239 local_user permission denied

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -33,12 +33,12 @@ Facter.add(:docker_user_temp_path) do
 end
 
 Facter.add(:docker_home_dirs) do
-  confine :kernel => 'Linux'
+  confine kernel: 'Linux'
   setcode do
     home_dirs = {}
-    Etc.passwd { |user|
+    Etc.passwd do |user|
       home_dirs[user.name] = user.dir
-    }
+    end
     home_dirs
   end
 end

--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -2,6 +2,7 @@
 
 require 'facter'
 require 'json'
+require 'etc'
 
 Facter.add(:docker_systemroot) do
   confine osfamily: :windows
@@ -28,6 +29,17 @@ Facter.add(:docker_user_temp_path) do
   confine osfamily: :windows
   setcode do
     Puppet::Util.get_env('TEMP')
+  end
+end
+
+Facter.add(:docker_home_dirs) do
+  confine :kernel => 'Linux'
+  setcode do
+    home_dirs = {}
+    Etc.passwd { |user|
+      home_dirs[user.name] = user.dir
+    }
+    home_dirs
   end
 end
 

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -61,6 +61,7 @@ define docker::registry(
     $exec_provider = undef
     $password_env = "\${password}"
     $exec_user = $local_user
+    $local_user_home = $facts['docker_home_dirs'][$local_user]
   }
 
   if $ensure == 'present' {
@@ -103,11 +104,13 @@ define docker::registry(
         Undef   => pw_hash($docker_auth, 'SHA-512', $local_user_strip),
         default => $pass_hash
       }
-      $_auth_command = "${auth_cmd} || rm -f \"/root/registry-auth-puppet_receipt_${server_strip}_${local_user}\""
+      $_auth_command = "${auth_cmd} || rm -f \"/${local_user_home}/registry-auth-puppet_receipt_${server_strip}_${local_user}\""
 
-      file { "/root/registry-auth-puppet_receipt_${server_strip}_${local_user}":
+      file { "/${local_user_home}/registry-auth-puppet_receipt_${server_strip}_${local_user}":
         ensure  => $ensure,
         content => $_pass_hash,
+        owner   => $local_user,
+        group   => $local_user,
         notify  => Exec["${title} auth"],
       }
     } else {

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -10,6 +10,9 @@ describe 'docker::registry', type: :define do
       lsbdistcodename: 'jessie',
       kernelrelease: '3.2.0-4-amd64',
       operatingsystemmajrelease: '8',
+      docker_home_dirs: {
+        root: '/root',
+      },
     }
   end
   let(:params) { { 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }


### PR DESCRIPTION
This is an approach to fixing the `local_user` permission issues (fixes #239). Instead of writing to `/root` the users home directory is used.