### PR TITLE
Fix docker::volumes hiera example

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ If using Hiera, configure the `docker::volumes` class in the manifest file:
   classes:
     - docker::volumes
 
-docker::volumes:
+docker::volumes::volumes:
   blueocean:
     ensure: present
     driver: local


### PR DESCRIPTION
Fixes a trivial mistake in the README.
The `volumes` key is required to address the proper parameter, see [reference](https://github.com/puppetlabs/puppetlabs-docker/blob/main/REFERENCE.md#dockervolumes).