### PR TITLE
Make docker::machine::url configurable

### DIFF
--- a/manifests/machine.pp
+++ b/manifests/machine.pp
@@ -20,11 +20,15 @@
 # [*proxy*]
 #   Proxy to use for downloading Docker Machine.
 #
+# [*url*]
+#   The URL from which the docker machine binary should be fetched
+#   Defaults to a auto determined value based on version, kernel and OS.
 class docker::machine(
-  Optional[Pattern[/^present$|^absent$/]] $ensure          = 'present',
-  Optional[String] $version                                = $docker::params::machine_version,
-  Optional[String] $install_path                           = $docker::params::machine_install_path,
-  Optional[String] $proxy                                  = undef
+  Optional[Pattern[/^present$|^absent$/]]              $ensure       = 'present',
+  Optional[String]                                     $version      = $docker::params::machine_version,
+  Optional[String]                                     $install_path = $docker::params::machine_install_path,
+  Optional[String]                                     $proxy        = undef,
+  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $url          = undef,
 ) inherits docker::params {
 
   if $proxy != undef {
@@ -43,7 +47,10 @@ class docker::machine(
   $docker_machine_location_versioned = "${install_path}/docker-machine-${version}${file_extension}"
 
   if $ensure == 'present' {
-    $docker_machine_url = "https://github.com/docker/machine/releases/download/v${version}/docker-machine-${::kernel}-x86_64${file_extension}"
+    $docker_machine_url = $url ? {
+      undef   => "https://github.com/docker/machine/releases/download/v${version}/docker-machine-${::kernel}-x86_64${file_extension}",
+      default => $url,
+    }
 
     if $proxy != undef {
       $proxy_opt = "--proxy ${proxy}"

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -14,15 +14,15 @@ describe 'docker::machine' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe file('/usr/local/bin/docker-machine-0.16.1') do
-      its('owner') { is_expected.to eq 'root' }
-      its('mode') { is_expected.to cmp '0755' }
-      it { is_expected.to be_file }
+    it 'machine configurable check of docker-machine-0.16.1' do
+      expect(file('/usr/local/bin/docker-machine-0.16.1')).to be_file
+      expect(file('/usr/local/bin/docker-machine-0.16.1')).to be_owned_by 'root'
+      expect(file('/usr/local/bin/docker-machine-0.16.1')).to be_mode 755
     end
 
-    describe file('/usr/local/bin/docker-machine') do
-      its('link_path') { is_expected.to eq '/usr/local/bin/docker-machine-0.16.1' }
-      it { is_expected.to be_symlink }
+    it 'machine configurable check of docker-machine' do
+      expect(file('/usr/local/bin/docker-machine')).to be_linked_to '/usr/local/bin/docker-machine-0.16.1'
+      expect(file('/usr/local/bin/docker-machine')).to be_symlink
     end
 
     it 'is installed and working' do
@@ -46,15 +46,15 @@ describe 'docker::machine' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe file('/usr/local/bin/docker-machine-0.16.2-gitlab.3') do
-      its('owner') { is_expected.to eq 'root' }
-      its('mode') { is_expected.to cmp '0755' }
-      it { is_expected.to be_file }
+    it 'machine configurable check of docker-machine-0.16.2-gitlab.3' do
+      expect(file('/usr/local/bin/docker-machine-0.16.2-gitlab.3')).to be_file
+      expect(file('/usr/local/bin/docker-machine-0.16.2-gitlab.3')).to be_owned_by 'root'
+      expect(file('/usr/local/bin/docker-machine-0.16.2-gitlab.3')).to be_mode 755
     end
 
-    describe file('/usr/local/bin/docker-machine') do
-      its('link_path') { is_expected.to eq '/usr/local/bin/docker-machine-0.16.2-gitlab.3' }
-      it { is_expected.to be_symlink }
+    it 'machine configurable check of docker-machine' do
+      expect(file('/usr/local/bin/docker-machine')).to be_linked_to '/usr/local/bin/docker-machine-0.16.2-gitlab.3'
+      expect(file('/usr/local/bin/docker-machine')).to be_symlink
     end
 
     it 'is installed and working' do

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper_acceptance'
+
+describe 'docker::machine' do
+  context 'with default parameters' do
+    pp = <<-EOS
+      include docker::machine
+    EOS
+
+    it 'applies with no errors' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    it 'is idempotent' do
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/usr/local/bin/docker-machine-0.16.1') do
+      its('owner') { is_expected.to eq 'root' }
+      its('mode') { is_expected.to cmp '0755' }
+      it { is_expected.to be_file }
+    end
+
+    describe file('/usr/local/bin/docker-machine') do
+      its('link_path') { is_expected.to eq '/usr/local/bin/docker-machine-0.16.1' }
+      it { is_expected.to be_symlink }
+    end
+
+    it 'is installed and working' do
+      shell('docker-machine --help', acceptable_exit_codes: [0])
+    end
+  end
+
+  context 'with url => https://gitlab-docker-machine-downloads.s3.amazonaws.com/v0.16.2-gitlab.3/docker-machine' do
+    pp = <<-EOS
+      class { 'docker::machine':
+        version => '0.16.2-gitlab.3',
+        url     => 'https://gitlab-docker-machine-downloads.s3.amazonaws.com/v0.16.2-gitlab.3/docker-machine',
+      }
+    EOS
+
+    it 'applies with no errors' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    it 'is idempotent' do
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/usr/local/bin/docker-machine-0.16.2-gitlab.3') do
+      its('owner') { is_expected.to eq 'root' }
+      its('mode') { is_expected.to cmp '0755' }
+      it { is_expected.to be_file }
+    end
+
+    describe file('/usr/local/bin/docker-machine') do
+      its('link_path') { is_expected.to eq '/usr/local/bin/docker-machine-0.16.2-gitlab.3' }
+      it { is_expected.to be_symlink }
+    end
+
+    it 'is installed and working' do
+      shell('docker-machine --help', acceptable_exit_codes: [0])
+    end
+  end
+end

--- a/spec/classes/machine_spec.rb
+++ b/spec/classes/machine_spec.rb
@@ -113,4 +113,20 @@ describe 'docker::machine', type: :class do
       )
     }
   end
+
+  context 'with docker_machine_url is provided' do
+    let(:params) do
+      {
+        version: '0.16.2',
+        url: 'https://gitlab-docker-machine-downloads.s3.amazonaws.com/v0.16.2-gitlab.3/docker-machine',
+      }
+    end
+
+    it { is_expected.to compile }
+    it {
+      is_expected.to contain_exec('Install Docker Machine 0.16.2').with_command(
+        'curl -s -S -L  https://gitlab-docker-machine-downloads.s3.amazonaws.com/v0.16.2-gitlab.3/docker-machine -o /usr/local/bin/docker-machine-0.16.2',
+      )
+    }
+  end
 end


### PR DESCRIPTION
As docker machine is now in maintanence mode [1] there are forks of it
where people might want to download the binary from.

[1]: https://github.com/docker/machine/issues/4537