### PR TITLE
Update systemd docker run template, remove WantedBy=multi-user.target to avoid ordering cycle

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -42,7 +42,6 @@ RemainAfterExit=<%= @remain_after_exit %>
 <%- end -%>
 
 [Install]
-WantedBy=multi-user.target
 <%- if @service_name -%>
 WantedBy=<%= @service_name %>.service
 <%- end -%>


### PR DESCRIPTION
When running docker-based services, puppet creates systemd startup file named  docker-<myservice>.service with dependency on `docker.service` and `multi-user.target`. 

docker.service depends on multi-user.target.
docker-<myservice> adds  WantedBy=multi-user.target that creates complement circular  dependency

According to docs:
```
Target units will automatically complement all configured dependencies of type Wants= or Requires= with dependencies of type After= unless DefaultDependencies=no is set in the specified units.
```

Service dependency graph looks like:
`docker-<myservice> -> docker.service -> multi-user.target ->  docker-<myservice>  -> .....`

When rebooting system:
```
multi-user.target: Found ordering cycle on docker-myservice.service/start
multi-user.target: Found dependency on docker.service/start
multi-user.target: Found dependency on multi-user.target/start
multi-user.target: Job docker-myservice.service/start deleted to break ordering cycle starting with multi-user.target/start
```
Service is not starts at boot anymore.

