### PR TITLE
Duplicate declaration statement: docker_params_changed is already declared

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -470,7 +470,7 @@ define docker::run(
 
         $detect_changes = Deferred('docker_params_changed', [$docker_params_changed_args])
 
-        notify { 'docker_params_changed':
+        notify { "${title}_docker_params_changed":
           message  => $detect_changes,
         }
       }

--- a/spec/shared_examples/run.rb
+++ b/spec/shared_examples/run.rb
@@ -246,7 +246,7 @@ shared_examples 'run' do |title, params, facts, defaults|
         detect_changes = get_docker_params_changed(docker_params_changed_args)
 
         it {
-          is_expected.to contain_notify('docker_params_changed').with(
+          is_expected.to contain_notify("#{title}_docker_params_changed").with(
             'message' => detect_changes,
           )
         }


### PR DESCRIPTION
Fix duplicate declaration
Closes #714
Closes #758