### PR TITLE
Change `stop_wait_time` value to match Docker default

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ docker::run { 'helloworld':
   after_start      => 'echo "container has started"',
   after            => [ 'container_b', 'mysql' ],
   depends          => [ 'container_a', 'postgres' ],
-  stop_wait_time   => 0,
+  stop_wait_time   => 10,
   read_only        => false,
   extra_parameters => [ '--restart=always' ],
 }

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -244,7 +244,7 @@ define docker::run (
   Boolean                                   $remove_container_on_stop          = true,
   Boolean                                   $remove_volume_on_start            = false,
   Boolean                                   $remove_volume_on_stop             = false,
-  Integer                                   $stop_wait_time                    = 0,
+  Integer                                   $stop_wait_time                    = 10,
   Optional[String]                          $syslog_identifier                 = undef,
   Optional[String]                          $syslog_facility                   = undef,
   Boolean                                   $read_only                         = false,

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -287,7 +287,7 @@ describe 'docker::run', type: :define do
             'service_prefix'                    => 'docker-',
             'service_provider'                  => :undef,
             'socket_connect'                    => [],
-            'stop_wait_time'                    => 0,
+            'stop_wait_time'                    => 10,
             'syslog_identifier'                 => :undef,
             'systemd_restart'                   => 'on-failure',
             'tty'                               => false,


### PR DESCRIPTION
According to Docker documentation, [the `--time` option default value is  10 seconds](https://docs.docker.com/engine/reference/commandline/stop/).

The module set this value to 0, causing immediate destruction of the container instead of leaving it a 10s grace time to shutdown.

Use the default value of 10 to honor the default behavior.
