### PR TITLE
Use puppet yaml helper to workaround psych >4 breaking changes 

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
 
     # get merged config using docker-compose config
     args = [compose_files, '-p', name, 'config'].insert(3, resource[:options]).compact
-    compose_output = YAML.safe_load(execute([command(:dockercompose)] + args, combine: false), [Symbol])
+    compose_output = Puppet::Util::Yaml.safe_load(execute([command(:dockercompose)] + args, combine: false), [Symbol])
 
     containers = docker([
                           'ps',


### PR DESCRIPTION
This issue occurs with Psych >= 4 and breaks docker_compose command in my case.
The safe_ load method in puppet helper is there since a while so no need to change puppet version requirements here.