### PR TITLE
Fix `docker` fact with recent version of docker

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -121,7 +121,7 @@ Facter.add(:docker) do
   confine { Facter::Core::Execution.which('docker') }
   setcode do
     docker_version = Facter.value(:docker_client_version)
-    if docker_version&.match?(%r{1[0-9][0-2]?[.]\w+})
+    if docker_version&.match?(%r{\A(1\.1[3-9]|[2-9]|\d{2,})\.})
       docker_json_str = Facter::Core::Execution.execute(
         "#{docker_command} info --format '{{json .}}'", timeout: 90
       )

--- a/spec/unit/lib/facter/docker_spec.rb
+++ b/spec/unit/lib/facter/docker_spec.rb
@@ -98,7 +98,7 @@ describe 'Facter::Util::Fact' do
     ].each do |docker_client_version|
       it "Does not generate a nested fact with legacy version #{docker_client_version}" do
         expect(Facter.fact(:docker_client_version)).to receive(:value).and_return(docker_client_version)
-        expect(Facter::Core::Execution).not_to receive(:execute).with("docker info --format '{{json .}}'", any_args)
+        expect(Facter::Core::Execution).not_to receive(:execute).with("#{docker_command} info --format '{{json .}}'", any_args)
 
         expect(Facter.fact(:docker).value).to be_nil
       end
@@ -114,7 +114,7 @@ describe 'Facter::Util::Fact' do
     ].each do |docker_client_version|
       it "Generates a nested fact with version #{docker_client_version}" do
         expect(Facter.fact(:docker_client_version)).to receive(:value).and_return(docker_client_version)
-        expect(Facter::Core::Execution).to receive(:execute).with("docker info --format '{{json .}}'", any_args).and_return('{}')
+        expect(Facter::Core::Execution).to receive(:execute).with("#{docker_command} info --format '{{json .}}'", any_args).and_return('{}')
 
         expect(Facter.fact(:docker).value).not_to be_nil
       end

--- a/spec/unit/lib/facter/docker_spec.rb
+++ b/spec/unit/lib/facter/docker_spec.rb
@@ -90,6 +90,37 @@ describe 'Facter::Util::Fact' do
     end
   end
 
+  describe 'docker_client_version fact containment' do
+    [
+      '0.0.1',
+      '0.5.12',
+      '1.12.0',
+    ].each do |docker_client_version|
+      it "Does not generate a nested fact with legacy version #{docker_client_version}" do
+        expect(Facter.fact(:docker_client_version)).to receive(:value).and_return(docker_client_version)
+        expect(Facter::Core::Execution).not_to receive(:execute).with("docker info --format '{{json .}}'", any_args)
+
+        expect(Facter.fact(:docker).value).to be_nil
+      end
+    end
+
+    [
+      '1.13.0',
+      '1.14.0',
+      '2.0.0',
+      '20.10.22',
+      '23.0.1',
+      '108.42.1',
+    ].each do |docker_client_version|
+      it "Generates a nested fact with version #{docker_client_version}" do
+        expect(Facter.fact(:docker_client_version)).to receive(:value).and_return(docker_client_version)
+        expect(Facter::Core::Execution).to receive(:execute).with("docker info --format '{{json .}}'", any_args).and_return('{}')
+
+        expect(Facter.fact(:docker).value).not_to be_nil
+      end
+    end
+  end
+
   describe 'docker server version' do
     before(:each) do
       docker_version = File.read(fixtures('facts', 'docker_version'))


### PR DESCRIPTION
The `docker` nested fact is supposed to be conditionaly build if the
docker client version is 1.13 or greater, as changed in #166.

Unfortunately, the regexp is not working as expected, and future tweaks
of the regexp did not fix it.

Fix the regexp to match versions greater are equal to 1.13.*.  Add a few
unit tests to verify the outcome.

Fixes #896
