### PR TITLE
pdksync - Add support on Debian10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8.0",
-        "9.0"
+        "9.0",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
Add support on Debian10
pdk version: `1.10.0` 
