### PR TITLE
(MAINT) Fixing pipeline for Windows

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -109,6 +109,7 @@ class docker::install (
               provider  => powershell,
               unless    => template('docker/windows/check_powershell_provider.ps1.erb'),
               logoutput => true,
+              timeout   => 1800,
               notify    => Exec['service-restart-on-failure'],
             }
           }

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -201,10 +201,13 @@ RSpec.configure do |c|
       @windows_ip = ip
     end
     apply_manifest("class { 'docker': docker_ee => true, extra_parameters => '\"insecure-registries\": [ \"#{@windows_ip}:5000\" ]' }", catch_failures: true)
-    sleep 300
+    retry_on_error_matching(120, 5, %r{.*}) do
+      puts 'waiting for VM to restart..'
+      run_shell('ls') # random command to check connectivity to litmus host
+    end
     docker_path = 'C:\\Program Files\\Docker'
-    run_shell("set PATH \"%PATH%;C:\\Users\\Administrator\\AppData\\Local\\Temp;#{docker_path}\"")
-    puts 'Waiting for box to come online'
-    sleep 300
+    retry_on_error_matching(120, 5, %r{.*}) do
+      run_shell("set PATH \"%PATH%;C:\\Users\\Administrator\\AppData\\Local\\Temp;#{docker_path}\"")
+    end
   end
 end

--- a/templates/windows/check_docker.ps1.erb
+++ b/templates/windows/check_docker.ps1.erb
@@ -1,5 +1,5 @@
-# this file checks the status of the Windows Docker package using the DockerMsftProvider powershell provider
-$dockerProviderName="DockerMsftProvider"
+# this file checks the status of the Windows Docker package using the DockerProvider powershell provider
+$dockerProviderName="DockerProvider"
 
 Write-Information "Checking Docker package."
 $package=Get-Package <%= @docker_ee_package_name %> -ProviderName $dockerProviderName -ErrorAction Ignore

--- a/templates/windows/check_powershell_provider.ps1.erb
+++ b/templates/windows/check_powershell_provider.ps1.erb
@@ -1,13 +1,14 @@
-# this file checks the status of the Windows Docker package using the DockerMsftProvider powershell provider
+# this file checks the status of the Windows Docker package using the DockerProvider powershell provider
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-$dockerProviderName="DockerMsftProvider"
+$dockerProviderName="DockerProvider"
 
 Write-Information "Checking Package Provider"
-$module = Get-PackageProvider NuGet
+$module = Get-PackageProvider NuGet -ErrorAction SilentlyContinue
 If ($module -eq $null) {
     Write-Error "NuGet PackagePrivider is not installed."
     Exit 1
 }
+
 <% if @nuget_package_provider_version -%>
 Write-Information "Checking Package provider version"
 if ($module.Version.ToString() -ne "<%= @nuget_package_provider_version %>" ) {
@@ -18,7 +19,7 @@ if ($module.Version.ToString() -ne "<%= @nuget_package_provider_version %>" ) {
 
 
 Write-Information "Checking Docker Provider"
-$provider = Get-Module -ListAvailable -Name $dockerProviderName
+$provider = Get-Module -ListAvailable -Name $dockerProviderName -ErrorAction SilentlyContinue
 If ($provider -eq $null) {
     Write-Error "Docker Microsoft Docker provider is not installed."
     Exit 1
@@ -33,7 +34,7 @@ if ($provider.Version.ToString() -ne "<%= @docker_msft_provider_version %>" ) {
 <% end -%>
 
 Write-Information "Checking Docker package."
-$package=Get-Package <%= @docker_ee_package_name %> -ProviderName $dockerProviderName
+$package=Get-Package <%= @docker_ee_package_name %> -ProviderName $dockerProviderName -ErrorAction SilentlyContinue
 If ($package -eq $null) { 
     Write-Error "Docker package is not installed."
     Exit 1

--- a/templates/windows/download_docker.ps1.erb
+++ b/templates/windows/download_docker.ps1.erb
@@ -1,3 +1,4 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $dockerLocation = Join-Path $env:TEMP "docker.zip"
 
 Invoke-webrequest -UseBasicparsing -Outfile $dockerLocation "<%= @docker_download_url %>"

--- a/templates/windows/install_powershell_provider.ps1.erb
+++ b/templates/windows/install_powershell_provider.ps1.erb
@@ -1,12 +1,9 @@
-# this file install the Windows Docker package using the DockerMsftProvider powershell provider
+# this file install the Windows Docker package using the DockerProvider powershell provider
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-$dockerProviderName="DockerMsftProvider"
+$dockerProviderName="DockerProvider"
 
 Write-Information "Installing Package Provider"
-$module = Install-PackageProvider NuGet -Force `
-<% if @nuget_package_provider_version -%>
--RequiredVersion <%= @nuget_package_provider_version %>
-<% end -%>
+$module = Install-PackageProvider NuGet -Force <%= "-RequiredVersion #{@nuget_package_provider_version}" if @nuget_package_provider_version %>
 
 If ($module -eq $null) {
     Write-Error "Failed to install NuGet Package Provider"
@@ -14,10 +11,7 @@ If ($module -eq $null) {
 }
 
 Write-Information "Installing Docker Provider"
-Install-Module $dockerProviderName -Force `
-<% if @docker_msft_provider_version -%>
--RequiredVersion <%= @docker_msft_provider_version %>
-<% end -%>
+Install-Module $dockerProviderName -Force <%= "-RequiredVersion #{@docker_msft_provider_version}" if @docker_msft_provider_version %>
 
 $provider = Get-Module -ListAvailable -Name $dockerProviderName
 If ($provider -eq $null) {
@@ -26,10 +20,7 @@ If ($provider -eq $null) {
 }
 
 Write-Information "Installing Docker Package"
-$package=Install-Package <%= @docker_ee_package_name %> -ProviderName $dockerProviderName -Force `
-<% if @version -%>
--RequiredVersion <%= @version %>
-<% end -%>
+$package=Install-Package Docker -ProviderName $dockerProviderName -Force <%= "-RequiredVersion #{@version}" if @version %>
 
 If ($package -eq $null) { 
     Write-Error "Failed to install Docker Package"

--- a/templates/windows/remove_docker.ps1.erb
+++ b/templates/windows/remove_docker.ps1.erb
@@ -1,5 +1,5 @@
-# this file install the Windows Docker package using the DockerMsftProvider powershell provider
-$dockerProviderName="DockerMsftProvider"
+# this file install the Windows Docker package using the DockerProvider powershell provider
+$dockerProviderName="DockerProvider"
 
 $package=Get-Package <%= @docker_ee_package_name %> -ProviderName $dockerProviderName -ErrorAction Ignore
 If ($package -ne $null) { 


### PR DESCRIPTION
## Summary
- Replacing `DockerMsftProvider` with `DockerProvider`
- Fixing pipeline

## Additional Context
- `DockerMsftProvider` has been deprecated and no support available 

## Related Issues (if any)
- N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)