### PR TITLE
Test against OS family rather than name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -483,8 +483,8 @@ class docker(
     }
   }
 
-  if ($facts['os']['name'] == 'CentOS') and (versioncmp($facts['os']['release']['major'], '7') < 0) {
-    fail(translate('This module only works on CentOS version 7 and higher based systems.'))
+  if ($facts['os']['family'] == 'RedHat') and (versioncmp($facts['os']['release']['major'], '7') < 0) {
+    fail(translate('This module only works on Red Hat based systems version 7 and higher.'))
   }
 
   if ($default_gateway) and (!$bridge) {


### PR DESCRIPTION
This then includes proper RHEL as well as CentOS. The module would (correctly) fail to work on CentOS 6 but wouldn't fail on RHEL 6.