### PR TITLE
Fixed docker facts to check for active swarm clusters before running docker swarm sub-commands.

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -41,6 +41,16 @@ def interfaces
   Facter.value(:interfaces).split(',')
 end
 
+Facter.add(:docker_version) do
+  confine { Facter::Core::Execution.which('docker') }
+  setcode do
+    value = Facter::Core::Execution.execute(
+      "#{docker_command} version --format '{{json .}}'", timeout: 90
+    )
+    JSON.parse(value)
+  end
+end
+
 Facter.add(:docker_client_version) do
   setcode do
     docker_version = Facter.value(:docker_version)
@@ -65,92 +75,77 @@ Facter.add(:docker_server_version) do
   end
 end
 
-Facter.add(:docker_version) do
-  setcode do
-    if Facter::Core::Execution.which('docker')
-      value = Facter::Core::Execution.execute(
-        "#{docker_command} version --format '{{json .}}'", timeout: 90
-      )
-      val = JSON.parse(value)
-    end
-    val
-  end
-end
-
 Facter.add(:docker_worker_join_token) do
+  confine { Facter::Core::Execution.which('docker') }
   setcode do
-    if Facter::Core::Execution.which('docker')
-      # only run `docker swarm` commands if this node is in active in a cluster
-      docker_json_str = Facter::Core::Execution.execute(
-        "#{docker_command} info --format '{{json .}}'", timeout: 90
-      )
-      begin
-        docker = JSON.parse(docker_json_str)
-        if docker.fetch('Swarm', {})['LocalNodeState'] == 'active'
-          val = Facter::Core::Execution.execute(
-            "#{docker_command} swarm join-token worker -q", timeout: 90
-          )
-        end
-      rescue JSON::ParserError
-        nil
+    # only run `docker swarm` commands if this node is in active in a cluster
+    docker_json_str = Facter::Core::Execution.execute(
+      "#{docker_command} info --format '{{json .}}'", timeout: 90
+    )
+    begin
+      docker = JSON.parse(docker_json_str)
+      if docker.fetch('Swarm', {})['LocalNodeState'] == 'active'
+        val = Facter::Core::Execution.execute(
+          "#{docker_command} swarm join-token worker -q", timeout: 90
+        )
       end
+    rescue JSON::ParserError
+      nil
     end
     val
   end
 end
 
 Facter.add(:docker_manager_join_token) do
+  confine { Facter::Core::Execution.which('docker') }
   setcode do
-    if Facter::Core::Execution.which('docker')
-      # only run `docker swarm` commands if this node is in active in a cluster
-      docker_json_str = Facter::Core::Execution.execute(
-        "#{docker_command} info --format '{{json .}}'", timeout: 90
-      )
-      begin
-        docker = JSON.parse(docker_json_str)
-        if docker.fetch('Swarm', {})['LocalNodeState'] == 'active'
-          val = Facter::Core::Execution.execute(
-            "#{docker_command} swarm join-token manager -q", timeout: 90
-          )
-        end
-      rescue JSON::ParserError
-        nil
+    # only run `docker swarm` commands if this node is in active in a cluster
+    docker_json_str = Facter::Core::Execution.execute(
+      "#{docker_command} info --format '{{json .}}'", timeout: 90
+    )
+    begin
+      docker = JSON.parse(docker_json_str)
+      if docker.fetch('Swarm', {})['LocalNodeState'] == 'active'
+        val = Facter::Core::Execution.execute(
+          "#{docker_command} swarm join-token manager -q", timeout: 90
+        )
       end
+    rescue JSON::ParserError
+      nil
     end
     val
   end
 end
 
 Facter.add(:docker) do
+  confine { Facter::Core::Execution.which('docker') }
   setcode do
     docker_version = Facter.value(:docker_client_version)
     if docker_version&.match?(%r{1[0-9][0-2]?[.]\w+})
-      if Facter::Core::Execution.which('docker')
-        docker_json_str = Facter::Core::Execution.execute(
-          "#{docker_command} info --format '{{json .}}'", timeout: 90
-        )
-        begin
-          docker = JSON.parse(docker_json_str)
-          docker['network'] = {}
+      docker_json_str = Facter::Core::Execution.execute(
+        "#{docker_command} info --format '{{json .}}'", timeout: 90
+      )
+      begin
+        docker = JSON.parse(docker_json_str)
+        docker['network'] = {}
 
-          docker['network']['managed_interfaces'] = {}
-          network_list = Facter::Core::Execution.execute("#{docker_command} network ls | tail -n +2", timeout: 90)
-          docker_network_names = []
-          network_list.each_line { |line| docker_network_names.push line.split[1] }
-          docker_network_ids = []
-          network_list.each_line { |line| docker_network_ids.push line.split[0] }
-          docker_network_names.each do |network|
-            inspect = JSON.parse(Facter::Core::Execution.execute("#{docker_command} network inspect #{network}", timeout: 90))
-            docker['network'][network] = inspect[0]
-            network_id = docker['network'][network]['Id'][0..11]
-            interfaces.each do |iface|
-              docker['network']['managed_interfaces'][iface] = network if %r{#{network_id}}.match?(iface)
-            end
+        docker['network']['managed_interfaces'] = {}
+        network_list = Facter::Core::Execution.execute("#{docker_command} network ls | tail -n +2", timeout: 90)
+        docker_network_names = []
+        network_list.each_line { |line| docker_network_names.push line.split[1] }
+        docker_network_ids = []
+        network_list.each_line { |line| docker_network_ids.push line.split[0] }
+        docker_network_names.each do |network|
+          inspect = JSON.parse(Facter::Core::Execution.execute("#{docker_command} network inspect #{network}", timeout: 90))
+          docker['network'][network] = inspect[0]
+          network_id = docker['network'][network]['Id'][0..11]
+          interfaces.each do |iface|
+            docker['network']['managed_interfaces'][iface] = network if %r{#{network_id}}.match?(iface)
           end
-          docker
-        rescue JSON::ParserError
-          nil
         end
+        docker
+      rescue JSON::ParserError
+        nil
       end
     end
   end

--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -80,9 +80,20 @@ end
 Facter.add(:docker_worker_join_token) do
   setcode do
     if Facter::Core::Execution.which('docker')
-      val = Facter::Core::Execution.execute(
-        "#{docker_command} swarm join-token worker -q", timeout: 90
+      # only run `docker swarm` commands if this node is in active in a cluster
+      docker_json_str = Facter::Core::Execution.execute(
+        "#{docker_command} info --format '{{json .}}'", timeout: 90
       )
+      begin
+        docker = JSON.parse(docker_json_str)
+        if docker.fetch('Swarm', {})['LocalNodeState'] == 'active'
+          val = Facter::Core::Execution.execute(
+            "#{docker_command} swarm join-token worker -q", timeout: 90
+          )
+        end
+      rescue JSON::ParserError
+        nil
+      end
     end
     val
   end
@@ -91,13 +102,25 @@ end
 Facter.add(:docker_manager_join_token) do
   setcode do
     if Facter::Core::Execution.which('docker')
-      val = Facter::Core::Execution.execute(
-        "#{docker_command} swarm join-token manager -q", timeout: 90
+      # only run `docker swarm` commands if this node is in active in a cluster
+      docker_json_str = Facter::Core::Execution.execute(
+        "#{docker_command} info --format '{{json .}}'", timeout: 90
       )
+      begin
+        docker = JSON.parse(docker_json_str)
+        if docker.fetch('Swarm', {})['LocalNodeState'] == 'active'
+          val = Facter::Core::Execution.execute(
+            "#{docker_command} swarm join-token manager -q", timeout: 90
+          )
+        end
+      rescue JSON::ParserError
+        nil
+      end
     end
     val
   end
 end
+
 
 Facter.add(:docker) do
   setcode do

--- a/spec/fixtures/facts/docker_info_swarm_inactive
+++ b/spec/fixtures/facts/docker_info_swarm_inactive
@@ -131,7 +131,7 @@
     },
     "ControlAvailable": false,
     "Error": "",
-    "LocalNodeState": "active",
+    "LocalNodeState": "inactive",
     "Managers": 0,
     "NodeAddr": "",
     "NodeID": "",


### PR DESCRIPTION
Closes #702

Previously the docker facts would run `docker swarm` commands without knowing if the node was a member of a swarm cluster. This generated errors in `/var/log/messages` every time facts were collected.

The fix is to check if the node is a member of an active swarm cluster before trying to run the swarm commands. Inspired by: https://stackoverflow.com/questions/43053013/how-do-i-check-that-a-docker-host-is-in-swarm-mode

