### PR TITLE
Simplify idempotency check

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -32,15 +32,15 @@
 # @param version
 #
 define docker::registry (
-  Optional[String]               $server          = $title,
-  Optional[Enum[present, absent]] $ensure         = 'present',
-  Optional[String]               $username        = undef,
-  Optional[String]               $password        = undef,
-  Optional[String]               $pass_hash       = undef,
-  Optional[String]               $email           = undef,
-  Optional[String]               $local_user      = 'root',
-  Optional[String]               $local_user_home = undef,
-  Optional[String]               $version         = $docker::version,
+  Optional[String]      $server          = $title,
+  Enum[present, absent] $ensure          = 'present',
+  Optional[String]      $username        = undef,
+  Optional[String]      $password        = undef,
+  Optional[String]      $pass_hash       = undef,
+  Optional[String]      $email           = undef,
+  Optional[String]      $local_user      = 'root',
+  Optional[String]      $local_user_home = undef,
+  Optional[String]      $version         = $docker::version,
 ) {
   include docker::params
 
@@ -48,18 +48,18 @@ define docker::registry (
 
   if $facts['os']['family'] == 'windows' {
     $exec_environment = [ "PATH=${::docker_program_files_path}/Docker/", ]
-    $exec_timeout = 3000
-    $exec_path = [ "${::docker_program_files_path}/Docker/", ]
-    $exec_provider = 'powershell'
-    $password_env = '$env:password'
-    $exec_user = undef
+    $exec_timeout     = 3000
+    $exec_path        = [ "${::docker_program_files_path}/Docker/", ]
+    $exec_provider    = 'powershell'
+    $password_env     = '$env:password'
+    $exec_user        = undef
   } else {
     $exec_environment = []
-    $exec_path = [ '/bin', '/usr/bin', ]
-    $exec_timeout = 0
-    $exec_provider = undef
-    $password_env = "\${password}"
-    $exec_user = $local_user
+    $exec_path        = [ '/bin', '/usr/bin', ]
+    $exec_timeout     = 0
+    $exec_provider    = undef
+    $password_env     = "\${password}"
+    $exec_user        = $local_user
     if $local_user_home {
       $_local_user_home = $local_user_home
     } else {

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -47,15 +47,15 @@ define docker::registry (
   $docker_command = $docker::params::docker_command
 
   if $facts['os']['family'] == 'windows' {
-    $exec_environment = [ "PATH=${::docker_program_files_path}/Docker/", ]
+    $exec_environment = ["PATH=${::docker_program_files_path}/Docker/",]
     $exec_timeout     = 3000
-    $exec_path        = [ "${::docker_program_files_path}/Docker/", ]
+    $exec_path        = ["${::docker_program_files_path}/Docker/",]
     $exec_provider    = 'powershell'
     $password_env     = '$env:password'
     $exec_user        = undef
   } else {
     $exec_environment = []
-    $exec_path        = [ '/bin', '/usr/bin', ]
+    $exec_path        = ['/bin', '/usr/bin',]
     $exec_timeout     = 0
     $exec_provider    = undef
     $password_env     = "\${password}"

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -33,7 +33,7 @@
 #
 define docker::registry (
   Optional[String]      $server          = $title,
-  Enum[present, absent] $ensure          = 'present',
+  Enum[present,absent]  $ensure          = 'present',
   Optional[String]      $username        = undef,
   Optional[String]      $password        = undef,
   Optional[String]      $pass_hash       = undef,

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -28,42 +28,38 @@
 #
 # @param local_user_home
 #   The local user home directory.
-#   
-# @param receipt
-#   Required to be true for idempotency
 #
 # @param version
 #
 define docker::registry (
-  Optional[String]      $server          = $title,
-  Enum[present,absent]  $ensure          = 'present',
-  Optional[String]      $username        = undef,
-  Optional[String]      $password        = undef,
-  Optional[String]      $pass_hash       = undef,
-  Optional[String]      $email           = undef,
-  String                $local_user      = 'root',
-  Optional[String]      $local_user_home = undef,
-  Optional[String]      $version         = $docker::version,
-  Boolean               $receipt         = true,
+  Optional[String]               $server          = $title,
+  Optional[Enum[present, absent]] $ensure         = 'present',
+  Optional[String]               $username        = undef,
+  Optional[String]               $password        = undef,
+  Optional[String]               $pass_hash       = undef,
+  Optional[String]               $email           = undef,
+  Optional[String]               $local_user      = 'root',
+  Optional[String]               $local_user_home = undef,
+  Optional[String]               $version         = $docker::version,
 ) {
   include docker::params
 
   $docker_command = $docker::params::docker_command
 
   if $facts['os']['family'] == 'windows' {
-    $exec_environment = ["PATH=${::docker_program_files_path}/Docker/",]
-    $exec_timeout     = 3000
-    $exec_path        = ["${::docker_program_files_path}/Docker/",]
-    $exec_provider    = 'powershell'
-    $password_env     = '$env:password'
-    $exec_user        = undef
+    $exec_environment = [ "PATH=${::docker_program_files_path}/Docker/", ]
+    $exec_timeout = 3000
+    $exec_path = [ "${::docker_program_files_path}/Docker/", ]
+    $exec_provider = 'powershell'
+    $password_env = '$env:password'
+    $exec_user = undef
   } else {
     $exec_environment = []
-    $exec_path        = ['/bin', '/usr/bin',]
-    $exec_timeout     = 0
-    $exec_provider    = undef
-    $password_env     = "\${password}"
-    $exec_user        = $local_user
+    $exec_path = [ '/bin', '/usr/bin', ]
+    $exec_timeout = 0
+    $exec_provider = undef
+    $password_env = "\${password}"
+    $exec_user = $local_user
     if $local_user_home {
       $_local_user_home = $local_user_home
     } else {
@@ -76,18 +72,19 @@ define docker::registry (
   }
 
   if $ensure == 'present' {
-    if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/ {
-      $auth_cmd         = "${docker_command} login -u '${username}' -p \"${password_env}\" -e '${email}' ${server}"
+    if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/
+    {
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"${password_env}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     } elsif $username != undef and $password != undef {
-      $auth_cmd         = "${docker_command} login -u '${username}' -p \"${password_env}\" ${server}"
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"${password_env}\" ${server}"
       $auth_environment = "password=${password}"
     } else {
-      $auth_cmd         = "${docker_command} login ${server}"
+      $auth_cmd = "${docker_command} login ${server}"
       $auth_environment = ''
     }
   }  else {
-    $auth_cmd         = "${docker_command} logout ${server}"
+    $auth_cmd = "${docker_command} logout ${server}"
     $auth_environment = ''
   }
 
@@ -99,61 +96,13 @@ define docker::registry (
     $exec_env = concat($exec_environment, "docker_auth=${docker_auth}")
   }
 
-  if $receipt {
-    if $facts['os']['family'] != 'windows' {
-      # server may be an URI, which can contain /
-      $server_strip = regsubst($server, '/', '_', 'G')
-
-      # no - with pw_hash
-      $local_user_strip = regsubst($local_user, '[-_]', '', 'G')
-
-      $_pass_hash = $pass_hash ? {
-        Undef   => pw_hash($docker_auth, 'SHA-512', $local_user_strip),
-        default => $pass_hash
-      }
-
-      $_auth_command = "${auth_cmd} || (rm -f \"/${_local_user_home}/registry-auth-puppet_receipt_${server_strip}_${local_user}\"; exit 1;)"
-
-      file { "/${_local_user_home}/registry-auth-puppet_receipt_${server_strip}_${local_user}":
-        ensure  => $ensure,
-        content => $_pass_hash,
-        owner   => $local_user,
-        group   => $local_user,
-        notify  => Exec["${title} auth"],
-      }
-    } else {
-      # server may be an URI, which can contain /
-      $server_strip  = regsubst($server, '[/:]', '_', 'G')
-      $passfile      = "${::docker_user_temp_path}/registry-auth-puppet_receipt_${server_strip}_${local_user}"
-      $_auth_command = "if (-not (${auth_cmd})) { Remove-Item -Path ${passfile} -Force -Recurse -EA SilentlyContinue; exit 1 } else { exit 0 }" # lint:ignore:140chars
-
-      if $ensure == 'absent' {
-        file { $passfile:
-          ensure => $ensure,
-          notify => Exec["${title} auth"],
-        }
-      } elsif $ensure == 'present' {
-        exec { 'compute-hash':
-          command     => template('docker/windows/compute_hash.ps1.erb'),
-          environment => $exec_env,
-          provider    => $exec_provider,
-          logoutput   => true,
-          unless      => template('docker/windows/check_hash.ps1.erb'),
-          notify      => Exec["${title} auth"],
-        }
-      }
-    }
-  } else {
-    $_auth_command = $auth_cmd
-  }
-
   exec { "${title} auth":
     environment => $exec_env,
-    command     => $_auth_command,
+    command     => $auth_cmd,
     user        => $exec_user,
     path        => $exec_path,
     timeout     => $exec_timeout,
     provider    => $exec_provider,
-    refreshonly => $receipt,
+    creates     => "/${_local_user_home}/.docker/config.json",
   }
 }

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -38,7 +38,7 @@ define docker::registry (
   Optional[String]      $password        = undef,
   Optional[String]      $pass_hash       = undef,
   Optional[String]      $email           = undef,
-  Optional[String]      $local_user      = 'root',
+  String                $local_user      = 'root',
   Optional[String]      $local_user_home = undef,
   Optional[String]      $version         = $docker::version,
 ) {
@@ -72,19 +72,18 @@ define docker::registry (
   }
 
   if $ensure == 'present' {
-    if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/
-    {
-      $auth_cmd = "${docker_command} login -u '${username}' -p \"${password_env}\" -e '${email}' ${server}"
+    if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/ {
+      $auth_cmd         = "${docker_command} login -u '${username}' -p \"${password_env}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     } elsif $username != undef and $password != undef {
-      $auth_cmd = "${docker_command} login -u '${username}' -p \"${password_env}\" ${server}"
+      $auth_cmd         = "${docker_command} login -u '${username}' -p \"${password_env}\" ${server}"
       $auth_environment = "password=${password}"
     } else {
-      $auth_cmd = "${docker_command} login ${server}"
+      $auth_cmd         = "${docker_command} login ${server}"
       $auth_environment = ''
     }
   }  else {
-    $auth_cmd = "${docker_command} logout ${server}"
+    $auth_cmd         = "${docker_command} logout ${server}"
     $auth_environment = ''
   }
 


### PR DESCRIPTION
If the receipt is only for idempotency, then we can simply use "creates" instead. 

I am not sure if I am fulfilling all requirements here. 

Closes https://github.com/puppetlabs/puppetlabs-docker/issues/842