### PR TITLE
Fix docker-compose, network and volumes not applying on 1st run, fix other idempotency

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -6,16 +6,10 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
   desc 'Support for Puppet running Docker Compose'
 
   mk_resource_methods
-  commands dockercompose: 'docker-compose'
-  commands dockercmd: 'docker'
 
-  has_command(:docker, command(:dockercmd)) do
-    environment(HOME: '/root')
-  end
+  has_command(:docker, 'docker')
 
-  has_command(:dockercompose, command(:dockercompose)) do
-    environment(HOME: '/root')
-  end
+  has_command(:dockercompose, 'docker-compose')
 
   def set_tmpdir
     return unless resource[:tmpdir]

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
     environment(HOME: '/root')
   end
 
-  has_command(:docker_compose, command(:dockercompose)) do
+  has_command(:dockercompose, command(:dockercompose)) do
     environment(HOME: '/root')
   end
 

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -6,11 +6,8 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
   desc 'Support for Docker Networking'
 
   mk_resource_methods
-  commands dockercmd: 'docker'
 
-  has_command(:docker, command(:dockercmd)) do
-    environment(HOME: '/root')
-  end
+  has_command(:docker, 'docker')
 
   def network_conf
     flags = ['network', 'create']

--- a/lib/puppet/provider/docker_stack/ruby.rb
+++ b/lib/puppet/provider/docker_stack/ruby.rb
@@ -6,11 +6,8 @@ Puppet::Type.type(:docker_stack).provide(:ruby) do
   desc 'Support for Puppet running Docker Stacks'
 
   mk_resource_methods
-  commands dockercmd: 'docker'
 
-  has_command(:docker, command(:dockercmd)) do
-    environment(HOME: '/root')
-  end
+  has_command(:docker, 'docker')
 
   def exists?
     Puppet.info("Checking for stack #{name}")

--- a/lib/puppet/provider/docker_volume/ruby.rb
+++ b/lib/puppet/provider/docker_volume/ruby.rb
@@ -6,11 +6,8 @@ Puppet::Type.type(:docker_volume).provide(:ruby) do
   desc 'Support for Docker Volumes'
 
   mk_resource_methods
-  commands dockercmd: 'docker'
 
-  has_command(:docker, command(:dockercmd)) do
-    environment(HOME: '/root')
-  end
+  has_command(:docker, 'docker')
 
   def volume_conf
     flags = ['volume', 'create']

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -100,6 +100,7 @@ class docker::compose (
       file { $docker_compose_location_versioned:
         owner   => $file_owner,
         mode    => '0755',
+        seltype => 'container_runtime_exec_t',
         require => Exec["Install Docker Compose ${version}"],
       }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,7 +91,7 @@ class docker::params {
 
   if ($facts['os']['family'] == 'windows') {
     $compose_install_path   = "${::docker_program_files_path}/Docker"
-    $compose_version        = '1.21.2'
+    $compose_version        = '1.29.2'
     $docker_ee_package_name = 'Docker'
     $machine_install_path   = "${::docker_program_files_path}/Docker"
     $tls_cacert             = "${::docker_program_data_path}/docker/certs.d/ca.pem"
@@ -99,7 +99,7 @@ class docker::params {
     $tls_key                = "${::docker_program_data_path}/docker/certs.d/server-key.pem"
   } else {
     $compose_install_path   = '/usr/local/bin'
-    $compose_version        = '1.21.2'
+    $compose_version        = '1.29.2'
     $docker_ee_package_name = 'docker-ee'
     $machine_install_path   = '/usr/local/bin'
     $tls_cacert             = '/etc/docker/tls/ca.pem'

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -590,6 +590,7 @@ define docker::run (
       file { $initscript:
         ensure  => file,
         content => template($init_template),
+        seltype => 'container_unit_file_t',
         owner   => 'root',
         group   => $docker_group,
         mode    => $mode,

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -572,6 +572,7 @@ define docker::run (
         file { $startscript:
           ensure  => file,
           content => epp($startstop_template, { 'script' => $docker_run_inline_start }),
+          seltype => 'container_runtime_exec_t',
           owner   => 'root',
           group   => $docker_group,
           mode    => '0770',
@@ -581,6 +582,7 @@ define docker::run (
         file { $stopscript:
           ensure  => file,
           content => epp($startstop_template, { 'script' => $docker_run_inline_stop }),
+          seltype => 'container_runtime_exec_t',
           owner   => 'root',
           group   => $docker_group,
           mode    => '0770',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -334,6 +334,7 @@ class docker::service (
         file { '/etc/systemd/system/docker.socket.d/socket-overrides.conf':
           ensure  => file,
           content => template($socket_overrides_template),
+          seltype => 'container_unit_file_t',
           notify  => Exec['docker-systemd-reload-before-service'],
           before  => $_manage_service,
         }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -320,6 +320,7 @@ class docker::service (
         file { '/etc/systemd/system/docker.service.d/service-overrides.conf':
           ensure  => file,
           content => template($service_overrides_template),
+          seltype => 'container_unit_file_t',
           notify  => Exec['docker-systemd-reload-before-service'],
           before  => $_manage_service,
         }


### PR DESCRIPTION
These changes appear to fix the issue where the docker and docker-compose binaries are not found on first run, by removing the early realizing of those resources before they actually exist.

A further issue with selinux context being reset on container `.system` files,  `service-overrides.conf` and `socket-overrides.conf` is also fixed by setting the seltype upon creating these files.  This also prevents containers being restarted as a result.

Despite the removal of `commands` in the provider files, the `has_command` appears to be sufficient to allow the binaries to be located at runtime and after first installation.  The `HOME: '/root'` environment parameter has also been removed from the providers without perceived side-effect.

I have tested these changes to the desired effect, however welcome others to test and verify please.