### PR TITLE
allow docker::networks::networks param to be undef

### DIFF
--- a/manifests/networks.pp
+++ b/manifests/networks.pp
@@ -3,7 +3,9 @@
 # @param networks
 #
 class docker::networks (
-  $networks
+  Optional[Hash[String, Hash]] $networks = undef,
 ) {
-  create_resources(docker_network, $networks)
+  if $networks {
+    create_resources(docker_network, $networks)
+  }
 }

--- a/spec/classes/networks_spec.rb
+++ b/spec/classes/networks_spec.rb
@@ -61,7 +61,13 @@ describe 'docker::networks', type: :class do
               'ip_range' => params['ip_range'],
             )
           }
+
+          it { is_expected.to have_docker_network_resource_count(1) }
         end
+      end
+
+      context 'with no params' do
+        it { is_expected.to have_docker_network_resource_count(0) }
       end
     end
   end


### PR DESCRIPTION
I would like to include the docker::networks class into the role
(manifest) of nodes which are also including the docker module but not
necessarily always defining docker network(s). This would allow docker
networks to optionally be defined, when needed, via hiera. Currently,
this type of arrangement would require constructing a wrapper class as
the docker::networks::networks parameter is mandatory.