### PR TITLE
(CONT-903) Address cache@v2 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           ruby-version: "2.7"
 
       - name: Cache gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/gems
           key: ${{ runner.os }}-pr-${{ hashFiles('**/Gemfile') }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
           ruby-version: "2.7"
 
       - name: Cache gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/gems
           key: ${{ runner.os }}-pr-${{ hashFiles('**/Gemfile') }}


### PR DESCRIPTION
cache@v2 deprecation warnings were missed in the previous PR to remove deprecation warnings in this repo. This PR addresses these remaining warnings