### PR TITLE
feature/match_docker_windows_version

### DIFF
--- a/templates/windows/check_powershell_provider.ps1.erb
+++ b/templates/windows/check_powershell_provider.ps1.erb
@@ -40,7 +40,7 @@ If ($package -eq $null) {
 
 <% if @version -%>
 Write-Information "Checking Docker package version"
-if ($package.Version.ToString() -ne  "<%= @version %>"){
+if ($package.Version.ToString() -notmatch  "<%= @version %>"){
     Write-Error "Incorrect Docker package version installed."
     Exit 1
 }


### PR DESCRIPTION
On Windows `-notmatch` instead of `-ne` on version compared.  This will allow the use of version channels from DockerMsftProvier.  

PR for proposed solution at:

https://github.com/puppetlabs/puppetlabs-docker/issues/542