### PR TITLE
adding optional variable for package_key_check_source to RedHat

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -588,7 +588,7 @@ class docker (
         'RedHat' : {
           $package_location         = $docker_ce_source_location
           $package_key_source       = $docker_ce_key_source
-          $package_key_check_source = true
+          $package_key_check_source = $docker_package_key_check_source
         }
         'windows': {
           fail('This module only work for Docker Enterprise Edition on Windows.')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -570,7 +570,7 @@ class docker (
     if ($docker_ee) {
       $package_location         = $docker::docker_ee_source_location
       $package_key_source       = $docker::docker_ee_key_source
-      $package_key_check_source = true
+      $package_key_check_source = $docker_package_key_check_source
       $package_key              = $docker::docker_ee_key_id
       $package_repos            = $docker::docker_ee_repos
       $release                  = $docker::docker_ee_release


### PR DESCRIPTION
Change the hard coded value for `$package_key_check_source` for RedHat to the optional variable `$docker_package_key_check_source`.
The variable is already used further down in the following else-block for RedHat.
The optional var is defined as `true` within the `params.pp` so there should be no following issues.

The change is needed for one of my customers which used an own yum-repo for the docker repository, were the values must be set to `false`.