### PR TITLE
Let docker.service start docker services managed by puppetlabs/docker…

### DIFF
--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -74,6 +74,7 @@ require 'spec_helper'
 
         if systemd
           it { is_expected.to contain_file(initscript).with_content(%r{^SyslogIdentifier=docker-sample$}) }
+          it { is_expected.to contain_file(initscript).with_content(%r{^WantedBy=docker.service$}) }
         end
       end
 
@@ -104,6 +105,7 @@ require 'spec_helper'
           it { is_expected.to contain_file(initscript).with_content(%r{Requires=(.*\s+)?docker-foo.service}) }
           it { is_expected.to contain_file(initscript).with_content(%r{Requires=(.*\s+)?docker-bar.service}) }
           it { is_expected.to contain_file(initscript).with_content(%r{Requires=(.*\s+)?docker-foo_bar-baz.service}) }
+          it { is_expected.to contain_file(initscript).with_content(%r{WantedBy=docker.service}) }
         else
           it { is_expected.to contain_file(initscript).with_content(%r{Required-Start:.*\s+docker-foo}) }
           it { is_expected.to contain_file(initscript).with_content(%r{Required-Start:.*\s+docker-bar}) }
@@ -132,12 +134,24 @@ require 'spec_helper'
             it { is_expected.to contain_file(initscript).with_content(%r{Requires=(.*\s+)?foo.service(\s+|$)}) }
             it { is_expected.to contain_file(initscript).with_content(%r{Requires=(.*\s+)?bar.service(\s+|$)}) }
             it { is_expected.to contain_file(initscript).with_content(%r{Requires=(.*\s+)?baz.target(\s+|$)}) }
+            it { is_expected.to contain_file(initscript).with_content(%r{WantedBy=docker.service}) }
           end
         else
           it { is_expected.to contain_file(initscript).with_content(%r{Required-Start:.*\s+foo}) }
           it { is_expected.to contain_file(initscript).with_content(%r{Required-Start:.*\s+bar}) }
           it { is_expected.to contain_file(initscript).with_content(%r{Required-Stop:.*\s+foo}) }
           it { is_expected.to contain_file(initscript).with_content(%r{Required-Stop:.*\s+bar}) }
+        end
+      end
+
+      context 'with different docker service name' do
+        # let(:pre_condition) { ["class { 'docker': docker_group => 'docker', service_name => 'dockerd', service_provider => systemd, acknowledge_unsupported_os => true }"] }
+        let(:pre_condition) { pre_condition.gsub("service_name => 'docker'", "service_name => 'dockerd'") }
+
+        let(:params) { params }
+
+        if systemd
+          it { is_expected.to contain_file(initscript).with_content(%r{^WantedBy=dockerd.service$}) }
         end
       end
 

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -36,3 +36,6 @@ RemainAfterExit=<%= @remain_after_exit %>
 
 [Install]
 WantedBy=multi-user.target
+<%- if @service_name -%>
+WantedBy=<%= @service_name %>.service
+<%- end -%>


### PR DESCRIPTION
Systemd units created by `puppetlabs/docker` defines the dependency on `docker.service` via `Requires=docker.service` stanza. This won't let `docker-mycontainer.service` service start unless `docker.service` is running.

From time to time there are situations where you stop `docker.service` (mostly due to `docker` upgrades / setup changes etc.).
`apt-get upgrade` (or you) will stop `docker.service`, `systemd` will take a care of stopping all services that states `Requires=docker.service`, docker is being upgraded and started. Unfortunately `systemd` won't boot up the `docker-mycontainer.service` as there's no dependency definition.

This PR introduces simple reverse dependency relation between docker container systemd units and `docker.service`.