### PR TITLE
New create_user parameter on main class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,9 +1,12 @@
-# @summary
+# @summary Configuration for docker
+# @api private
 #
 class docker::config {
   if $facts['os']['family'] != 'windows' {
     $docker::docker_users.each |$user| {
-      docker::system_user { $user: }
+      docker::system_user { $user:
+        create_user => $docker::create_user,
+      }
     }
   } else {
     $docker::docker_users.each |$user| {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -259,6 +259,9 @@
 # @param docker_users
 #   Specify an array of users to add to the docker group
 #
+# @param create_user
+#   If `true` the list of `docker_users` will be created as well as added to the docker group
+#
 # @param docker_group
 #   Specify a string for the docker group
 #
@@ -446,6 +449,7 @@ class docker (
   Optional[String]                        $package_source                    = $docker::params::package_source,
   Optional[String]                        $service_name                      = $docker::params::service_name,
   Array                                   $docker_users                      = [],
+  Boolean                                 $create_user                       = true,
   String                                  $docker_group                      = $docker::params::docker_group,
   Array                                   $daemon_environment_files          = [],
   Optional[Variant[String,Hash]]          $repo_opt                          = $docker::params::repo_opt,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -65,6 +65,7 @@ describe 'docker', type: :class do
             'apt_source_pin_level'              => defaults['apt_source_pin_level'],
             'bip'                               => defaults['bip'],
             'bridge'                            => defaults['bridge'],
+            'create_user'                       => true,
             'daemon_environment_files'          => [],
             'default_gateway_ipv6'              => defaults['default_gateway_ipv6'],
             'default_gateway'                   => defaults['default_gateway'],


### PR DESCRIPTION
Currently when specifying `docker_users` every user is
both created and added to the docker group.

If `create_user` is false then the users are presumed to exist
via another method outside this module and will only be added to
the docker group.

Fixes #840