### PR TITLE
Ignore image digests (`@sha256:...`) when checking for compose services

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
     end
 
     counts = Hash[*compose_services.each.map { |key, array|
-                    image = (array['image']) ? array['image'] : get_image(key, compose_services)
+                    image = ((array['image']) ? array['image'] : get_image(key, compose_services)).gsub(/@sha256:[a-f0-9]+$/i, '')
                     Puppet.info("Checking for compose service #{key} #{image}")
                     ["#{key}-#{image}", compose_containers.count("#{key}-#{image}")]
                   }.flatten]


### PR DESCRIPTION
Fixes #655. 

## Describe the Bug

When `docker_compose` is pointed to a `docker-compose.yml` file that specifies the image like so:

```yml
version: '2'
services:
  my_service:
    image: melville/whale@sha256:58a102090d5e684e1956fdf0ce7bf34084e88cf91d9e423dc6c535aede19d263
    ...
```

then on _every_ Puppet run I'll see

```
Info: Checking for compose project my_project
Info: Checking for compose service my_service melville/whale@sha256:58a102090d5e684e1956fdf0ce7bf34084e88cf91d9e423dc6c535aede19d263
Info: Running compose project my_project
Notice: /Stage[main]/.../Docker_compose[my_project]/ensure: created
```

Note that I specify Docker images using their SHA265 id to ensure consistent deployments to well-known (and audited) versions; image tags may be re-assigned.

## Expected Behavior

`docker-compose ... up ...` should be run only once for every (new) image that needs to be deployed.

## Steps to Reproduce

1. Use a `docker-compose.yml` file with an `image` statement as above, including the image ID. Use the `docker_compose` resource to deploy it.
2. Run Puppet again.

## Environment
 - Version 3.11.0 of this module here