### PR TITLE
Updates dependencies to be Puppet 7 compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,11 +22,11 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 2.1.4 < 4.0.0"
+      "version_requirement": ">= 2.1.4 < 5.0.0"
     },
     {
       "name": "puppetlabs/reboot",
-      "version_requirement": ">=2.0.0 < 3.0.0"
+      "version_requirement": ">=2.0.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Updates dependencies version_requierement

Tested with:
* puppetlabs-translate (v2.2.0)
* puppetlabs-reboot (v3.2.0)
* puppetlabs-powershell (v4.1.0)
* puppetlabs-apt (v7.7.1)
* puppetlabs-stdlib (v6.6.0)

Test summary :

```
Deprecation Warnings:

puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 16 minutes 28 seconds (files took 6 minutes 2 seconds to load)
4196 examples, 0 failures


Code coverage
  must cover at least 0% of resources


Coverage Report:

Total resources:   132
Touched resources: 131
Resource coverage: 99.24%

Untouched resources:
  File[/etc/default/my-docker]
```

