### PR TITLE
Allow defining the name of the docker-compose symlink

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -17,6 +17,12 @@
 #   The path where to install Docker Compose.
 #   Defaults to the value set in $docker::params::compose_install_path
 #
+# [*symlink_name*]
+#   The name of the symlink created pointing to the actual docker-compose binary
+#   This allows use of own docker-compose wrapper scripts for the times it's
+#   necessary to set certain things before running the docker-compose binary
+#   Defaults to the value set in $docker::params::compose_symlink_name
+#
 # [*proxy*]
 #   Proxy to use for downloading Docker Compose.
 #
@@ -35,6 +41,7 @@ class docker::compose(
   Optional[Pattern[/^present$|^absent$/]] $ensure          = 'present',
   Optional[String] $version                                = $docker::params::compose_version,
   Optional[String] $install_path                           = $docker::params::compose_install_path,
+  Optional[String] $symlink_name                           = $docker::params::compose_symlink_name,
   Optional[String] $proxy                                  = undef,
   Optional[String] $base_url                               = $docker::params::compose_base_url,
   Optional[String] $raw_url                                = undef
@@ -52,7 +59,7 @@ class docker::compose(
     $file_owner = 'root'
   }
 
-  $docker_compose_location = "${install_path}/docker-compose${file_extension}"
+  $docker_compose_location = "${install_path}/${symlink_name}${file_extension}"
   $docker_compose_location_versioned = "${install_path}/docker-compose-${version}${file_extension}"
 
   if $ensure == 'present' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,6 +69,7 @@ class docker::params {
   $dns_search                        = undef
   $proxy                             = undef
   $compose_base_url                  = 'https://github.com/docker/compose/releases/download'
+  $compose_symlink_name              = 'docker-compose'
   $no_proxy                          = undef
   $execdriver                        = undef
   $storage_driver                    = undef


### PR DESCRIPTION
I bumped into a problem with docker-compose where every docker-compose command failed with:

```
docker compose: Error while loading shared libraries: libz.so.1: failed to map segment from shared object: Operation not permitted
```
 
Found out it's related to docker-composes use of the environment variable `TMPDIR`, usually pointing to /tmp or /var/tmp, and that docker-compose expects to be able to run scripts from this path. Being able to run scripts from these locations is not a security best practice, so I made a wrapper script installed at `/usr/local/bin/docker-compose` where I set TMPDIR to a safer location, before running the actual docker-compose binary. This wrapper script now conflicts with the default symlink file created by this fabulous module, so this PR adds the ability to give this symlink another name.

The issues I'm referring to is also described in more detail on this stackoverflow post:
https://stackoverflow.com/questions/57796839/docker-compose-error-while-loading-shared-libraries-libz-so-1-failed-to-map-s

