### PR TITLE
Fix for permission denied with registry

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -58,7 +58,6 @@ define docker::registry (
     $password_env     = '$env:password'
     $exec_user        = undef
   } else {
-    $exec_environment = []
     $exec_path        = ['/bin', '/usr/bin',]
     $exec_timeout     = 0
     $exec_provider    = undef
@@ -73,6 +72,7 @@ define docker::registry (
         default => "/home/${local_user}",
       }
     }
+    $exec_environment = ["HOME=${_local_user_home}",]
   }
 
   if $ensure == 'present' {

--- a/spec/shared_examples/registry.rb
+++ b/spec/shared_examples/registry.rb
@@ -21,7 +21,15 @@ shared_examples 'registry' do |title, params, facts, defaults|
     password_env     = '$env:password'
     exec_user        = nil
   else
-    exec_environment = []
+    local_user_home = if params['local_user_home'] && params['local_user_home'] != :undef
+                        params['local_user_home']
+                      elsif local_user == 'root'
+                        '/root'
+                      else
+                        "/home/#{local_user}"
+                      end
+
+    exec_environment = ["HOME=#{local_user_home}"]
     exec_path        = ['/bin', '/usr/bin']
     exec_timeout     = 0
     exec_provider    = nil


### PR DESCRIPTION
When using `local_user` when creating registry credentials, puppet would fail with a permission denied error when writing to `.docker/config.json`. When `local_user` was specified, it seems that the `docker login` command would use the incorrect home directory of the specified user.

Making sure the `HOME` environment variable was set fixes the problem.

Seems to be related to https://github.com/puppetlabs/puppetlabs-docker/issues/358

I experienced this problem on Centos7.

Not sure this is necessarily the best way to fix this, but it solved my problem.