### PR TITLE
README: add Debian 10 to list of supported OSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ This module supports:
 * Centos 7.0
 * Debian 8.0
 * Debian 9.0
+* Debian 10
 * RedHat 7.0
 * Ubuntu 14.04
 * Ubuntu 16.04


### PR DESCRIPTION
Debian 10 is supported according to metadata.json.