### PR TITLE
Ensure docker-ce-cli is same version as docker

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -80,6 +80,10 @@ class docker::install (
               ensure => $ensure,
               name   => $docker::docker_package_name,
         }))
+        ensure_resource('package', 'docker-ce-cli', stdlib::merge($docker_hash, {
+              ensure => $ensure,
+              name   => $docker::docker_ce_cli_package_name,
+        }))
 
         if $ensure == 'absent' {
           ensure_resource('package', $dependent_packages, {


### PR DESCRIPTION
## Summary
When `docker::package_source` is not provided - ensure not only docker version, but also `docker-ce-cli`.

## Additional Context
If `docker::package_source` is not used, then only docker version is ensured and `docker-ce-cli` is left out. That creates issues where docker version gets updated to newer, but `docker-ce-cli` is still using older versions. 

## Related Issues (if any)
[[#865] Should also manage docker-ce-cli package with docker-ce](https://github.com/puppetlabs/puppetlabs-docker/issues/865)
[[#903] docker-ce and docker-ce-cli version mismatch when the 'version' option set ](https://github.com/puppetlabs/puppetlabs-docker/issues/903)

## Checklist
- [x] Manually verified. (For example `puppet apply`)