### PR TITLE
Avoid spacing changes after switching to EPP

### DIFF
--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.epp
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.epp
@@ -1,8 +1,8 @@
 <% if $service_after_override { -%>
 [Unit]
 After=<%= $service_after_override %>  
-<% } -%>
 
+<% } -%>
 [Service]
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.epp
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.epp
@@ -1,8 +1,8 @@
 <% if $service_after_override { -%>
 [Unit]
 After=<%= $service_after_override %>
-<% } -%>
 
+<% } -%>
 [Service]
 EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage


### PR DESCRIPTION
In #944, we switched from ERB to EPP.  This has not been released yet,
but while testing I spotted some white space changes that where
unexpected.

Adjust the code so that the EPP template produce the same result as the
ERB template did, making changes more relevant to end-users if they see
some files being changed.
