### PR TITLE
Fix syntax for puppet 4 support

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -68,7 +68,7 @@ define docker::registry(
       $_local_user_home = $local_user_home
     } else {
       # set sensible default
-      $_local_user_home = $local_user == 'root' ? {
+      $_local_user_home = ($local_user == 'root') ? {
         true    => '/root',
         default => "/home/${local_user}",
       }


### PR DESCRIPTION
On older versions of puppet (discovered on 4.10.7)
this select statement fails and $_local_user_home
ends up with the boolean value 'false' instead of
one of the strings you would expect.