### PR TITLE
(MODULES-9696) remove docker_home_dirs fact

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -2,7 +2,6 @@
 
 require 'facter'
 require 'json'
-require 'etc'
 
 Facter.add(:docker_systemroot) do
   confine osfamily: :windows
@@ -29,17 +28,6 @@ Facter.add(:docker_user_temp_path) do
   confine osfamily: :windows
   setcode do
     Puppet::Util.get_env('TEMP')
-  end
-end
-
-Facter.add(:docker_home_dirs) do
-  confine kernel: 'Linux'
-  setcode do
-    home_dirs = {}
-    Etc.passwd do |user|
-      home_dirs[user.name] = user.dir
-    end
-    home_dirs
   end
 end
 

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -10,9 +10,6 @@ describe 'docker::registry', type: :define do
       lsbdistcodename: 'jessie',
       kernelrelease: '3.2.0-4-amd64',
       operatingsystemmajrelease: '8',
-      docker_home_dirs: {
-        root: '/root',
-      },
     }
   end
   let(:params) { { 'version' => '17.06', 'pass_hash' => 'test1234', 'receipt' => false } }


### PR DESCRIPTION
enumerating existing users is insecure and resource consuming
user with non-standard home needs to path it explicitly when creating docker::registry resource