### PR TITLE
Add option for RemainAfterExit

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -92,12 +92,6 @@
 # configuration.
 # Default: Not included in unit file
 #
-# [*timeout_start_sec*]
-# (optional) If the container is to be managed by a systemd unit file set the
-# TimeoutStartSec option on the unit file.  Can be any valid value for this systemd
-# configuration.
-# Default: 0
-#
 define docker::run(
   Optional[Pattern[/^[\S]*$/]] $image,
   Optional[Pattern[/^present$|^absent$/]] $ensure       = 'present',
@@ -156,7 +150,6 @@ define docker::run(
   Optional[Integer] $health_check_interval              = undef,
   Variant[String,Array,Undef] $custom_unless            = [],
   Optional[String] $remain_after_exit                   = undef,
-  Variant[String,Integer] $timeout_start_sec            = 0,
 ) {
   include docker::params
   if ($socket_connect != []) {

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -86,6 +86,18 @@
 # (optional) Specifies the command to execute after container is created but before it is started.
 # Default: undef
 #
+# [*remain_after_exit*]
+# (optional) If the container is to be managed by a systemd unit file set the
+# RemainAfterExit option on the unit file.  Can be any valid value for this systemd
+# configuration.
+# Default: Not included in unit file
+#
+# [*timeout_start_sec*]
+# (optional) If the container is to be managed by a systemd unit file set the
+# TimeoutStartSec option on the unit file.  Can be any valid value for this systemd
+# configuration.
+# Default: 0
+#
 define docker::run(
   Optional[Pattern[/^[\S]*$/]] $image,
   Optional[Pattern[/^present$|^absent$/]] $ensure       = 'present',
@@ -143,6 +155,8 @@ define docker::run(
   Optional[Boolean] $restart_on_unhealthy               = false,
   Optional[Integer] $health_check_interval              = undef,
   Variant[String,Array,Undef] $custom_unless            = [],
+  Optional[String] $remain_after_exit                   = undef,
+  Variant[String,Integer] $timeout_start_sec            = 0,
 ) {
   include docker::params
   if ($socket_connect != []) {

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -22,7 +22,7 @@ StartLimitBurst=5
 
 [Service]
 Restart=<%= @systemd_restart %>
-TimeoutStartSec=0
+TimeoutStartSec=<%= @timeout_start_sec %>
 RestartSec=5
 Environment="HOME=/root"
 <%- if @_syslog_identifier -%>
@@ -30,6 +30,9 @@ SyslogIdentifier=<%= @_syslog_identifier %>
 <%- end -%>
 ExecStart=/usr/local/bin/docker-run-<%= @sanitised_title %>-start.sh
 ExecStop=-/usr/local/bin/docker-run-<%= @sanitised_title %>-stop.sh
+<%- if @remain_after_exit %>
+RemainAfterExit=<%= @remain_after_exit %>
+<%- end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -22,7 +22,7 @@ StartLimitBurst=5
 
 [Service]
 Restart=<%= @systemd_restart %>
-TimeoutStartSec=<%= @timeout_start_sec %>
+TimeoutStartSec=0
 RestartSec=5
 Environment="HOME=/root"
 <%- if @_syslog_identifier -%>


### PR DESCRIPTION
I required this because I found that with RemainAfterExit defaulted to `no` systemd was immediately calling `ExecStop` and shutting down my container, presumably due to how it interacts with the wrapper that starts up the container (Ubuntu 16.04).