### PR TITLE
(GH-1097) Add mint support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -328,9 +328,9 @@ class docker::params {
   # https://github.com/docker/docker/issues/4734
   $prerequired_packages = $::osfamily ? {
     'Debian' => $::operatingsystem ? {
-      'Debian' => ['cgroupfs-mount'],
       'Ubuntu' => ['cgroup-lite', 'apparmor'],
-      default  => [],
+      'LinuxMint' => ['cgroup-lite', 'apparmor'],
+      default => ['cgroupfs-mount'],
     },
     'RedHat' => ['device-mapper'],
     default  => [],


### PR DESCRIPTION
This allows the docker module to be installed on Mint systems, as though
they were ubuntu systems, without having to change Mint system facts.
Specifically it changes the OS names when installing pre-required
packages so that the default for all Debian family OSes is the same as
the Debian required packages, and so that Mint and Ubuntu install the
same packages.