### PR TITLE
fix if docker_version is nil

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -102,7 +102,7 @@ end
 Facter.add(:docker) do
   setcode do
     docker_version = Facter.value(:docker_client_version)
-    if docker_version.match?(%r{1[0-9][0-2]?[.]\w+})
+    if docker_version and docker_version.match?(%r{1[0-9][0-2]?[.]\w+})
       if Facter::Core::Execution.which('docker')
         docker_json_str = Facter::Core::Execution.exec(
           "#{docker_command} info --format '{{json .}}'", timeout: 90


### PR DESCRIPTION
If docker is not (yet) installed this fact creates "undefined method `match?' for nil:NilClass" error in the logs
Added extra check to skip if docker_client_version is nil