### PR TITLE
(CONT-263) Bumping required puppet version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.4.0",


### PR DESCRIPTION
Prior to this commit, as part of the codebase hardening project, an important piece of update was missed: raising the minimum required puppet version to 6.24.0, so that certain command breakdowns could occur.

This commit aims to fix that. It can also be considered part of the ticket CONT-263 and the final update required before a major release can be cut.