### PR TITLE
Allow module to work on SLES 12

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,6 +278,46 @@ class docker::params {
       $service_hasrestart                  = undef
       $detach_service_in_init              = true
     }
+    'Suse': {
+      $docker_group                        = $docker_group_default
+      $socket_group                        = $socket_group_default
+      $package_key_source                  = undef
+      $package_key_check_source            = undef
+      $package_source_location             = undef
+      $package_key_id                      = undef
+      $package_repos                       = undef
+      $package_release                     = undef
+      $package_ce_key_source               = undef
+      $package_ce_source_location          = undef
+      $package_ce_key_id                   = undef
+      $package_ce_repos                    = undef
+      $package_ce_release                  = undef
+      $package_ee_source_location          = undef
+      $package_ee_key_source               = undef
+      $package_ee_key_id                   = undef
+      $package_ee_release                  = undef
+      $package_ee_repos                    = undef
+      $package_ee_package_name             = undef
+      $use_upstream_package_source         = true
+      $service_overrides_template          = undef
+      $socket_overrides_template           = undef
+      $socket_override                     = false
+      $service_after_override              = undef
+      $service_hasstatus                   = undef
+      $service_hasrestart                  = undef
+      $service_provider                    = 'systemd'
+      $package_name                        = $docker_ce_package_name
+      $service_name                        = $service_name_default
+      $detach_service_in_init              = true
+      $repo_opt                            = undef
+      $nowarn_kernel                       = false
+      $service_config                      = undef
+      $storage_config                      = undef
+      $storage_setup_file                  = undef
+      $service_config_template             = undef
+      $pin_upstream_package_source         = undef
+      $apt_source_pin_level                = undef
+    }
     default: {
       $docker_group                        = $docker_group_default
       $socket_group                        = $socket_group_default


### PR DESCRIPTION
Prior to this commit, if you set acknowledge_unsupported_os = true
you'd still fail on SLES 12 because the docker::run define
doesn't know that SLES uses systemd and drops down to failing

After this commit, we copy the default section in params for
suse and set the service_provider to systemd so the run define
will work.

The user still needs to manually install docker on SLES 12 but this
allows managing the service etc... to work.