### PR TITLE
Fix aarch64 architecture in apt repo

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -22,10 +22,16 @@ class docker::repos (
       $package_key   = $docker::package_key
       $package_repos = $docker::package_repos
 
+      if $architecture == 'aarch64' {
+        $_architecture = 'arm64'
+      } else {
+        $_architecture = $architecture
+      }
+
       if ($docker::use_upstream_package_source) {
         apt::source { 'docker':
           location     => $location,
-          architecture => $architecture,
+          architecture => $_architecture,
           release      => $release,
           repos        => $package_repos,
           key          => {


### PR DESCRIPTION
dpkg expects `arm64`, while the kernel reports `aarch64`

#115 broke it on ARM. In #494 was this already pointed out. 