### PR TITLE
Support different Architectures (like `aarch64`) when installing Compose

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -61,7 +61,7 @@ class docker::compose(
     if $raw_url != undef {
       $docker_compose_url = $raw_url
     } else {
-      $docker_compose_url = "${base_url}/${version}/docker-compose-${::kernel}-x86_64${file_extension}"
+      $docker_compose_url = "${base_url}/${version}/docker-compose-${::kernel}-${facter['os']['hardware']}${file_extension}"
     }
 
     if $proxy != undef {

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -61,7 +61,7 @@ class docker::compose(
     if $raw_url != undef {
       $docker_compose_url = $raw_url
     } else {
-      $docker_compose_url = "${base_url}/${version}/docker-compose-${::kernel}-${facter['os']['hardware']}${file_extension}"
+      $docker_compose_url = "${base_url}/${version}/docker-compose-${::kernel}-${facts['os']['hardware']}${file_extension}"
     }
 
     if $proxy != undef {


### PR DESCRIPTION
Note that `aarch64` is only supported for Compose V2.