### PR TITLE
Fix error does not show when image:tag does not exists (#552)

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -144,11 +144,19 @@ define docker::image(
     notify { "Check if image ${image_arg} is in-sync":
       noop      => false,
     }
+    ~> exec { $image_install:
+      environment => $exec_environment,
+      path        => $exec_path,
+      timeout     => $exec_timeout,
+      returns     => ['0', '2'],
+      require     => File[$update_docker_image_path],
+      provider    => $exec_provider,
+      logoutput   => true,
+    }
     ~> exec { "echo 'Update of ${image_arg} complete'":
       environment => $exec_environment,
       path        => $exec_path,
       timeout     => $exec_timeout,
-      onlyif      => $image_install,
       require     => File[$update_docker_image_path],
       provider    => $exec_provider,
       logoutput   => true,

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -157,7 +157,8 @@ describe 'docker::image', type: :define do
   context 'with ensure => latest' do
     let(:params) { { 'ensure' => 'latest' } }
 
-    it { is_expected.to contain_exec("echo 'Update of base complete'").with_onlyif('/usr/local/bin/update_docker_image.sh base') }
+    it { is_expected.to contain_exec('/usr/local/bin/update_docker_image.sh base') }
+    it { is_expected.to contain_exec("echo 'Update of base complete'") }
   end
 
   context 'with ensure => latest and image_tag => precise' do

--- a/spec/defines/image_windows_spec.rb
+++ b/spec/defines/image_windows_spec.rb
@@ -58,6 +58,7 @@ describe 'docker::image', type: :define do
   context 'with ensure => latest' do
     let(:params) { { 'ensure' => 'latest' } }
 
-    it { is_expected.to contain_exec("echo 'Update of base complete'").with_onlyif('& C:/Users/Administrator/AppData/Local/Temp/update_docker_image.ps1 -DockerImage base') }
+    it { is_expected.to contain_exec('& C:/Users/Administrator/AppData/Local/Temp/update_docker_image.ps1 -DockerImage base') }
+    it { is_expected.to contain_exec("echo 'Update of base complete'") }
   end
 end


### PR DESCRIPTION
Using an exec resource instead of the onlyif will execute the script in a resource, not in a condition. This will make an error to be shown when an image:tag does not exists, not just not making an echo to be shown when the script fails.
Doing the execution of the script this way will be easier to track when a image:tag has a typo or was not created yet.