### PR TITLE
Add docker swarm join-tokens as facts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -184,3 +184,4 @@
      1	Geoff Meakin
      1	Joshua Spence
      1	Justin Riley
+     1  Schusler, Olaf

--- a/README.md
+++ b/README.md
@@ -759,21 +759,21 @@ To configure the swarm worker, add the following code to the manifest file:
 
 ```puppet
 docker::swarm {'cluster_worker':
-join           => true,
-advertise_addr => '192.168.1.2',
-listen_addr    => '192.168.1.2',
-manager_ip     => '192.168.1.1',
-token          => 'your_join_token'
+  join           => true,
+  advertise_addr => '192.168.1.2',
+  listen_addr    => '192.168.1.2',
+  manager_ip     => '192.168.1.1',
+  token          => 'your_join_token'
 }
 ```
 
-To configure a worker node or a second manager, include the swarm manager IP address in the `manager_ip` parameter. To define the role of the node in the cluster, include the `token` parameter. When creating an additional swarm manager and a worker node, separate tokens are required.
+To configure a worker node or a second manager, include the swarm manager IP address in the `manager_ip` parameter. To define the role of the node in the cluster, include the `token` parameter. When creating an additional swarm manager and a worker node, separate tokens are required. These tokens (i.e. `docker_worker_join_token` and `docker_manager_join_token`) can be retrieved from Facter.
 
 To remove a node from a cluster, add the following code to the manifest file:
 
 ```puppet
 docker::swarm {'cluster_worker':
-ensure => absent
+  ensure => absent
 }
 ```
 

--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -77,6 +77,28 @@ Facter.add(:docker_version) do
   end
 end
 
+Facter.add(:docker_worker_join_token) do
+  setcode do
+    if Facter::Util::Resolution.which('docker')
+      val = Facter::Util::Resolution.exec(
+        "#{docker_command} swarm join-token worker -q",
+      )
+    end
+    val
+  end
+end
+
+Facter.add(:docker_manager_join_token) do
+  setcode do
+    if Facter::Util::Resolution.which('docker')
+      val = Facter::Util::Resolution.exec(
+        "#{docker_command} swarm join-token manager -q",
+      )
+    end
+    val
+  end
+end
+
 Facter.add(:docker) do
   setcode do
     docker_version = Facter.value(:docker_client_version)

--- a/spec/fixtures/facts/docker_swarm_manager_token
+++ b/spec/fixtures/facts/docker_swarm_manager_token
@@ -1,0 +1,1 @@
+SWMTKN-1-2m7ekt7511j5kgrc6seyrewpdxv47ksz1sdg7iybzhuug6nmws-8gh1ns1lcavgau8k9p6ou7xj3

--- a/spec/fixtures/facts/docker_swarm_worker_token
+++ b/spec/fixtures/facts/docker_swarm_worker_token
@@ -1,0 +1,1 @@
+SWMTKN-1-2m7ekt7511j5kgrc6seyrewpdxv47ksz1sdg7iybzhuug6nmws-0jh0syqeoj3tlr81p165ydfkm

--- a/spec/unit/lib/facter/docker_spec.rb
+++ b/spec/unit/lib/facter/docker_spec.rb
@@ -25,6 +25,10 @@ describe 'Facter::Util::Fact' do
       inspect = File.read(fixtures('facts', "docker_network_inspect_#{network}"))
       Facter::Util::Resolution.stubs(:exec).with("#{docker_command} network inspect #{network}").returns(inspect)
     end
+    docker_worker_token = File.read(fixtures('facts', 'docker_swarm_worker_token'))
+    Facter::Util::Resolution.stubs(:exec).with("#{docker_command} swarm join-token worker -q").returns(docker_worker_token.chomp)
+    docker_manager_token = File.read(fixtures('facts', 'docker_swarm_manager_token'))
+    Facter::Util::Resolution.stubs(:exec).with("#{docker_command} swarm join-token manager -q").returns(docker_manager_token.chomp)
   end
   after(:each) { Facter.clear }
 
@@ -91,6 +95,28 @@ describe 'Facter::Util::Fact' do
     it 'has valid entries' do
       expect(Facter.fact(:docker).value).to include(
         'Architecture' => 'x86_64',
+      )
+    end
+  end
+
+  describe 'docker swarm worker join-token' do
+    before :each do
+      Facter.fact(:interfaces).stubs(:value).returns('br-19a6ebf6f5a5,docker0,eth0,lo')
+    end
+    it do
+      expect(Facter.fact(:docker_worker_join_token).value).to eq(
+        'SWMTKN-1-2m7ekt7511j5kgrc6seyrewpdxv47ksz1sdg7iybzhuug6nmws-0jh0syqeoj3tlr81p165ydfkm',
+      )
+    end
+  end
+
+  describe 'docker swarm manager join-token' do
+    before :each do
+      Facter.fact(:interfaces).stubs(:value).returns('br-19a6ebf6f5a5,docker0,eth0,lo')
+    end
+    it do
+      expect(Facter.fact(:docker_manager_join_token).value).to eq(
+        'SWMTKN-1-2m7ekt7511j5kgrc6seyrewpdxv47ksz1sdg7iybzhuug6nmws-8gh1ns1lcavgau8k9p6ou7xj3',
       )
     end
   end


### PR DESCRIPTION
Fix for issue #638. 

This PR adds 2 facts to PuppetDB (`worker_join_token` and `manager_join_token`). The puppet agent will have to be run twice, once to setup the docker manager, and a second time to send the updated fact to PuppetDB. Combined with the following snippet, a docker cluster can be started up, unsupervised:

```
node 'manager' {
  docker::swarm {'cluster_manager':
    init           => true,
    advertise_addr => "${::ipaddress}",
    listen_addr    => "${::ipaddress}",
    require        => Class['docker'],
  }

  @@docker::swarm {'cluster_worker':
    join           => true,
    manager_ip     => "${ipaddress}",
    token          => "${worker_join_token}",
    tag            => "cluster_join_command",
    require        => Class['docker'],
  }
}

node 'worker' {
  Docker::Swarm<<| tag == 'cluster_join_command' |>> {
    advertise_addr => "${ipaddress}",
    listen_addr    => "${ipaddress}",
  }
}
```