### PR TITLE
Fix aliased plugin names

### DIFF
--- a/lib/puppet/parser/functions/docker_plugin_enable_flags.rb
+++ b/lib/puppet/parser/functions/docker_plugin_enable_flags.rb
@@ -12,8 +12,8 @@ module Puppet::Parser::Functions
     flags << '--force' if opts['force_remove'] == true
     if opts['plugin_alias'] && opts['plugin_alias'].to_s != 'undef'
       flags << "'#{opts['plugin_alias']}'"
-    else
-      flags << "'#{opts['plugin_name']}'" if opts['plugin_name'] && opts['plugin_name'].to_s != 'undef'
+    elsif opts['plugin_name'] && opts['plugin_name'].to_s != 'undef'
+      flags << "'#{opts['plugin_name']}'"
     end
     flags.flatten.join(' ')
   end

--- a/lib/puppet/parser/functions/docker_plugin_enable_flags.rb
+++ b/lib/puppet/parser/functions/docker_plugin_enable_flags.rb
@@ -10,7 +10,11 @@ module Puppet::Parser::Functions
     opts = args[0] || {}
     flags = []
     flags << '--force' if opts['force_remove'] == true
-    flags << "'#{opts['plugin_name']}'" if opts['plugin_name'] && opts['plugin_name'].to_s != 'undef'
+    if opts['plugin_alias'] && opts['plugin_alias'].to_s != 'undef'
+      flags << "'#{opts['plugin_alias']}'"
+    else
+      flags << "'#{opts['plugin_name']}'" if opts['plugin_name'] && opts['plugin_name'].to_s != 'undef'
+    end
     flags.flatten.join(' ')
   end
 end

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -79,7 +79,7 @@ define docker::plugin(
     })
 
     $exec_install = "${docker_command} install ${docker_plugin_install_flags}"
-    $unless_install = "${docker_command} ls | grep -w ${plugin_name}"
+    $unless_install = "${docker_command} ls --format='{{.PluginReference}}' | grep -w ${plugin_name}"
 
     exec { "plugin install ${plugin_name}":
       command     => $exec_install,
@@ -95,7 +95,7 @@ define docker::plugin(
     })
 
     $exec_rm = "${docker_command} rm ${docker_plugin_remove_flags}"
-    $onlyif_rm = "${docker_command} ls | grep -w ${plugin_name}"
+    $onlyif_rm = "${docker_command} ls --format='{{.PluginReference}}' | grep -w ${plugin_name}"
 
     exec { "plugin remove ${plugin_name}":
       command     => $exec_rm,
@@ -109,11 +109,12 @@ define docker::plugin(
   if $enabled {
     $docker_plugin_enable_flags = docker_plugin_enable_flags({
       plugin_name => $plugin_name,
+      plugin_alias => $plugin_alias,
       timeout => $timeout,
     })
 
     $exec_enable = "${docker_command} enable ${docker_plugin_enable_flags}"
-    $onlyif_enable = "${docker_command} ls -f enabled=false | grep -w ${plugin_name}"
+    $onlyif_enable = "${docker_command} ls -f enabled=false --format='{{.PluginReference}}' | grep -w ${plugin_name}"
 
     exec { "plugin enable ${plugin_name}":
       command     => $exec_enable,
@@ -129,7 +130,7 @@ define docker::plugin(
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
       timeout     => 0,
-      unless      => "${docker_command} ls -f enabled=false | grep -w ${plugin_name}",
+      unless      => "${docker_command} ls -f enabled=false --format='{{.PluginReference}}' | grep -w ${plugin_name}",
     }
   }
 }

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -15,20 +15,27 @@ describe 'docker::plugin', type: :define do
 
   context 'with defaults for all parameters' do
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}) }
+    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}).with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
 
   context 'with enabled => false' do
     let(:params) { { 'enabled' => false } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec('disable foo/plugin:latest').with_command(%r{docker plugin disable}) }
+    it { is_expected.to contain_exec('disable foo/plugin:latest').with_command(%r{docker plugin disable}).with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
 
   context 'with ensure => absent' do
     let(:params) { { 'ensure' => 'absent' } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec('plugin remove foo/plugin:latest').with_command(%r{docker plugin rm}) }
+    it { is_expected.to contain_exec('plugin remove foo/plugin:latest').with_command(%r{docker plugin rm}).with_onlyif(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
+
+  context 'with alias => foo-plugin' do
+    let(:params) { { 'plugin_alias' => 'foo-plugin' } }
+
+    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}).with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
+  end
+
 end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -15,27 +15,30 @@ describe 'docker::plugin', type: :define do
 
   context 'with defaults for all parameters' do
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}).with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
+    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}) }
+    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
 
   context 'with enabled => false' do
     let(:params) { { 'enabled' => false } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec('disable foo/plugin:latest').with_command(%r{docker plugin disable}).with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
+    it { is_expected.to contain_exec('disable foo/plugin:latest').with_command(%r{docker plugin disable}) }
+    it { is_expected.to contain_exec('disable foo/plugin:latest').with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
 
   context 'with ensure => absent' do
     let(:params) { { 'ensure' => 'absent' } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec('plugin remove foo/plugin:latest').with_command(%r{docker plugin rm}).with_onlyif(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
+    it { is_expected.to contain_exec('plugin remove foo/plugin:latest').with_command(%r{docker plugin rm}) }
+    it { is_expected.to contain_exec('plugin remove foo/plugin:latest').with_onlyif(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
 
   context 'with alias => foo-plugin' do
     let(:params) { { 'plugin_alias' => 'foo-plugin' } }
 
-    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}).with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
+    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_command(%r{docker plugin install}) }
+    it { is_expected.to contain_exec('plugin install foo/plugin:latest').with_unless(%r{docker ls --format='{{.PluginReference}}' | grep -w foo/plugin:latest}) }
   end
-
 end


### PR DESCRIPTION
#### What change does this introduce?

- Adds the option `plugin_alias` to `docker_plugin_enable_flags`.
- Adds `--format='{{.PluginReference}}'` to the plugin ls commands.

#### Why make this change?

Current code assumes that plugin_name is the same as plugin_alias, even though plugin_alias is parameter.

#### What issues does this relate to?

- #510 
