### PR TITLE
:bug: Fix wrong service detach handling

### DIFF
--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -10,12 +10,12 @@ module Puppet::Parser::Functions
     opts = args[0] || {}
     flags = []
 
-    if opts['detach'].to_s != 'true'
-      flags << '--detach'
-    end
-
     if opts['service_name'] && opts['service_name'].to_s != 'undef'
       flags << "'#{opts['service_name']}'"
+    end
+
+    if opts['detach'].to_s != 'false'
+      flags << '--detach'
     end
 
     if opts['env'].is_a? Array


### PR DESCRIPTION
the service_name always needs to be first argument in the flags array, otherwise the `service create` cmd results in a wrong order / syntax:

https://github.com/puppetlabs/puppetlabs-docker/blob/master/manifests/services.pp#L150

besides that, checking "if not true" results in the opposite behaviour as expected.
which means, setting the puppet param detach to true, results in not setting it on the cmd :) 