### PR TITLE
Move StartLimit* options to [Unit], fix StartLimitIntervalSec

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -17,11 +17,11 @@ Description=Daemon for <%= @title %>
 After=<%= @after.uniq.join(" ") %>
 Wants=<%= @wants.uniq.join(" ") %>
 Requires=<%= @requires.uniq.join(" ") %>
+StartLimitIntervalSec=20
+StartLimitBurst=5
 
 [Service]
 Restart=<%= @systemd_restart %>
-StartLimitInterval=20
-StartLimitBurst=5
 TimeoutStartSec=0
 RestartSec=5
 Environment="HOME=/root"


### PR DESCRIPTION
Fixes https://github.com/puppetlabs/puppetlabs-docker/issues/456

Signed-off-by: Rune Juhl Jacobsen <runejuhl@petardo.dk>