### PR TITLE
Blocking ordering between non-Windows service stops

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -493,6 +493,7 @@ define docker::run(
           enable    => false,
           hasstatus => $hasstatus,
           provider  => $service_provider_real,
+          notify    => Exec["remove container ${service_prefix}${sanitised_title}"],
         }
       }
       exec { "remove container ${service_prefix}${sanitised_title}":


### PR DESCRIPTION
Windows based services stopping will block until the docker container stops (ie: if `docker::run::stop_wait_time` has been set to !=0)

`service` based stops do not - this adds that dependency in so that containers are not attempted to be removed until the service has stopped