### PR TITLE
[MODULES-10898] Disable forced docker service restart for RedHat 7 and docker server 1.13

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -356,12 +356,14 @@ class docker::service (
     default: {}
   }
 
-  if $storage_config {
-    file { $storage_config:
-      ensure  => file,
-      force   => true,
-      content => template($storage_config_template),
-      notify  => $_manage_service,
+  unless $facts['os']['family'] == 'RedHat' and $facts['docker_server_version'] =~ /1\.13.+/ {
+    if $storage_config {
+      file { $storage_config:
+        ensure  => file,
+        force   => true, #force rewrite storage configuration 
+        content => template($storage_config_template),
+        notify  => $_manage_service, #the force notify here causes the idempotency failure when using storage-> driver on redhat
+      }
     }
   }
 


### PR DESCRIPTION
Workaround for https://github.com/puppetlabs/puppetlabs-docker/issues/518 by disabling forced service restart on storage configuration change for RedHat 7 and Docker server version 1.13+ 

