### PR TITLE
Support Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
This declares Ubuntu 22.04 as compatible in the `metadata.json` file.