### PR TITLE
Remove stderr empty check to avoid docker_params_changed failures when warnings appear

### DIFF
--- a/lib/puppet/functions/docker_params_changed.rb
+++ b/lib/puppet/functions/docker_params_changed.rb
@@ -78,7 +78,7 @@ Puppet::Functions.create_function(:docker_params_changed) do
 
     if opts['sanitised_title'] && opts['osfamily']
       stdout, stderr, status = Open3.capture3("docker inspect #{opts['sanitised_title']}")
-      if stderr.to_s == '' && status.to_s.include?('exit 0')
+      if status.to_s.include?('exit 0')
         param_changed = false
         inspect_hash = JSON.parse(stdout)[0]
 

--- a/lib/puppet/functions/docker_params_changed.rb
+++ b/lib/puppet/functions/docker_params_changed.rb
@@ -77,7 +77,7 @@ Puppet::Functions.create_function(:docker_params_changed) do
     return_value = 'No changes detected'
 
     if opts['sanitised_title'] && opts['osfamily']
-      stdout, stderr, status = Open3.capture3("docker inspect #{opts['sanitised_title']}")
+      stdout, _stderr, status = Open3.capture3("docker inspect #{opts['sanitised_title']}")
       if status.to_s.include?('exit 0')
         param_changed = false
         inspect_hash = JSON.parse(stdout)[0]

--- a/spec/helper/get_docker_params_changed.rb
+++ b/spec/helper/get_docker_params_changed.rb
@@ -6,7 +6,7 @@ def get_docker_params_changed(opts)
   return_value = 'No changes detected'
 
   if opts['sanitised_title'] && opts['osfamily']
-    stdout, stderr, status = Open3.capture3("docker inspect #{opts['sanitised_title']}")
+    stdout, _stderr, status = Open3.capture3("docker inspect #{opts['sanitised_title']}")
     if status.to_s.include?('exit 0')
       param_changed = false
       inspect_hash = JSON.parse(stdout)[0]

--- a/spec/helper/get_docker_params_changed.rb
+++ b/spec/helper/get_docker_params_changed.rb
@@ -7,7 +7,7 @@ def get_docker_params_changed(opts)
 
   if opts['sanitised_title'] && opts['osfamily']
     stdout, stderr, status = Open3.capture3("docker inspect #{opts['sanitised_title']}")
-    if stderr.to_s == '' && status.to_s.include?('exit 0')
+    if status.to_s.include?('exit 0')
       param_changed = false
       inspect_hash = JSON.parse(stdout)[0]
 


### PR DESCRIPTION
Relates to #689.

This is my suggested fix for the `docker_params_changed` Deferred function in environments where `$HOME` is unset. This can happen if Puppet is ran as a service. If `$HOME` is unset, Docker prints this to stderr:

```
WARNING: Error loading config file: .dockercfg: $HOME is not defined
```

POSIX spec defines stderr as being for errors *and* diagnostic information. Therefore any output to stderr does not mean there has been an error. The check as it stands is not correct, so let's check just the status code.