### PR TITLE
Add tmpdir option to docker_compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ When setting up TLS, upload the related files (CA certificate, server certificat
 
 ```puppet
 class { 'docker':
-  tcp_bind        => ['tcp://0.0.0.0:2376'],
-  tls_enable      => true,
-  tls_cacert      => '/etc/docker/tls/ca.pem',
-  tls_cert        => '/etc/docker/tls/cert.pem',
-  tls_key         => '/etc/docker/tls/key.pem',
+  tcp_bind   => ['tcp://0.0.0.0:2376'],
+  tls_enable => true,
+  tls_cacert => '/etc/docker/tls/ca.pem',
+  tls_cert   => '/etc/docker/tls/cert.pem',
+  tls_key    => '/etc/docker/tls/key.pem',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To use the CE packages, add the following code to the manifest file:
 ```puppet
 class { 'docker':
   use_upstream_package_source => false,
-  repo_opt => '',
+  repo_opt                    => '',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ To install Docker EE on RHEL/CentOS:
 
 ```puppet
 class { 'docker':
-  docker_ee => true,
+  docker_ee                 => true,
   docker_ee_source_location => 'https://<docker_ee_repo_url>',
-  docker_ee_key_source => 'https://<docker_ee_key_source_url>',
+  docker_ee_key_source      => 'https://<docker_ee_key_source_url>',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ By default, the Docker daemon binds to a unix socket at `/var/run/docker.sock`. 
 
 ```puppet
 class { 'docker':
-  tcp_bind        => ['tcp://127.0.0.1:2375'],
-  socket_bind     => 'unix:///var/run/docker.sock',
-  ip_forward      => true,
-  iptables        => true,
-  ip_masq         => true,
-  bip             => '192.168.1.1/24',
-  fixed_cidr      => '192.168.1.144/28',
+  tcp_bind    => ['tcp://127.0.0.1:2375'],
+  socket_bind => 'unix:///var/run/docker.sock',
+  ip_forward  => true,
+  iptables    => true,
+  ip_masq     => true,
+  bip         => '192.168.1.1/24',
+  fixed_cidr  => '192.168.1.144/28',
 }
 ```
 
@@ -132,7 +132,7 @@ The default group ownership of the Unix control socket differs based on OS. For 
 
 ```puppet
 class {'docker':
-  socket_group => 'root',
+  socket_group    => 'root',
   socket_override => true,
 }
 ```
@@ -965,14 +965,14 @@ Within the context of a running container, the docker module supports arbitrary 
 
 ```puppet
 docker::exec { 'cron_allow_root':
-  detach       => true,
-  container    => 'mycontainer',
-  command      => '/bin/echo root >> /usr/lib/cron/cron.allow',
-  onlyif       => 'running',
-  tty          => true,
-  env          => ['FOO=BAR', 'FOO2=BAR2'],
-  unless       => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
-  refreshonly  => true,
+  detach      => true,
+  container   => 'mycontainer',
+  command     => '/bin/echo root >> /usr/lib/cron/cron.allow',
+  onlyif      => 'running',
+  tty         => true,
+  env         => ['FOO=BAR', 'FOO2=BAR2'],
+  unless      => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
+  refreshonly => true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -477,10 +477,10 @@ To enable the restart of an unhealthy container, add the following code to the m
 
 ```puppet
 docker::run { 'helloworld':
-  image => 'base',
-  command => 'command',
-  health_check_cmd => '<command_to_execute_to_check_your_containers_health>',
-  restart_on_unhealthy => true,
+  image                 => 'base',
+  command               => 'command',
+  health_check_cmd      => '<command_to_execute_to_check_your_containers_health>',
+  restart_on_unhealthy  => true,
   health_check_interval => '<time between running docker healthcheck>',
 ```
 
@@ -488,7 +488,7 @@ To run command on Windows 2016 requires the `restart` parameter to be set:
 
 ```puppet
 docker::run { 'helloworld':
-  image => 'microsoft/nanoserver',
+  image   => 'microsoft/nanoserver',
   command => 'ping 127.0.0.1 -t',
   restart => 'always'
 ```
@@ -611,7 +611,7 @@ To install Docker Compose, add the following code to the manifest file:
 
 ```puppet
 class {'docker::compose':
-  ensure => present,
+  ensure  => present,
   version => '1.9.0',
 }
 ```
@@ -631,22 +631,25 @@ Specify the `file` resource to add a Compose file to the machine you have Puppet
 ```puppet
 docker_compose { 'test':
   compose_files => ['/tmp/docker-compose.yml'],
-  ensure  => present,
+  ensure        => present,
 }
 ```
 
 Puppet automatically runs Compose because the relevant Compose services aren't running. If required, include additional options such as enabling experimental features and scaling rules.
 
-In the example below, Puppet runs Compose when the number of containers specified for a service doesn't match the scale values.
+Additionally, the TMPDIR environment variable can optionally be set when docker_compose runs if you want Puppet to manage the environment variable within the scope of the resource. This is effective when noexec is set on the default /tmp dir, however you must ensure that the target directory exists as the resource will not create it.
+
+In the example below, Puppet runs Compose when the number of containers specified for a service doesn't match the scale values.  The optional tmpdir parameter is also specified.
 
 ```puppet
 docker_compose { 'test':
   compose_files => ['/tmp/docker-compose.yml'],
-  ensure  => present,
-  scale   => {
+  ensure        => present,
+  scale         => {
     'compose_test' => 2,
   },
-  options => ['--x-networking']
+  tmpdir        => '/usr/local/share/tmp_docker',
+  options       => ['--x-networking']
 }
 ```
 
@@ -670,10 +673,10 @@ To deploy the stack, add the following code to the manifest file:
 
 ```puppet
  docker::stack { 'yourapp':
-   ensure  => present,
-   stack_name => 'yourapp',
+   ensure        => present,
+   stack_name    => 'yourapp',
    compose_files => ['/tmp/docker-compose.yaml'],
-   require => [Class['docker'], File['/tmp/docker-compose.yaml']],
+   require       => [Class['docker'], File['/tmp/docker-compose.yaml']],
 }
 ```
 
@@ -685,11 +688,11 @@ To deploy the stack, add the following code to the manifest file.
 
 ```puppet
 docker::stack { 'yourapp':
-  ensure  => present,
-  stack_name => 'yourapp',
-  compose_files => ['/tmp/docker-compose.yaml'],
+  ensure             => present,
+  stack_name         => 'yourapp',
+  compose_files      => ['/tmp/docker-compose.yaml'],
   with_registry_auth => true,
-  require => [Class['docker'], File['/tmp/docker-compose.yaml']],
+  require            => [Class['docker'], File['/tmp/docker-compose.yaml']],
 }
 ```
 
@@ -698,8 +701,8 @@ To use the equivalent type and provider, use the following in your manifest file
 ```puppet
 docker_stack { 'test':
   compose_files => ['/tmp/docker-compose.yml'],
-  ensure  => present,
-  up_args => '--with-registry-auth',
+  ensure        => present,
+  up_args       => '--with-registry-auth',
 }
 ```
 
@@ -717,7 +720,7 @@ To install Docker Machine, add the following code to the manifest file:
 
 ```puppet
 class {'docker::machine':
-  ensure => present,
+  ensure  => present,
   version => '1.16.1',
 }
 ```
@@ -834,14 +837,14 @@ To create a Docker service, add the following code to the manifest file:
 
 ```puppet
 docker::services {'redis':
-    create => true,
+    create       => true,
     service_name => 'redis',
-    image => 'redis:latest',
-    publish => '6379:639',
-    replicas => '5',
-    mounts => ['type=bind,source=/etc/my-redis.conf,target=/etc/redis/redis.conf,readonly'],
+    image        => 'redis:latest',
+    publish      => '6379:639',
+    replicas     => '5',
+    mounts       => ['type=bind,source=/etc/my-redis.conf,target=/etc/redis/redis.conf,readonly'],
     extra_params => ['--update-delay 1m', '--restart-window 30s'],
-    command => ['redis-server', '--appendonly', 'yes'],
+    command      => ['redis-server', '--appendonly', 'yes'],
   }
 ```
 
@@ -851,10 +854,10 @@ To update the service, add the following code to the manifest file:
 
 ```puppet
 docker::services {'redis_update':
-  create => false,
-  update => true,
+  create       => false,
+  update       => true,
   service_name => 'redis',
-  replicas => '3',
+  replicas     => '3',
 }
 ```
 
@@ -864,10 +867,10 @@ To scale a service, add the following code to the manifest file:
 
 ```puppet
 docker::services {'redis_scale':
-  create => false,
-  scale => true,
+  create       => false,
+  scale        => true,
   service_name => 'redis',
-  replicas => '10',
+  replicas     => '10',
 }
 ```
 
@@ -877,8 +880,8 @@ To remove a service, add the following code to the manifest file:
 
 ```puppet
 docker::services {'redis':
-  create => false,
-  ensure => 'absent',
+  create       => false,
+  ensure       => 'absent',
   service_name => 'redis',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Docker provides a enterprise addition of the [Docker Engine](https://www.docker.
 
 ```puppet
 class { 'docker':
-  docker_ee => true,
+  docker_ee                 => true,
   docker_ee_source_location => 'https://<docker_ee_repo_url>',
-  docker_ee_key_source => 'https://<docker_ee_key_source_url>',
-  docker_ee_key_id => '<key id>',
+  docker_ee_key_source      => 'https://<docker_ee_key_source_url>',
+  docker_ee_key_id          => '<key id>',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To track the latest version of Docker, add the following code to the manifest fi
 
 ```puppet
 class { 'docker':
-  version => 'latest',
+  version => latest,
 }
 ```
 

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
       # Check if the the tmpdir target exists
       Puppet.warning("#{resource[:tmpdir]} (defined as docker_compose tmpdir) does not exist") unless Dir.exist?(resource[:tmpdir])
       # Set TMPDIR environment variable only if defined among resources and exists
-      ENV['TMPDIR'] = resource[:tmpdir] unless !resource[:tmpdir] unless !Dir.exist?(resource[:tmpdir])
+      ENV['TMPDIR'] = resource[:tmpdir] unless !Dir.exist?(resource[:tmpdir])
     end
   end
 

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -17,10 +17,17 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
     environment(HOME: '/root')
   end
 
+  def set_tmpdir
+    # Set TMPDIR environment variable only if defined among resources
+    ENV['TMPDIR'] = resource[:tmpdir] unless !resource[:tmpdir]
+  end
+
   def exists?
     Puppet.info("Checking for compose project #{name}")
     compose_services = {}
     compose_containers = []
+
+    set_tmpdir
 
     # get merged config using docker-compose config
     args = [compose_files, '-p', name, 'config'].insert(3, resource[:options]).compact

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -18,8 +18,12 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
   end
 
   def set_tmpdir
-    # Set TMPDIR environment variable only if defined among resources
-    ENV['TMPDIR'] = resource[:tmpdir] unless !resource[:tmpdir]
+    if resource[:tmpdir]
+      # Check if the the tmpdir target exists
+      Puppet.warning("#{resource[:tmpdir]} (defined as docker_compose tmpdir) does not exist") unless Dir.exist?(resource[:tmpdir])
+      # Set TMPDIR environment variable only if defined among resources
+      ENV['TMPDIR'] = resource[:tmpdir] unless !resource[:tmpdir] unless !Dir.exist?(resource[:tmpdir])
+    end
   end
 
   def exists?

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -18,12 +18,11 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
   end
 
   def set_tmpdir
-    if resource[:tmpdir]
-      # Check if the the tmpdir target exists
-      Puppet.warning("#{resource[:tmpdir]} (defined as docker_compose tmpdir) does not exist") unless Dir.exist?(resource[:tmpdir])
-      # Set TMPDIR environment variable only if defined among resources and exists
-      ENV['TMPDIR'] = resource[:tmpdir] unless !Dir.exist?(resource[:tmpdir])
-    end
+    return unless resource[:tmpdir]
+    # Check if the the tmpdir target exists
+    Puppet.warning("#{resource[:tmpdir]} (defined as docker_compose tmpdir) does not exist") unless Dir.exist?(resource[:tmpdir])
+    # Set TMPDIR environment variable only if defined among resources and exists
+    ENV['TMPDIR'] = resource[:tmpdir] if Dir.exist?(resource[:tmpdir])
   end
 
   def exists?

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
     if resource[:tmpdir]
       # Check if the the tmpdir target exists
       Puppet.warning("#{resource[:tmpdir]} (defined as docker_compose tmpdir) does not exist") unless Dir.exist?(resource[:tmpdir])
-      # Set TMPDIR environment variable only if defined among resources
+      # Set TMPDIR environment variable only if defined among resources and exists
       ENV['TMPDIR'] = resource[:tmpdir] unless !resource[:tmpdir] unless !Dir.exist?(resource[:tmpdir])
     end
   end

--- a/lib/puppet/type/docker_compose.rb
+++ b/lib/puppet/type/docker_compose.rb
@@ -47,4 +47,19 @@ Puppet::Type.newtype(:docker_compose) do
     isnamevar
     desc 'The name of the project'
   end
+
+  newparam(:tmpdir) do
+    desc "Override the temporary directory used by docker-compose.
+
+    This property is useful when the /tmp directory has been mounted
+    with the noexec option. Or is otherwise being prevented  It allows the module consumer to redirect
+    docker-composes temporary files to a known directory.
+
+    The directory passed to this property must exist and be accessible
+    by the user that is executing the puppet agent.
+    "
+    validate do |value|
+      raise _('tmpdir should be a String') unless value.is_a? String
+    end
+  end
 end

--- a/spec/unit/lib/puppet/type/docker_compose_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_compose_spec.rb
@@ -44,4 +44,8 @@ describe compose do
   it 'requires scale to be a hash' do
     expect(compose).to require_hash_for('scale')
   end
+
+  it 'requires tmpdir to be a string' do
+    expect(compose).to require_string_for('tmpdir')
+  end
 end


### PR DESCRIPTION
This pull request adds an optional tmpdir parameter to the docker_compose resource.  It is useful on systems where the default /tmp directory is mounted with noexec, or consumers wish to specify an alternate tmpdir other than the system-wide environment variable.  Note that it does **_not_** create the target directory, the consumer is responsible to ensure that the directory exists and is executable.

As well as adding the type from @chelnak  example, I have added the following to the provider, which includes verification that the tmpdir target exists, warns and does not set the env var if not.  If there is a better way to perform this in Ruby, please comment.

```Ruby
  def set_tmpdir
    return unless resource[:tmpdir]
    # Check if the the tmpdir target exists
    Puppet.warning("#{resource[:tmpdir]} (defined as docker_compose tmpdir) does not exist") unless Dir.exist?(resource[:tmpdir])
    # Set TMPDIR environment variable only if defined among resources and exists
    ENV['TMPDIR'] = resource[:tmpdir] if Dir.exist?(resource[:tmpdir])
  end
```

The changes pass unit tests and have been verified with the following manifest
```puppet
class test {

  file { '/usr/local/share/tmp_docker':
    ensure => directory
  }

  class { 'docker':
    log_driver => 'journald',
  }
  
  $compose = "compose_test:
    image: ubuntu:14.04
    command: /bin/sh -c 'while true; do echo hello world; sleep 1; done'
  "
  
  file { '/tmp/compose.yml':
    content => $compose
  }
  
  class { 'docker::compose':
    ensure => present,
  }
  
  docker_compose {'test':
    ensure => present,
    compose_files => [
      '/tmp/compose.yml'
    ],
    tmpdir => '/usr/local/share/tmp_docker',
    scale  => {
      compose_test => 3
    },
  }
  docker_compose {'test2':
    ensure => present,
    compose_files => [
      '/tmp/compose.yml'
    ],
  }
}
```
**Note1**:  this implementation is optional, and does not affect global TMPDIR environment variable (as tested on Linux) as it only applies within the docker_compose resource.  I have also updated the readme to reflect that this is optional.

**Note2**: if any resource has the tmpdir param set, subsequent resources will inherit it unless they specify a different tmpdir target.  Therefore it only has to be specified in the first resource if you want it to apply to all (as per above example, test2 will also use the same tmpdir, however if test2 was declared first it would use the system TMPDIR variable or default to /tmp if not set and fail if that dir is noexec).  If subsequent resource tmpdir is defined but does not exist, a warning is raised and the previously successful tmpdir value is used.

Apologies for the previous attempt at this that also managed directory creation and introduced a breaking change on first puppet run (though other changes in that merge did fix idempotency with scaling).  This however is a more considered approach to address issue as reported at https://github.com/docker/compose/issues/8041 and experienced on hardened systems with noexec on /tmp.  

I have not expanded the acceptance test for these changes, and defer to maintainers if they wish to add one.

Any comment or suggestions are welcome.
