### PR TITLE
Minimal changes to work with podman-docker

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -56,12 +56,12 @@ end
 Facter.add(:docker_client_version) do
   setcode do
     docker_version = Facter.value(:docker_version)
-    if docker_version 
-            if !docker_version['Client'].nil?
-                    docker_version['Client']['Version']
-            else
-                    docker_version['Version']
-            end
+    if docker_version
+      if !docker_version['Client'].nil?
+        docker_version['Client']['Version']
+      else
+        docker_version['Version']
+      end
     end
   end
 end

--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -56,7 +56,13 @@ end
 Facter.add(:docker_client_version) do
   setcode do
     docker_version = Facter.value(:docker_version)
-    docker_version['Client']['Version'] if docker_version
+    if docker_version 
+            if !docker_version['Client'].nil?
+                    docker_version['Client']['Version']
+            else
+                    docker_version['Version']
+            end
+    end
   end
 end
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -130,7 +130,7 @@ define docker::run(
   Variant[String,Array,Undef] $after                    = [],
   Variant[String,Array,Undef] $after_service            = [],
   Variant[String,Array,Undef] $depends                  = [],
-  Variant[String,Array,Undef] $depend_services          = [],
+  Variant[String,Array,Undef] $depend_services          = ['docker.service'],
   Optional[Boolean] $tty                                = false,
   Variant[String,Array,Undef] $socket_connect           = [],
   Variant[String,Array,Undef] $hostentries              = [],

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -1,10 +1,10 @@
 <%-
-	@required_start = ["$network", "docker"] +
+	@required_start = ["$network"] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}"} +
 		@depend_services_array
 
-	@required_stop = ["$network", "docker"] +
+	@required_stop = ["$network"] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}"} +
 		@depend_services_array
 -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -1,13 +1,11 @@
 <%-
 	depend_services = @depend_services_array.map{|s| s =~ /\.[a-z]+$/ ? s : "#{s}.service"}
-	@after = [@service_name.nil? ? "" : "#@service_name.service"] +
-		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
-		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
-		depend_services
+	@after = @sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
+		 @sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
+		 depend_services
 	@wants = @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}
-	@requires = [@service_name.nil? ? "" : "#@service_name.service"] +
-		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
-		depend_services
+	@requires = @sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
+		    depend_services
 -%>
 # This file is managed by Puppet and local changes
 # may be overwritten


### PR DESCRIPTION
These are the minimal changes for puppet docker module to work on RedHat machines with podman-docker package. It does not have a docker service, and has a different output of 'docker version' command.