### PR TITLE
pdksync - (GH-iac-334) Remove Support for Ubuntu 14.04/16.04

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,9 +5,9 @@ fixtures:
     powershell: 'puppetlabs-powershell'
     reboot: 'puppetlabs-reboot'
   repositories:
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    provision: 'https://github.com/puppetlabs/provision.git'
     yumrepo_core: 
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/.github/workflows/ubuntu18_pr.yaml
+++ b/.github/workflows/ubuntu18_pr.yaml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-16.04
           - ubuntu-18.04
           - ubuntu-20.04
         collection:

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "18.04",
         "20.04"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,6 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04",
         "18.04",
         "20.04"
       ]


### PR DESCRIPTION
(GH-iac-334) Remove Support for Ubuntu 16.04
pdk version: `2.1.0` 

- Fix put in place for the fixtures.yml
- Removed support for Ubuntu 14.04, seem's to have been missed during an earlier removal sweep