### PR TITLE
Add syslog_facility parameter to docker::run

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -187,6 +187,8 @@
 #
 # @param syslog_identifier
 #
+# @param syslog_facility
+#
 # @param read_only
 #
 define docker::run(
@@ -244,6 +246,7 @@ define docker::run(
   Optional[Boolean]                       $remove_volume_on_stop             = false,
   Optional[Integer]                       $stop_wait_time                    = 0,
   Optional[String]                        $syslog_identifier                 = undef,
+  Optional[String]                        $syslog_facility                   = undef,
   Optional[Boolean]                       $read_only                         = false,
   Optional[String]                        $health_check_cmd                  = undef,
   Optional[Boolean]                       $restart_on_unhealthy              = false,

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -197,6 +197,9 @@ tests = {
     'docker_service' => 'my-docker',
     'restart_service_on_docker_refresh' => false,
   },
+  'when passing syslog_facility' => {
+    'syslog_facility' => 'user',
+  },
 }
 
 describe 'docker::run', type: :define do

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -32,6 +32,9 @@ Environment="HOME=/root"
 <%- if @_syslog_identifier -%>
 SyslogIdentifier=<%= @_syslog_identifier %>
 <%- end -%>
+<%- if @syslog_facility -%>
+SyslogFacility=<%= @syslog_facility %>
+<%- end -%>
 ExecStart=/usr/local/bin/docker-run-<%= @sanitised_title %>-start.sh
 ExecStop=-/usr/local/bin/docker-run-<%= @sanitised_title %>-stop.sh
 <%- if @remain_after_exit %>


### PR DESCRIPTION
It is useful to be able to control the facility of log messages, so that
it can be handled by syslog appropriately