### PR TITLE
Option to specify a custom timeout for building a docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,17 @@ docker_stack { 'test':
 
 To remove the stack, set `ensure  => absent`.
 
+There is an optional timout setting which is usefull if your stack takes longe than the default 5 minutes to build. You ncan specify the timout in seconds like this.
+```puppet
+ docker::stack { 'yourapp':
+   ensure  => present,
+   stack_name => 'yourapp',
+   compose_files => ['/tmp/docker-compose.yaml'],
+   require => [Class['docker'], File['/tmp/docker-compose.yaml']],
+   timeout => 600,
+}
+```
+
 ### Machine
 
 You can use Docker Machine to install Docker Engine on virtual hosts, and manage the hosts with docker-machine commands. You can also use Machine to create Docker hosts on your local Mac or Windows box, on your company network, in your data center, or on cloud providers like Azure, AWS, or Digital Ocean.

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ docker_stack { 'test':
 
 To remove the stack, set `ensure  => absent`.
 
-There is an optional timout setting which is usefull if your stack takes longe than the default 5 minutes to build. You ncan specify the timout in seconds like this.
+There is an optional timeout setting which is usefull if your stack takes longer than the default 5 minutes to build. You can specify the timout (in seconds) like this.
 ```puppet
  docker::stack { 'yourapp':
    ensure  => present,

--- a/manifests/stack.pp
+++ b/manifests/stack.pp
@@ -33,6 +33,10 @@
 # [*with_registry_auth*]
 #  Send registry authentication details to Swarm agents
 #  Defaults to undef
+#
+# [*timeout*]
+#  Adjust the timeout for deploying a docker stack in seconds
+#  Defaults to 300
 
 define docker::stack(
 
@@ -43,6 +47,7 @@ define docker::stack(
   Optional[Boolean] $prune                                       = false,
   Optional[Boolean] $with_registry_auth                          = false,
   Optional[Pattern[/^always$|^changed$|^never$/]] $resolve_image = undef,
+  Optional[Integer] $timeout                                     = 300,
 ){
 
   include docker::params
@@ -80,6 +85,7 @@ define docker::stack(
       unless   => $check_stack,
       path     => $exec_path,
       provider => $provider,
+      timeout  => $timeout,
     }
   }
 

--- a/manifests/stack.pp
+++ b/manifests/stack.pp
@@ -35,7 +35,7 @@
 #  Defaults to undef
 #
 # [*timeout*]
-#  Adjust the timeout for deploying a docker stack in seconds
+#  Adjust the timeout for deploying a docker stack (in seconds)
 #  Defaults to 300
 
 define docker::stack(
@@ -96,6 +96,7 @@ define docker::stack(
       onlyif   => $check_stack,
       path     => $exec_path,
       provider => $provider,
+      timeout  => $timeout,
     }
   }
 }


### PR DESCRIPTION
I actually requested this feature myself in https://github.com/puppetlabs/puppetlabs-docker/issues/540 
turns out it wasn't too difficult to implement