### PR TITLE
Fix systemd units for systemd versions < v230

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -476,6 +476,8 @@ class docker(
   # Windows specific parameters
   Optional[String]                        $docker_msft_provider_version      = $docker::params::docker_msft_provider_version,
   Optional[String]                        $nuget_package_provider_version    = $docker::params::nuget_package_provider_version,
+
+  Boolean                                 $have_systemd_v230                 = $docker::params::have_systemd_v230,
 ) inherits docker::params {
   if $facts['os']['family'] and ! $acknowledge_unsupported_os {
     assert_type(Pattern[/^(Debian|RedHat|windows)$/], $facts['os']['family']) |$a, $b| {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -373,4 +373,19 @@ class docker::params {
   }
 
   $dependent_packages = [ 'docker-ce-cli', 'containerd.io', ]
+
+  if($service_provider == 'systemd') {
+    # systemd v230 adds new StartLimitIntervalSec, StartLimitBurst
+    if($::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '8') < 0) {
+      $have_systemd_v230 = false
+    } elsif($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '18.04') < 0) {
+      $have_systemd_v230 = false
+    } elsif($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') < 0) {
+      $have_systemd_v230 = false
+    } else {
+      $have_systemd_v230 = true
+    }
+  } else {
+    $have_systemd_v230 = false
+  }
 }

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -15,11 +15,17 @@ Description=Daemon for <%= @title %>
 After=<%= @after.uniq.join(" ") %>
 Wants=<%= @wants.uniq.join(" ") %>
 Requires=<%= @requires.uniq.join(" ") %>
+<%- if @have_systemd_v230 -%>
 StartLimitIntervalSec=20
 StartLimitBurst=3
+<%- end -%>
 
 [Service]
 Restart=<%= @systemd_restart %>
+<%- unless @have_systemd_v230 -%>
+StartLimitInterval=20
+StartLimitBurst=3
+<%- end -%>
 TimeoutStartSec=0
 RestartSec=5
 Environment="HOME=/root"


### PR DESCRIPTION
This will revert the change introduced in 2675ed7 for
systems with systemd versions older than v230 as these systemd
versions dont support StartLimitIntervalSec and StartLimitBurst
in [Unit] sections causing:

  Unknown lvalue 'StartLimitIntervalSec' in section 'Unit'
  Unknown lvalue 'StartLimitBurst' in section 'Unit'

related #456