### PR TITLE
Defaults memory_limit to undef instead of ignored 0b value

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -196,7 +196,7 @@ define docker::run (
   Enum[present,absent]                      $ensure                            = 'present',
   Optional[String]                          $verify_digest                     = undef,
   Optional[String]                          $command                           = undef,
-  Pattern[/^[\d]*(b|k|m|g)$/]               $memory_limit                      = '0b',
+  Pattern[/^[\d]*(b|k|m|g)$/]               $memory_limit                      = undef,
   Variant[String,Array,Undef]               $cpuset                            = [],
   Variant[String,Array,Undef]               $ports                             = [],
   Variant[String,Array,Undef]               $labels                            = [],


### PR DESCRIPTION
## Summary
From https://github.com/puppetlabs/puppetlabs-docker/issues/748 - sets the default `memory_limits` value to `undef` instead of `0b`. As the Docker documentation states that `0b` is an impossible value to use - it appears to be ignoring the `0b` value. In which case this should not be a breaking change to any setup. 

## Additional Context
Add any additional context about the problem here. 
- Also helps with `podman` usage as per the linked issue

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-docker/issues/748 

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)