### PR TITLE
Allow force update non-latest tagged image

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -143,7 +143,7 @@ define docker::image(
       timeout     => $exec_timeout,
       logoutput   => true,
     }
-  } elsif $ensure == 'latest' or $image_tag == 'latest' {
+  } elsif $ensure == 'latest' or $image_tag == 'latest' or $force {
     notify { "Check if image ${image_arg} is in-sync":
       noop => false,
     }


### PR DESCRIPTION
add an option to force update an image.

Taking the senario that, `prod` image tag is always for production deployment.
we only regularly update `prod` image tag.