### PR TITLE
Fix permission denied issue introduced in v4.2.0

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -14,8 +14,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
   end
 
   has_command(:docker_compose, command(:dockercompose)) do
-    Dir.mkdir('/tmp_docker') unless Dir.exist?('/tmp_docker')
-    ENV.store('TMPDIR', '/tmp_docker')
+    environment(HOME: '/root')
   end
 
   def exists?

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -196,12 +196,6 @@ describe 'docker', type: :class do
               }
             else
               it {
-                # Stub /tmp_docker dir to prevent shelling out during spec test
-                allow(Dir).to receive(:exist?).and_wrap_original do |original_method, a|
-                  original_method.call(a)
-                end
-                allow(Dir).to receive(:exist?).with('/tmp_docker').and_return(true)
-
                 is_expected.to contain_class('docker::repos').that_comes_before('Class[docker::install]')
                 is_expected.to contain_class('docker::install').that_comes_before('Class[docker::config]')
                 is_expected.to contain_class('docker::config').that_comes_before('Class[docker::service]')

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -2,15 +2,6 @@
 
 require 'spec_helper'
 
-# Stub /tmp_docker dir to prevent shelling out during spec test
-class Dir
-  class << self
-    def exist?(var)
-      return true if var == '/tmp_docker'
-    end
-  end
-end
-
 tests = {
   'with ensure => absent' => {
     'ensure' => 'absent',

--- a/spec/unit/lib/puppet/type/docker_compose_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_compose_spec.rb
@@ -2,15 +2,6 @@
 
 require 'spec_helper'
 
-# Stub /tmp_docker dir to prevent shelling out during spec test
-class Dir
-  class << self
-    def exist?(var)
-      return true if var == '/tmp_docker'
-    end
-  end
-end
-
 compose = Puppet::Type.type(:docker_compose)
 
 describe compose do


### PR DESCRIPTION
# Context

This PR fixes #819 

# What has changed?

This PR reverts the modification of the TMPDIR environment variable from the previous release. This change was made to fix a bug in docker compose where some processes would fail if the noexec bit had been set on /tmp. However this change caused unexpected failures in certain environments.