### PR TITLE
Improve param_changed detection (#881)

### DIFF
--- a/lib/puppet/functions/docker_params_changed.rb
+++ b/lib/puppet/functions/docker_params_changed.rb
@@ -86,38 +86,87 @@ Puppet::Functions.create_function(:docker_params_changed) do
         param_changed = true if opts['image'] && opts['image'] != inspect_hash['Config']['Image']
 
         # check if something on volumes or mounts was changed(a new volume/mount was added or removed)
-        param_changed = true if opts['volumes'].is_a?(String) && opts['volumes'].include?(':') && opts['volumes'] != inspect_hash['Mounts'].to_a[0] && opts['osfamily'] != 'windows'
-        param_changed = true if opts['volumes'].is_a?(String) && !opts['volumes'].include?(':') && opts['volumes'] != inspect_hash['Config']['Volumes'].to_a[0] && opts['osfamily'] != 'windows'
-        param_changed = true if opts['volumes'].is_a?(String) && opts['volumes'].scan(%r{(?=:)}).count == 2 && opts['volumes'] != inspect_hash['Mounts'].to_a[0] && opts['osfamily'] == 'windows'
-        param_changed = if opts['volumes'].is_a?(String) && opts['volumes'].scan(%r{(?=:)}).count == 1 && opts['volumes'] != inspect_hash['Config']['Volumes'].to_a[0] && opts['osfamily'] == 'windows'
-                          true
-                        else
-                          param_changed
-                        end
+        # we need to split the mounts from the manifest based on types (binds and volumes)
+        # we then do a similar split on inspect[hostconfig][mounts]
+        # TODO make volumes an array vs mixed type support; this feels like it was partially attempted with any2array()
+        # TODO handle checking options better
+        pp_binds = []
+        pp_volumes = []
+        if opts['osfamily'] != 'windows'
+            vols = opts['volumes'].is_a?(String) ? [opts['volumes']] : opts['volumes']
+            vols.each do |vol|
+                vol_params = vol.split(':')
+                # we are going to assume that if length is 1 or the first char of the first element is not one of [./~] it is a volume
+                if vol_params.length == 1
+                    t_vol = { 'destination' => vol_params[0], 'rw' => true}
+                    # not pushing this to the array because i'm not sure how to deal with the compare...
+                    #pp_volumes.append(t_vol)
+                elsif not ['.', '~', '/'].include?(vol_params[0][0])
+                    # this next line is fragile and likely to break because it assumes some ordering op the options
+                    # which may not be true
+                    t_rw = vol_params[2] ? vol_params[2].split(',')[0].downcase == 'rw' ? true : false : true
+                    t_vol = { 'name' => vol_params[0], 'destination' => vol_params[1], 'rw' => t_rw }
+                    pp_volumes.append(t_vol)
+                else
+                    # this next line is fragile and likely to break because it assumes some ordering op the options
+                    # which may not be true
+                    t_rw = vol_params[2] ? vol_params[2].split(',')[0].downcase == 'rw' ? true : false : true
+                    t_bind = { 'source' => vol_params[0], 'destination' => vol_params[1], 'rw' => t_rw }
+                    pp_binds.append(t_bind)
+                end
+            end
 
-        pp_paths = opts['volumes'].reject { |item| item.include?(':') } if opts['volumes'].is_a?(Array) && opts['osfamily'] != 'windows'
-        pp_mounts = opts['volumes'].select { |item| item.include?(':') } if opts['volumes'].is_a?(Array) && opts['osfamily'] != 'windows'
-        pp_paths = opts['volumes'].select { |item| item.scan(%r{(?=:)}).count == 1 } if opts['volumes'].is_a?(Array) && opts['osfamily'] == 'windows'
-        pp_mounts = opts['volumes'].select { |item| item.scan(%r{(?=:)}).count == 2 } if opts['volumes'].is_a?(Array) && opts['osfamily'] == 'windows'
+            binds = []
+            volumes = []
+            inspect_hash['Mounts'].map do |mount|
+                if mount.fetch('Type').downcase == 'bind'
+                    binds.append({ 'source' => mount.fetch('Source'), 'destination' => mount.fetch('Destination'), 'rw' => mount.fetch('RW') })
+                elsif mount.fetch('Type').downcase == 'volume'
+                    volumes.append({ 'name' => mount.fetch('Name'), 'destination' => mount.fetch('Destination'), 'rw' => mount.fetch('RW') })
+                end
+            end
 
-        inspect_paths = if inspect_hash['Config']['Volumes']
-                          inspect_hash['Config']['Volumes'].keys
-                        else
-                          []
-                        end
-        param_changed = true if pp_paths != inspect_paths
+            param_changed = true if (pp_binds.length != binds.length && Set.new(pp_binds) != Set.new(binds))
+            param_changed = true if (pp_volumes.length > volumes.length && !volumes.subset(pp_volumes))
+        elsif opts['osfamily'] == 'windows'
+            # going to consider this broken for windows since I cant test this...
+            # what we can do is keep the existing logic and hope for the best...
+            param_changed = true if opts['volumes'].is_a?(String) && opts['volumes'].scan(%r{(?=:)}).count == 2 && opts['volumes'] != inspect_hash['Mounts'].to_a[0] && opts['osfamily'] == 'windows'
+            param_changed = if opts['volumes'].is_a?(String) && opts['volumes'].scan(%r{(?=:)}).count == 1 && opts['volumes'] != inspect_hash['Config']['Volumes'].to_a[0] && opts['osfamily'] == 'windows'
+                              true
+                            else
+                              param_changed
+                            end
 
-        names = inspect_hash['Mounts'].map { |item| item.values[1] } if inspect_hash['Mounts']
-        pp_names = pp_mounts.map { |item| item.split(':')[0] } if pp_mounts
-        names = names.select { |item| pp_names.include?(item) } if names && pp_names
-        destinations = inspect_hash['Mounts'].map { |item| item.values[3] } if inspect_hash['Mounts']
-        pp_destinations = pp_mounts.map { |item| item.split(':')[1] } if pp_mounts && opts['osfamily'] != 'windows'
-        pp_destinations = pp_mounts.map { |item| "#{item.split(':')[1].downcase}:#{item.split(':')[2]}" } if pp_mounts && opts['osfamily'] == 'windows'
-        destinations = destinations.select { |item| pp_destinations.include?(item) } if destinations && pp_destinations
+            pp_paths = opts['volumes'].select { |item| item.scan(%r{(?=:)}).count == 1 } if opts['volumes'].is_a?(Array) && opts['osfamily'] == 'windows'
+            pp_mounts = opts['volumes'].select { |item| item.scan(%r{(?=:)}).count == 2 } if opts['volumes'].is_a?(Array) && opts['osfamily'] == 'windows'
 
-        param_changed = true if pp_names != names
-        param_changed = true if pp_destinations != destinations
-        param_changed = true if pp_mounts != [] && inspect_hash['Mounts'].nil?
+            inspect_paths = if inspect_hash['Config']['Volumes']
+                              inspect_hash['Config']['Volumes'].keys
+                            else
+                              []
+                            end
+
+            # for the mounts from insepct, if it is a volume, use the volume name
+            # otherwise use the source path as the value saved for comparison with the manifest values
+            names = inspect_hash['Mounts'].map { |item| item.fetch('Type').downcase == 'volume' ? item.fetch('Name') : item.fetch('Source') } if inspect_hash['Mounts']
+            # for the mounts from the manifest, split the entry and use
+            pp_names = pp_mounts.map { |item| item.split(':')[0] } if pp_mounts
+            # sort both lists for the comparison since we don't know which order they will be in
+            param_changed = true if pp_names.sort != names.sort
+
+
+            destinations = inspect_hash['Mounts'].map { |item| item.fetch('Destination') } if inspect_hash['Mounts']
+            # remove inspect_paths volumes that are mounted
+            inspect_paths = inspect_paths.reject { |item| destinations.include?(item) }
+            pp_destinations = pp_mounts.map { |item| "#{item.split(':')[1].downcase}:#{item.split(':')[2]}" } if pp_mounts && opts['osfamily'] == 'windows'
+            destinations = destinations.select { |item| pp_destinations.include?(item) } if destinations && pp_destinations
+
+            param_changed = true if pp_destinations.sort != destinations.sort
+            param_changed = true if pp_paths != inspect_paths
+            param_changed = true if pp_mounts != [] && inspect_hash['Mounts'].nil?
+        end
+
 
         # check if something on ports was changed(some ports were added or removed)
 


### PR DESCRIPTION
This attempts to fix the issues identified in #881 and while it does address the identified issues in our scenario, I have some concerns about the approach/sanity of these checks related to the concerns called out by @mastermind2k in https://github.com/puppetlabs/puppetlabs-docker/issues/781#issuecomment-1242956951 .

In this case, the comparison for the mounts + volumes does not preserve the source/destination paring so while comparing the list of source and destination mounts might be correct, the pairing could still be wrong ie `source1:dest2` when it should be `source1:dest1` and wound not trigger the `param_changed` event that would be desired.  When talking about configured volumes, It also does not take into account the mount type such as volume, bind, etc (not sure if this one should as it could be multiple types and still be a valid match in my opinion).

It also seems like this function may break when called on a windows host.  All of the start, stop, create, etc calls wrap the command with `run_with_powershell` while the `detect_changes` does not.

I would appreciate hearing from @adrianiurca who authored most of this function as I had to guess at a couple things so if additional light can be shed on what it should be accomplishing I can try to make some updates.