### PR TITLE
Fix multiple additional flags for docker_network

### DIFF
--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -23,11 +23,16 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
       ['--ipam-driver=%s',  :ipam_driver],
       ['--aux-address=%s',  :aux_address],
       ['--opt=%s',          :options],
-      ['%s',                :additional_flags],
     ].each do |(format, key)|
       values    = resource[key]
       new_flags = multi_flags.call(values, format)
       flags.concat(new_flags)
+    end
+    if resource[:additional_flags].is_a?(String)
+      additional_flags = resource[:additional_flags].split
+      additional_flags.each do |additional_flag|
+        flags << additional_flag
+      end
     end
     flags << resource[:name]
   end

--- a/spec/unit/lib/puppet/type/docker_network_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_network_spec.rb
@@ -12,6 +12,7 @@ describe network do
       :ip_range,
       :aux_address,
       :options,
+      :additional_flags,
     ]
   end
 


### PR DESCRIPTION
I tried to create docker network with multiple additional parameters like:
_docker_network { 'db_net'_
_.._
_additional_flags => '--scope swarm --attachable --internal --config-from db_net_config',_
_.._
but Docker complained about uknown flag:

> Error: Execution of '/usr/bin/docker network create --driver=macvlan --scope swarm --attachable --internal --config-from db_net_config db_net' returned 125: unknown flag: --scope swarm --attachable --internal --config-from db_net_config
See 'docker network create --help'.

While running the command by simple copy&paste worked just fine:
>~# /usr/bin/docker network create --driver=macvlan --scope swarm --attachable --internal --config-from db_net_config db_net
ep37zquecbh4qp5ks06n1v244

Each additional flag has to be pushed as extra String otherwise
Docker will complain about uknown flag.

I don't know how to write tests but even clean repository fails _bundle exec rake spec_ on Ubuntu 19.04 with:

> Failures:

  1)  create creates a docker network
     Failure/Error: expect(provider.create).to be_nil
     
     NoMethodError:
       undefined method `create' for nil:NilClass
     # ./spec/unit/lib/puppet/provider/docker_network_spec.rb:22:in `block (3 levels) in <top (required)>'
