### PR TITLE
Fix array of additional flags

### DIFF
--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -29,13 +29,15 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
       flags.concat(new_flags)
     end
 
-    if resource[:additional_flags].is_a?(String)
-      additional_flags = resource[:additional_flags].split
-    elsif resource[:additional_flags].is_a?(Array)
-      additional_flags = resource[:additional_flags]
-    end
-    additional_flags.each do |additional_flag|
-      flags << additional_flag
+    if defined?(resource[:additional_flags])
+      if resource[:additional_flags].is_a?(String)
+        additional_flags = resource[:additional_flags].split
+      elsif resource[:additional_flags].is_a?(Array)
+        additional_flags = resource[:additional_flags]
+      end
+      additional_flags.each do |additional_flag|
+        flags << additional_flag
+      end
     end
     
     flags << resource[:name]

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
         flags << additional_flag
       end
     end
-    
+
     flags << resource[:name]
   end
 

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
     end
 
     if defined?(resource[:additional_flags])
-      additional_flags = Array.new
+      additional_flags = []
       if resource[:additional_flags].is_a?(String)
         additional_flags = resource[:additional_flags].split
       elsif resource[:additional_flags].is_a?(Array)

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -28,12 +28,16 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
       new_flags = multi_flags.call(values, format)
       flags.concat(new_flags)
     end
+
     if resource[:additional_flags].is_a?(String)
       additional_flags = resource[:additional_flags].split
-      additional_flags.each do |additional_flag|
-        flags << additional_flag
-      end
+    elsif resource[:additional_flags].is_a?(Array)
+      additional_flags = resource[:additional_flags]
     end
+    additional_flags.each do |additional_flag|
+      flags << additional_flag
+    end
+    
     flags << resource[:name]
   end
 

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -30,12 +30,11 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
     end
 
     if defined?(resource[:additional_flags])
+      additional_flags = Array.new
       if resource[:additional_flags].is_a?(String)
         additional_flags = resource[:additional_flags].split
       elsif resource[:additional_flags].is_a?(Array)
         additional_flags = resource[:additional_flags]
-      else
-        additional_flags = [nil]
       end
       additional_flags.each do |additional_flag|
         flags << additional_flag

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -34,6 +34,8 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
         additional_flags = resource[:additional_flags].split
       elsif resource[:additional_flags].is_a?(Array)
         additional_flags = resource[:additional_flags]
+      else
+        additional_flags = [nil]
       end
       additional_flags.each do |additional_flag|
         flags << additional_flag


### PR DESCRIPTION
Do not ignore the 'additional_flags' option of docker_networks when it is specified as an array instead of a simple string.
Without this fix 'additional_flags' is silently ignored when it is an array.