### PR TITLE
Use standardized quote type to help tests pass

### DIFF
--- a/manifests/stack.pp
+++ b/manifests/stack.pp
@@ -27,7 +27,7 @@
 #
 # [*resolve_image*]
 #  Query the registry to resolve image digest and supported platforms
-#  Only accepts (“always”|“changed”|“never”)
+#  Only accepts ("always"|"changed"|"never")
 #  Defaults to undef
 #
 # [*with_registry_auth*]


### PR DESCRIPTION
When executing the [Onceover](https://github.com/dylanratcliffe/onceover) testing suite in a control repo which references this puppetlabs-docker module in its puppetfile, Onceover throws the following error for incorrect quote types.

`ERROR	 -> ignoring invalid line in file: /var/lib/jenkins/workspace/CPSRE_puppet_production/.onceover/etc/puppetlabs/code/environments/production/modules/docker/manifests/stack.pp (invalid byte sequence in US-ASCII) - line: '#  Only accepts (“always”|“changed”|“never”)`

This pull request changes the quote types to standardized ASCII form on the affected comment line.