### PR TITLE
Fix version number validation for fact :docker

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -121,7 +121,7 @@ Facter.add(:docker) do
   confine { Facter::Core::Execution.which('docker') }
   setcode do
     docker_version = Facter.value(:docker_client_version)
-    if docker_version&.match?(%r{1[0-9][0-2]?[.]\w+})
+    if docker_version&.match?(%r{[1-9][0-9][0-2]?[.]\w+})
       docker_json_str = Facter::Core::Execution.execute(
         "#{docker_command} info --format '{{json .}}'", timeout: 90
       )


### PR DESCRIPTION
Docker client versions have reached >=20, and previous validation broke after 19.

I'm not sure why there's the [0-2] at the end, it would imply there has been three digit versions starting with 1 and ending in 0-2, which doesn't really make sense, but I'm too scared of regressions.

I'd guess the ideal would be '[1-9][0-9][\\.\d]+' or simply '[\d\\.]+'