### PR TITLE
[CAT-1382] : Fixing CI failure due to rubocop

### DIFF
--- a/spec/acceptance/compose_v3_spec.rb
+++ b/spec/acceptance/compose_v3_spec.rb
@@ -33,7 +33,7 @@ describe 'docker compose' do
     end
   end
 
-  context 'Creating compose v3 projects', win_broken: true do
+  context 'Creating compose v3 projects', :win_broken do
     let(:install_pp) do
       <<-MANIFEST
         docker_compose { 'web':
@@ -59,7 +59,7 @@ describe 'docker compose' do
     end
   end
 
-  context 'creating compose projects with multi compose files', win_broken: true do
+  context 'creating compose projects with multi compose files', :win_broken do
     before(:all) do
       install_pp = <<-MANIFEST
         docker_compose { 'web1':
@@ -79,7 +79,7 @@ describe 'docker compose' do
     end
   end
 
-  context 'Destroying project with multiple compose files', win_broken: true do
+  context 'Destroying project with multiple compose files', :win_broken do
     let(:destroy_pp) do
       <<-MANIFEST
         docker_compose { 'web1':

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -49,7 +49,7 @@ else
 end
 
 describe 'the Puppet Docker module' do
-  context 'clean up before each test', win_broken: true do
+  context 'clean up before each test', :win_broken do
     before(:each) do
       retry_on_error_matching(60, 5, %r{connection failure running}) do
         # Stop all container using systemd
@@ -70,7 +70,7 @@ describe 'the Puppet Docker module' do
     end
 
     describe 'docker class' do
-      context 'without any parameters', win_broken: true do
+      context 'without any parameters', :win_broken do
         let(:pp) { "class { 'docker': #{docker_args} }" }
 
         it 'runs successfully' do
@@ -349,7 +349,7 @@ describe 'the Puppet Docker module' do
         end
       end
 
-      it 'creates a new image based on a tar', win_broken: true do
+      it 'creates a new image based on a tar', :win_broken do
         pp = <<-EOS
           class { 'docker': #{docker_args} }
           docker::image { '#{default_image}':
@@ -585,7 +585,7 @@ describe 'the Puppet Docker module' do
 
       # cpuset is not supported on Docker Windows
       # STDERR: C:/Program Files/Docker/docker.exe: Error response from daemon: invalid option: Windows does not support CpusetCpus.
-      it 'starts a container with cpuset paramater set', win_broken: true do
+      it 'starts a container with cpuset paramater set', :win_broken do
         pp = <<-EOS
           class { 'docker': #{docker_args} }
 
@@ -614,7 +614,7 @@ describe 'the Puppet Docker module' do
       end
 
       # leagacy container linking was not implemented on Windows. --link is a legacy Docker feature: https://docs.docker.com/network/links/
-      it 'starts multiple linked containers', win_broken: true do
+      it 'starts multiple linked containers', :win_broken do
         pp = <<-EOS
           class { 'docker': #{docker_args} }
 
@@ -669,7 +669,7 @@ describe 'the Puppet Docker module' do
         end
       end
 
-      it 'stops a running container', win_broken: true do
+      it 'stops a running container', :win_broken do
         pp = <<-EOS
           class { 'docker': #{docker_args} }
 
@@ -860,7 +860,7 @@ describe 'the Puppet Docker module' do
     end
   end
 
-  describe 'docker::exec', win_broken: true do
+  describe 'docker::exec', :win_broken do
     it 'runs a command inside an already running container' do
       pp = <<-EOS
           class { 'docker': #{docker_args} }
@@ -919,7 +919,7 @@ describe 'the Puppet Docker module' do
       apply_manifest(pp_delete, catch_failures: true)
     end
 
-    it 'onlies run if notified when refreshonly is true', win_broken: true do
+    it 'onlies run if notified when refreshonly is true', :win_broken do
       container_name = 'container_4_2'
       pp = <<-EOS
           class { 'docker': #{docker_args} }

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -293,7 +293,7 @@ describe 'docker' do
       sleep 10
     end
 
-    it 'is able to login to the registry', retry: 3, retry_wait: 10, win_broken: true do
+    it 'is able to login to the registry', :win_broken, retry: 3, retry_wait: 10 do
       pp = <<-MANIFEST
         docker::registry { '#{registry_address}':
           username => 'username',
@@ -305,7 +305,7 @@ describe 'docker' do
       run_shell("test -e \"#{root_dir}/registry-auth-puppet_receipt_#{server_strip}_root\"", expect_failures: false)
     end
 
-    it 'is able to logout from the registry', win_broken: true do
+    it 'is able to logout from the registry', :win_broken do
       pp = <<-MANIFEST
         docker::registry { '#{registry_address}':
           ensure=> absent,
@@ -315,7 +315,7 @@ describe 'docker' do
       run_shell("grep #{registry_address} #{config_file}", expect_failures: true)
     end
 
-    it 'does not create receipt if registry login fails', win_broken: true do
+    it 'does not create receipt if registry login fails', :win_broken do
       pp = <<-MANIFEST
         docker::registry { '#{registry_bad_address}':
           username => 'username',

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'docker::machine', win_broken: true do
+describe 'docker::machine', :win_broken do
   context 'with default parameters' do
     pp = <<-EOS
       include docker::machine

--- a/spec/acceptance/stack_spec.rb
+++ b/spec/acceptance/stack_spec.rb
@@ -12,7 +12,7 @@ else
   wait_for_container_seconds = 10
 end
 
-describe 'docker stack', win_broken: true do
+describe 'docker stack', :win_broken do
   before(:all) do
     retry_on_error_matching(60, 5, %r{connection failure running}) do
       install_pp = <<-MANIFEST


### PR DESCRIPTION
## Summary
Fixing CI failure in rubocop

## Additional Context
- [x] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Add RSpec/MetadataStyle and RSpec/EmptyMetadata cops.
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)