### PR TITLE
Add after_start and after_stop options to docker::run define

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ docker::run { 'helloworld':
   pull_on_start    => false,
   before_stop      => 'echo "So Long, and Thanks for All the Fish"',
   before_start     => 'echo "Run this on the host before starting the Docker container"',
+  after_stop       => 'echo "container has stopped"',
+  after_start      => 'echo "container has started"',
   after            => [ 'container_b', 'mysql' ],
   depends          => [ 'container_a', 'postgres' ],
   stop_wait_time   => 0,
@@ -406,7 +408,7 @@ To pull the image before it starts, specify the `pull_on_start` parameter.
 
 Use the `detach` param to run container a container without the `-a` flag. This is only required on systems without `systemd`. This default is set in the params.pp based on the OS. Only override if you understand the consuquences and have a specific use case.
 
-To execute a command before the container stops, specify the `before_stop` parameter.
+To execute a command before the container starts or stops, specify the `before_start` or `before_stop` parameters, respectively. Similarly, you can specify the `after_start` or `after_stop` parameters to run a command after the container starts or stops.
 
 Adding the container name to the `after` parameter to specify which containers start first, affects the generation of the `init.d/systemd` script.
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -137,6 +137,8 @@ define docker::run(
   Optional[String] $restart                             = undef,
   Variant[String,Boolean] $before_start                 = false,
   Variant[String,Boolean] $before_stop                  = false,
+  Variant[String,Boolean] $after_start                  = false,
+  Variant[String,Boolean] $after_stop                   = false,
   Optional[String]  $after_create                       = undef,
   Optional[Boolean] $remove_container_on_start          = true,
   Optional[Boolean] $remove_container_on_stop           = true,

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -550,6 +550,30 @@ require 'spec_helper'
         it { is_expected.not_to contain_file(stopscript_or_init).with_content(%r{before_stop}) }
       end
 
+      context 'when `after_start` is set' do
+        let(:params) { params.merge('after_start' => 'echo after_start') }
+
+        it { is_expected.to contain_file(startscript_or_init).with_content(%r{after_start}) }
+      end
+
+      context 'when `after_start` is not set' do
+        let(:params) { params.merge('after_start' => false) }
+
+        it { is_expected.not_to contain_file(startscript_or_init).with_content(%r{after_start}) }
+      end
+
+      context 'when `after_stop` is set' do
+        let(:params) { params.merge('after_stop' => 'echo after_stop') }
+
+        it { is_expected.to contain_file(stopscript_or_init).with_content(%r{after_stop}) }
+      end
+
+      context 'when `after_stop` is not set' do
+        let(:params) { params.merge('after_stop' => false) }
+
+        it { is_expected.not_to contain_file(stopscript_or_init).with_content(%r{after_stop}) }
+      end
+
       context 'when `after_create` is set' do
         let(:params) { params.merge('after_create' => 'echo after_create') }
 

--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -23,3 +23,6 @@
 <% end %>
 
 /usr/bin/<%= @docker_command %> start <% if ! @valid_detach %>-a<% end %> <%= @sanitised_title %>
+<% if @after_start -%>
+    <%= @after_start %>
+<% end -%>

--- a/templates/docker-run-stop.erb
+++ b/templates/docker-run-stop.erb
@@ -5,3 +5,6 @@
 <% if @remove_container_on_stop -%>
     /usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
 <% end -%>
+<% if @after_stop -%>
+    <%= @after_stop %>
+<% end -%>


### PR DESCRIPTION
This pull request adds ``after_start`` and ``after_stop`` parameters to the ``docker::run`` define, working similarly to the existing ``before_start`` and ``before_stop`` options (i.e. these execute a command _after_ the container is started or stopped).

PR includes unit tests. I haven't added these to the acceptance tests as the existing ``before_`` variants weren't being tested there, but these are relatively simple template changes and we're currently using this code.