### PR TITLE
Make it possible to use pod's network

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -22,10 +22,12 @@ module Puppet::Parser::Functions
       flags << "--restart '#{opts['restart']}'"
     end
 
-    if opts['net'].is_a? String
-      flags << "--net #{opts['net'].shellescape}"
-    elsif opts['net'].is_a? Array
-      flags << "--net #{opts['net'].join(' --net ').shellescape}"
+    if opts['net']
+      if opts['net'].is_a? String
+        flags << "--net #{opts['net'].shellescape}"
+      elsif opts['net'].is_a? Array
+        flags << "--net #{opts['net'].join(' --net ').shellescape}"
+      end
     end
 
     if opts['memory_limit']

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -204,7 +204,7 @@ define docker::run(
   Optional[Boolean]                       $use_name                          = false,
   Optional[Boolean]                       $running                           = true,
   Optional[Variant[String,Array]]         $volumes_from                      = [],
-  Variant[String,Array]                   $net                               = 'bridge',
+  Variant[String,Array,Undef]             $net                               = undef,
   Variant[String,Boolean]                 $username                          = false,
   Variant[String,Boolean]                 $hostname                          = false,
   Optional[Variant[String,Array]]         $env                               = [],


### PR DESCRIPTION
To use pod's network in a container, it shuld have --pod argument
and should not have --net.
The latter was always being added to the docker run command, if
not provided to the class as a parameter, then defaults to 'bridge'.
If empty or empty arrar - added as '' which also breaks networking
for the container in the pod.

With this fix, if a network is not defined, the whole argument will
be omitted in the docker run / docker create flags. This is the
same as providing previous default 'bridge' if container is created
or started without '--pod', and is not breaking compatibility with
podman create/run command without explicit '--net' argument.