### PR TITLE
Allow all 3.x docker-compose minor versions

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
       compose_containers.uniq!
       # rubocop:enable Style/StringLiterals
       case compose_file['version']
-      when %r{^2(\.[0-3])?$}, %r{^3(\.[0-6])?$}
+      when %r{^2(\.[0-3])?$}, %r{^3(\.\d+)?$}
         compose_services.deep_merge!(compose_file['services'])
       # in compose v1 "version" parameter is not specified
       when nil


### PR DESCRIPTION
No major changes affecting this module compared to the previous max
compatibility with docker-compose 3.6; see
https://docs.docker.com/compose/compose-file/compose-versioning/#version-37

Fixes https://github.com/puppetlabs/puppetlabs-docker/issues/575