### PR TITLE
Add missing extra_systemd_parameters values to docker-run.erb

### DIFF
--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -200,6 +200,26 @@ tests = {
   'when passing syslog_facility' => {
     'syslog_facility' => 'user',
   },
+  'when passing serveral extra systemd parameters' => {
+    'extra_systemd_parameters' => {
+      'Service' => {
+        'TimeoutStopSec' => '120',
+      },
+      'Unit' => {
+        'Documentation' => 'https://example.com/'
+      },
+      'Install' => {
+        'Alias' => 'example2',
+      },
+    }
+  },
+  'when passing an extra systemd parameter' => {
+    'extra_systemd_parameters' => {
+      'Service' => {
+        'TimeoutStopSec' => '120',
+      }
+    }
+  },
 }
 
 describe 'docker::run', type: :define do

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -19,6 +19,11 @@ Requires=<%= @requires.uniq.join(" ") %>
 StartLimitIntervalSec=20
 StartLimitBurst=3
 <%- end -%>
+<%- if @extra_systemd_parameters['Unit'] -%>
+<%- @extra_systemd_parameters['Unit'].each do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
+<%- end -%>
 
 [Service]
 Restart=<%= @systemd_restart %>
@@ -40,9 +45,19 @@ ExecStop=-/usr/local/bin/docker-run-<%= @sanitised_title %>-stop.sh
 <%- if @remain_after_exit %>
 RemainAfterExit=<%= @remain_after_exit %>
 <%- end -%>
+<%- if @extra_systemd_parameters['Service'] -%>
+<%- @extra_systemd_parameters['Service'].each do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
+<%- end -%>
 
 [Install]
 WantedBy=multi-user.target
 <%- if @service_name -%>
 WantedBy=<%= @service_name %>.service
+<%- end -%>
+<%- if @extra_systemd_parameters['Install'] -%>
+<%- @extra_systemd_parameters['Install'].each do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
 <%- end -%>


### PR DESCRIPTION
The extra_systemd_parameters values in docker::run had no implementation.

Add implementation to docker-run.erb template file.