### PR TITLE
Prefer timeout to time_limit for Facter::Core::Execution

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -69,7 +69,7 @@ Facter.add(:docker_version) do
   setcode do
     if Facter::Core::Execution.which('docker')
       value = Facter::Core::Execution.execute(
-        "#{docker_command} version --format '{{json .}}'", time_limit: 90
+        "#{docker_command} version --format '{{json .}}'", timeout: 90
       )
       val = JSON.parse(value)
     end
@@ -81,7 +81,7 @@ Facter.add(:docker_worker_join_token) do
   setcode do
     if Facter::Core::Execution.which('docker')
       val = Facter::Core::Execution.execute(
-        "#{docker_command} swarm join-token worker -q", time_limit: 90
+        "#{docker_command} swarm join-token worker -q", timeout: 90
       )
     end
     val
@@ -92,7 +92,7 @@ Facter.add(:docker_manager_join_token) do
   setcode do
     if Facter::Core::Execution.which('docker')
       val = Facter::Core::Execution.execute(
-        "#{docker_command} swarm join-token manager -q", time_limit: 90
+        "#{docker_command} swarm join-token manager -q", timeout: 90
       )
     end
     val
@@ -105,20 +105,20 @@ Facter.add(:docker) do
     if docker_version&.match?(%r{1[0-9][0-2]?[.]\w+})
       if Facter::Core::Execution.which('docker')
         docker_json_str = Facter::Core::Execution.execute(
-          "#{docker_command} info --format '{{json .}}'", time_limit: 90
+          "#{docker_command} info --format '{{json .}}'", timeout: 90
         )
         begin
           docker = JSON.parse(docker_json_str)
           docker['network'] = {}
 
           docker['network']['managed_interfaces'] = {}
-          network_list = Facter::Core::Execution.execute("#{docker_command} network ls | tail -n +2", time_limit: 90)
+          network_list = Facter::Core::Execution.execute("#{docker_command} network ls | tail -n +2", timeout: 90)
           docker_network_names = []
           network_list.each_line { |line| docker_network_names.push line.split[1] }
           docker_network_ids = []
           network_list.each_line { |line| docker_network_ids.push line.split[0] }
           docker_network_names.each do |network|
-            inspect = JSON.parse(Facter::Core::Execution.execute("#{docker_command} network inspect #{network}", time_limit: 90))
+            inspect = JSON.parse(Facter::Core::Execution.execute("#{docker_command} network inspect #{network}", timeout: 90))
             docker['network'][network] = inspect[0]
             network_id = docker['network'][network]['Id'][0..11]
             interfaces.each do |iface|

--- a/spec/unit/lib/facter/docker_spec.rb
+++ b/spec/unit/lib/facter/docker_spec.rb
@@ -21,23 +21,23 @@ describe 'Facter::Util::Fact' do
       allow(Facter::Core::Execution).to receive(:which).with('docker').and_return('/usr/bin/docker')
     end
     docker_info = File.read(fixtures('facts', 'docker_info'))
-    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} info --format '{{json .}}'", time_limit: 90).and_return(docker_info)
+    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} info --format '{{json .}}'", timeout: 90).and_return(docker_info)
     processors = File.read(fixtures('facts', 'processors'))
     allow(Facter.fact(:processors)).to receive(:value).and_return(JSON.parse(processors))
     docker_version = File.read(fixtures('facts', 'docker_version'))
-    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} version --format '{{json .}}'", time_limit: 90).and_return(docker_version)
+    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} version --format '{{json .}}'", timeout: 90).and_return(docker_version)
     docker_network_list = File.read(fixtures('facts', 'docker_network_list'))
-    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} network ls | tail -n +2", time_limit: 90).and_return(docker_network_list)
+    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} network ls | tail -n +2", timeout: 90).and_return(docker_network_list)
     docker_network_names = []
     docker_network_list.each_line { |line| docker_network_names.push line.split[1] }
     docker_network_names.each do |network|
       inspect = File.read(fixtures('facts', "docker_network_inspect_#{network}"))
-      allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} network inspect #{network}", time_limit: 90).and_return(inspect)
+      allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} network inspect #{network}", timeout: 90).and_return(inspect)
     end
     docker_worker_token = File.read(fixtures('facts', 'docker_swarm_worker_token'))
-    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} swarm join-token worker -q", time_limit: 90).and_return(docker_worker_token.chomp)
+    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} swarm join-token worker -q", timeout: 90).and_return(docker_worker_token.chomp)
     docker_manager_token = File.read(fixtures('facts', 'docker_swarm_manager_token'))
-    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} swarm join-token manager -q", time_limit: 90).and_return(docker_manager_token.chomp)
+    allow(Facter::Core::Execution).to receive(:execute).with("#{docker_command} swarm join-token manager -q", timeout: 90).and_return(docker_manager_token.chomp)
   end
   after(:each) { Facter.clear }
 


### PR DESCRIPTION
Facter 4 documentation and code was inconsistent regarding naming of
this option.  `limit` and `time_limit` have been replaced by `timeout`
which also match the option name in previous versions of facter.  The
old names will output a warning when used, so swith to the new
terminology now.

Releated PR:
https://github.com/puppetlabs/facter/pull/2429
