### PR TITLE
Fix misplaced backslash in start template

### DIFF
--- a/templates/docker-run-start.erb
+++ b/templates/docker-run-start.erb
@@ -12,7 +12,8 @@
 /usr/bin/<%= @docker_command %> create \
 <%= @docker_run_flags %> \
 --name <%= @sanitised_title %> \
-<%= @image %> <% if @command %> \ <%= @command %><% end %>
+<%= @image %> <% if @command %> \
+<%= @command %><% end %>
 
 <% if @after_create %><%= @after_create %><% end %>
 <% if @net.is_a? Array%>


### PR DESCRIPTION
During a recent refactor a backslash intended to be an end of line
escape was inadvertantly placed into the middle of a line when a
container command is specified. This fix reinserts the newline the
slash was meant to escape.

Fixes #661