### PR TITLE
Make management of systemd override directories optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,6 +159,16 @@
 # @param manage_service
 #   Specify whether the service should be managed.
 #
+# @param manage_systemd_override_dirs
+#   Specify whether the systemd override directories such as
+#   /etc/systemd/systemd/docker.service.d and
+#   /etc/systemd/system/docker.socket.d should be managed by this module or
+#   not. Set this to 'false' if you manage custom Docker-related systemd
+#   overrides, for example with `systemd::dropin_file` from puppet-systemd.
+#   Otherwise this will lead to duplicate resource declaration errors because
+#   both this module and puppet-systemd want to manage the override
+#   directories.
+#
 # @param root_dir
 #   Custom root directory for containers
 #
@@ -405,6 +415,7 @@ class docker (
   String                                  $service_state                     = $docker::params::service_state,
   Boolean                                 $service_enable                    = $docker::params::service_enable,
   Boolean                                 $manage_service                    = $docker::params::manage_service,
+  Boolean                                 $manage_systemd_override_dirs      = $docker::params::manage_systemd_override_dirs,
   Optional[String]                        $root_dir                          = $docker::params::root_dir,
   Optional[Boolean]                       $tmp_dir_config                    = $docker::params::tmp_dir_config,
   Optional[String]                        $tmp_dir                           = $docker::params::tmp_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,7 @@ class docker::params {
   $service_state                     = running
   $service_enable                    = true
   $manage_service                    = true
+  $manage_systemd_override_dirs      = true
   $root_dir                          = undef
   $tmp_dir_config                    = true
   $tmp_dir                           = '/tmp/'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,6 +30,9 @@ tests = {
     'docker_msft_provider_version'   => '123',
     'nuget_package_provider_version' => '41',
   },
+  'with management of systemd override directories disabled' => {
+    'manage_systemd_override_dirs' => false,
+  }
 }
 
 describe 'docker', type: :class do
@@ -127,6 +130,7 @@ describe 'docker', type: :class do
             'log_opt'                           => defaults['log_opt'],
             'manage_package'                    => defaults['manage_package'],
             'manage_service'                    => defaults['manage_service'],
+            'manage_systemd_override_dirs'      => defaults['manage_systemd_override_dirs'],
             'mtu'                               => defaults['mtu'],
             'no_proxy'                          => defaults['no_proxy'],
             'nuget_package_provider_version'    => defaults['nuget_package_provider_version'],

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -55,6 +55,7 @@ def get_defaults(_facts)
   machine_version                   = '0.16.1'
   manage_package                    = true
   manage_service                    = true
+  manage_systemd_override_dirs      = true
   mtu                               = :undef
   no_proxy                          = :undef
   nuget_package_provider_version    = :undef
@@ -411,6 +412,7 @@ def get_defaults(_facts)
     'machine_version' => machine_version,
     'manage_package' => manage_package,
     'manage_service' => manage_service,
+    'manage_systemd_override_dirs' => manage_systemd_override_dirs,
     'msft_nuget_package_provider_version' => msft_nuget_package_provider_version,
     'msft_package_version' => msft_package_version,
     'msft_provider_version' => msft_provider_version,

--- a/spec/shared_examples/service.rb
+++ b/spec/shared_examples/service.rb
@@ -47,9 +47,15 @@ shared_examples 'service' do |params, facts|
 
   case params['service_provider']
   when 'systemd'
-    it {
-      is_expected.to contain_file('/etc/systemd/system/docker.service.d').with_ensure('directory')
-    }
+    if params['manage_systemd_override_dirs']
+      it {
+        is_expected.to contain_file('/etc/systemd/system/docker.service.d').with_ensure('directory')
+      }
+    else
+      it {
+        is_expected.not_to contain_file('/etc/systemd/system/docker.service.d').with_ensure('directory')
+      }
+    end
 
     if params['service_overrides_template']
       it {
@@ -64,9 +70,15 @@ shared_examples 'service' do |params, facts|
     end
 
     if params['socket_override']
-      it {
-        is_expected.to contain_file('/etc/systemd/system/docker.socket.d').with_ensure('directory')
-      }
+      if params['manage_systemd_override_dirs']
+        it {
+          is_expected.to contain_file('/etc/systemd/system/docker.socket.d').with_ensure('directory')
+        }
+      else
+        it {
+          is_expected.not_to contain_file('/etc/systemd/system/docker.socket.d').with_ensure('directory')
+        }
+      end
 
       it {
         is_expected.to contain_file('/etc/systemd/system/docker.socket.d/socket-overrides.conf').with(


### PR DESCRIPTION
When using puppet-systemd and the `systemd::dropin_file` type to manage
custom Docker-related overrides the puppet-systemd module takes care of
creating and managing the required override directories like
/etc/systemd/system/docker.service.d and
/etc/systemd/system/docker.socket.d. This leads to duplicate resource
declaration errors because the puppetlabs-docker module also wants to
manage these systemd override directories.

This change adds a boolean parameter `manage_systemd_override_dirs` to
control whether this module should manage the directories
/etc/systemd/system/docker.service.d and
/etc/systemd/system/docker.socket.d. If set to 'false' then these
directories will not be touched by this module and the user must take
care of managing them, e.g. by means of puppet-systemd and
`systemd::dropin_file`. The parameter `manage_systemd_override_dirs` is
set to 'true' by default, thus backwards-compatibility is preserved.

Contains updated spec tests and parameter documentation.