### PR TITLE
(CONT-903) Use checkout@v3 in docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Activate Ruby 2.7
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Prior to this commit, the docker module was using checkout@v3 in its ci workflow. This has been an oversight since docker doesn't use our resuable workflows. This commit updates checkout to v3 thus removing deprecation warnings