### PR TITLE
Only install docker-ce-cli with docker-ce

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -80,10 +80,6 @@ class docker::install(
           ensure => $ensure,
           name   => $docker::docker_package_name,
         }))
-        ensure_resource('package', 'docker-ce-cli', merge($docker_hash, {
-          ensure => $ensure,
-          name   => $docker::docker_ce_cli_package_name,
-        }))
 
         if $ensure == 'absent' {
           ensure_resource('package', $dependent_packages, {

--- a/spec/shared_examples/install.rb
+++ b/spec/shared_examples/install.rb
@@ -59,12 +59,6 @@ shared_examples 'install' do |_params, _facts|
           'name'   => values['docker_package_name'],
         )
       }
-      it {
-        is_expected.to contain_package('docker-ce-cli').with(
-          'ensure' => ensure_value,
-          'name'   => _params['docker_ce_cli_package_name'],
-        )
-      }
 
       if ensure_value == 'absent'
         _params['dependent_packages'].each do |dependent_package|


### PR DESCRIPTION
In #740 I mistakenly added code that manages the docker-ce-cli package when managing the "docker" package. The docker-ce-cli package should only be managed when also managing the docker-ce package.

Fixes #797