### PR TITLE
Allow management of the docker-ce-cli package

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -166,6 +166,7 @@ The following parameters are available in the `docker` class:
 * [`docker_msft_provider_version`](#docker_msft_provider_version)
 * [`docker_ce_start_command`](#docker_ce_start_command)
 * [`docker_ce_package_name`](#docker_ce_package_name)
+* [`docker_ce_cli_package_name`](#docker_ce_cli_package_name)
 * [`docker_ce_source_location`](#docker_ce_source_location)
 * [`docker_ce_key_source`](#docker_ce_key_source)
 * [`docker_ce_key_id`](#docker_ce_key_id)
@@ -925,6 +926,14 @@ Data type: `Optional[String]`
 
 
 Default value: `$docker::params::docker_ce_package_name`
+
+##### <a name="docker_ce_cli_package_name"></a>`docker_ce_cli_package_name`
+
+Data type: `String[1]`
+
+
+
+Default value: `$docker::params::docker_ce_cli_package_name`
 
 ##### <a name="docker_ce_source_location"></a>`docker_ce_source_location`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -318,6 +318,7 @@
 #
 # @param docker_ce_start_command
 # @param docker_ce_package_name
+# @param docker_ce_cli_package_name
 # @param docker_ce_source_location
 # @param docker_ce_key_source
 # @param docker_ce_key_id
@@ -363,6 +364,7 @@ class docker(
   Array                                   $dependent_packages                = $docker::params::dependent_packages,
   String                                  $docker_ce_start_command           = $docker::params::docker_ce_start_command,
   Optional[String]                        $docker_ce_package_name            = $docker::params::docker_ce_package_name,
+  String[1]                               $docker_ce_cli_package_name        = $docker::params::docker_ce_cli_package_name,
   Optional[String]                        $docker_ce_source_location         = $docker::params::package_ce_source_location,
   Optional[String]                        $docker_ce_key_source              = $docker::params::package_ce_key_source,
   Optional[String]                        $docker_ce_key_id                  = $docker::params::package_ce_key_id,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,35 +47,27 @@ class docker::install(
     }
 
     if $docker::package_source {
-      case $facts['os']['family'] {
-        'Debian' : {
-          $pk_provider = 'dpkg'
-        }
-        'RedHat' : {
-          $pk_provider = 'yum'
-        }
-        'windows' : {
-          fail('Custom package source is currently not implemented on windows.')
-        }
-        default : {
-          $pk_provider = undef
-        }
+      if $facts['os']['family'] == 'windows' {
+        fail('Custom package source is currently not implemented on windows.')
       }
       case $docker::package_source {
         /docker-engine/ : {
           ensure_resource('package', 'docker', merge($docker_hash, {
-            ensure   => $ensure,
-            provider => $pk_provider,
-            source   => $docker::package_source,
-            name     => $docker::docker_engine_package_name,
+            ensure => $ensure,
+            source => $docker::package_source,
+            name   => $docker::docker_engine_package_name,
           }))
         }
         /docker-ce/ : {
           ensure_resource('package', 'docker', merge($docker_hash, {
-            ensure   => $ensure,
-            provider => $pk_provider,
-            source   => $docker::package_source,
-            name     => $docker::docker_ce_package_name,
+            ensure => $ensure,
+            source => $docker::package_source,
+            name   => $docker::docker_ce_package_name,
+          }))
+          ensure_resource('package', 'docker-ce-cli', merge($docker_hash, {
+            ensure => $ensure,
+            source => $docker::package_source,
+            name   => $docker::docker_ce_cli_package_name,
           }))
         }
         default : {}
@@ -87,6 +79,10 @@ class docker::install(
         ensure_resource('package', 'docker', merge($docker_hash, {
           ensure => $ensure,
           name   => $docker::docker_package_name,
+        }))
+        ensure_resource('package', 'docker-ce-cli', merge($docker_hash, {
+          ensure => $ensure,
+          name   => $docker::docker_ce_cli_package_name,
         }))
 
         if $ensure == 'absent' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class docker::params {
   $ensure                            = present
   $docker_ce_start_command           = 'dockerd'
   $docker_ce_package_name            = 'docker-ce'
+  $docker_ce_cli_package_name        = 'docker-ce-cli'
   $docker_engine_start_command       = 'docker daemon'
   $docker_engine_package_name        = 'docker-engine'
   $docker_ce_channel                 = stable
@@ -372,7 +373,7 @@ class docker::params {
     default  => [],
   }
 
-  $dependent_packages = [ 'docker-ce-cli', 'containerd.io', ]
+  $dependent_packages = [ $docker_ce_cli_package_name, 'containerd.io', ]
 
   if($service_provider == 'systemd') {
     # systemd v230 adds new StartLimitIntervalSec, StartLimitBurst

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -89,6 +89,7 @@ describe 'docker', type: :class do
             'docker_ce_key_id'                  => defaults['package_ce_key_id'],
             'docker_ce_key_source'              => defaults['package_ce_key_source'],
             'docker_ce_package_name'            => defaults['docker_ce_package_name'],
+            'docker_ce_cli_package_name'        => defaults['docker_ce_cli_package_name'],
             'docker_ce_release'                 => defaults['package_ce_release'],
             'docker_ce_source_location'         => defaults['package_ce_source_location'],
             'docker_ce_start_command'           => defaults['docker_ce_start_command'],

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -26,6 +26,7 @@ def get_defaults(_facts)
   dns_search                        = :undef
   docker_ce_channel                 = 'stable'
   docker_ce_package_name            = 'docker-ce'
+  docker_ce_cli_package_name        = 'docker-ce-cli'
   docker_ce_start_command           = 'dockerd'
   docker_command                    = 'docker'
   docker_ee                         = false
@@ -343,7 +344,7 @@ def get_defaults(_facts)
     apt_source_pin_level                = :undef
   end
 
-  dependent_packages = ['docker-ce-cli', 'containerd.io']
+  dependent_packages = [docker_ce_cli_package_name, 'containerd.io']
 
   prerequired_packages = case _facts[:os]['family']
                          when 'Debian'
@@ -392,6 +393,7 @@ def get_defaults(_facts)
     'dns_search' => dns_search,
     'docker_ce_channel' => docker_ce_channel,
     'docker_ce_package_name' => docker_ce_package_name,
+    'docker_ce_cli_package_name' => docker_ce_cli_package_name,
     'docker_ce_start_command' => docker_ce_start_command,
     'docker_command' => docker_command,
     'docker_ee' => docker_ee,

--- a/spec/shared_examples/install.rb
+++ b/spec/shared_examples/install.rb
@@ -21,22 +21,12 @@ shared_examples 'install' do |_params, _facts|
         is_expected.to contain_class('docker::install')
       }
 
-      provider_value = case _facts[:os]['family']
-                       when 'Debian'
-                         'dpkg'
-                       when 'RedHat'
-                         'yum'
-                       else
-                         :undef
-                       end
-
       case _params['package_source']
       when 'docker-engine'
         it {
           is_expected.to contain_package('docker').with(
             {
               'ensure'   => ensure_value,
-              'provider' => provider_value,
               'source'   => _params['package_source'],
               'name'     => _params['docker_engine_package_name'],
             }.merge(docker_hash),
@@ -47,9 +37,17 @@ shared_examples 'install' do |_params, _facts|
           is_expected.to contain_package('docker').with(
             {
               'ensure'   => ensure_value,
-              'provider' => provider_value,
               'source'   => _params['package_source'],
               'name'     => _params['docker_ce_package_name'],
+            }.merge(docker_hash),
+          )
+        }
+        it {
+          is_expected.to contain_package('docker-ce-cli').with(
+            {
+              'ensure'   => ensure_value,
+              'source'   => _params['package_source'],
+              'name'     => _params['docker_ce_cli_package_name'],
             }.merge(docker_hash),
           )
         }
@@ -59,6 +57,12 @@ shared_examples 'install' do |_params, _facts|
         is_expected.to contain_package('docker').with(
           'ensure' => ensure_value,
           'name'   => values['docker_package_name'],
+        )
+      }
+      it {
+        is_expected.to contain_package('docker-ce-cli').with(
+          'ensure' => ensure_value,
+          'name'   => _params['docker_ce_cli_package_name'],
         )
       }
 


### PR DESCRIPTION
Manage the docker-ce-cli package the same way as the docker-ce package.

Fixes #597, #690.

Also remove obsolete manual setting of package provider.