### PR TITLE
Use the docker-compose-plugin via 'docker compose' instead of 'docker-compose'

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -40,7 +40,7 @@ class docker::compose (
         }
       }
       'Windows': {
-        fail('Docker compose is installed with docker machine on Windows')
+        fail('Docker compose is installed with Docker Desktop on Windows')
       }
       default: {
         fail('This module only works on Debian, RedHat or Windows.')

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -20,21 +20,23 @@ class docker::compose (
 
     case $facts['os']['family'] {
       'Debian': {
+        $_require = $docker::use_upstream_package_source ? {
+          true  => Apt::Source['docker'],
+          false => undef,
+        }
         package { 'docker-compose-plugin':
           ensure  => $package_ensure,
-          require => $docker::use_upstream_package_source ? {
-            true  => Apt::Source['docker'],
-            false => undef,
-          },
+          require => $_require,
         }
       }
       'RedHat': {
+        $_require = $docker::use_upstream_package_source ? {
+          true  => Yumrepo['docker'],
+          false => undef,
+        }
         package { 'docker-compose-plugin':
           ensure  => $package_ensure,
-          require => $docker::use_upstream_package_source ? {
-            true  => Yumrepo['docker'],
-            false => undef,
-          },
+          require => $_require,
         }
       }
       'Windows': {

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -11,6 +11,8 @@ class docker::compose (
   Enum[present,absent] $ensure  = present,
   Optional[String]     $version = undef,
 ) {
+  include docker
+
   if $docker::manage_package {
     include docker::params
 

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -12,6 +12,8 @@ class docker::compose (
   Optional[String]     $version = undef,
 ) {
   if $docker::manage_package {
+    include docker::params
+
     $_version = $version ? {
       undef   => $docker::params::compose_version,
       default => $version,

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -22,7 +22,7 @@ class docker::compose (
       'Debian': {
         package { 'docker-compose-plugin':
           ensure  => $package_ensure,
-          require => defined(bool2str($docker::use_upstream_package_source)) ? {
+          require => $docker::use_upstream_package_source ? {
             true  => Apt::Source['docker'],
             false => undef,
           },
@@ -31,7 +31,7 @@ class docker::compose (
       'RedHat': {
         package { 'docker-compose-plugin':
           ensure  => $package_ensure,
-          require => defined(bool2str($docker::use_upstream_package_source)) ? {
+          require => $docker::use_upstream_package_source ? {
             true  => Yumrepo['docker'],
             false => undef,
           },

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -7,118 +7,42 @@
 # @param version
 #   The version of Docker Compose to install.
 #
-# @param install_path
-#   The path where to install Docker Compose.
-#
-# @param symlink_name
-#   The name of the symlink created pointing to the actual docker-compose binary
-#   This allows use of own docker-compose wrapper scripts for the times it's
-#   necessary to set certain things before running the docker-compose binary
-#
-# @param proxy
-#   Proxy to use for downloading Docker Compose.
-#
-# @param base_url
-#   The base url for installation
-#   This allows use of a mirror that follows the same layout as the
-#   official repository
-#
-# @param raw_url
-#   Override the raw URL for installation
-#   The default is to build a URL from baseurl. If rawurl is set, the caller is
-#   responsible for ensuring the URL points to the correct version and
-#   architecture.
-#
-# @param curl_ensure
-#   Whether or not the curl package is ensured by this module.
-#
 class docker::compose (
-  Enum[present,absent] $ensure                 = present,
-  Optional[String]               $version      = $docker::params::compose_version,
-  Optional[String]               $install_path = $docker::params::compose_install_path,
-  Optional[String]               $symlink_name = $docker::params::compose_symlink_name,
-  Optional[Pattern['^((http[s]?)?:\/\/)?([^:^@]+:[^:^@]+@|)([\da-z\.-]+)\.([\da-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$']] $proxy = undef,
-  Optional[String]               $base_url     = $docker::params::compose_base_url,
-  Optional[String]               $raw_url      = undef,
-  Optional[Boolean]              $curl_ensure  = $docker::params::curl_ensure,
+  Enum[present,absent] $ensure  = present,
+  Optional[String]     $version = $docker::params::compose_version,
 ) inherits docker::params {
-  if $facts['os']['family'] == 'windows' {
-    $file_extension = '.exe'
-    $file_owner     = 'Administrator'
-  } else {
-    $file_extension = ''
-    $file_owner     = 'root'
-  }
-
-  $docker_compose_location           = "${install_path}/${symlink_name}${file_extension}"
-  $docker_compose_location_versioned = "${install_path}/docker-compose-${version}${file_extension}"
-
-  if $ensure == 'present' {
-    if $raw_url != undef {
-      $docker_compose_url = $raw_url
+  if $docker::manage_package {
+    if $version and $ensure != 'absent' {
+      $package_ensure = $version
     } else {
-      $docker_compose_url = "${base_url}/${version}/docker-compose-${facts['kernel']}-${facts['os']['hardware']}${file_extension}"
+      $package_ensure = $ensure
     }
 
-    if $proxy != undef {
-      $proxy_opt = "--proxy ${proxy}"
-    } else {
-      $proxy_opt = ''
-    }
-
-    if $facts['os']['family'] == 'windows' {
-      $docker_download_command = "if (Invoke-WebRequest ${docker_compose_url} ${proxy_opt} -UseBasicParsing -OutFile \"${docker_compose_location_versioned}\") { exit 0 } else { exit 1}" # lint:ignore:140chars
-
-      $parameters = {
-        'proxy'                             => $proxy,
-        'docker_compose_url'                => $docker_compose_url,
-        'docker_compose_location_versioned' => $docker_compose_location_versioned,
+    case $facts['os']['family'] {
+      'Debian': {
+        package { 'docker-compose-plugin':
+          ensure  => $package_ensure,
+          require => defined(bool2str($docker::use_upstream_package_source)) ? {
+            true  => Apt::Source['docker'],
+            false => undef,
+          },
+        }
       }
-
-      exec { "Install Docker Compose ${version}":
-        command  => epp('docker/windows/download_docker_compose.ps1.epp', $parameters),
-        provider => powershell,
-        creates  => $docker_compose_location_versioned,
+      'RedHat': {
+        package { 'docker-compose-plugin':
+          ensure  => $package_ensure,
+          require => defined(bool2str($docker::use_upstream_package_source)) ? {
+            true  => Yumrepo['docker'],
+            false => undef,
+          },
+        }
       }
-
-      file { $docker_compose_location:
-        ensure  => 'link',
-        target  => $docker_compose_location_versioned,
-        require => Exec["Install Docker Compose ${version}"],
+      'Windows': {
+        fail('Docker compose is installed with docker machine on Windows')
       }
-    } else {
-      if $curl_ensure {
-        stdlib::ensure_packages(['curl'])
+      default: {
+        fail('This module only works on Debian, RedHat or Windows.')
       }
-
-      exec { "Install Docker Compose ${version}":
-        path    => '/usr/bin/',
-        cwd     => '/tmp',
-        command => "curl -s -S -L ${proxy_opt} ${docker_compose_url} -o ${docker_compose_location_versioned}",
-        creates => $docker_compose_location_versioned,
-        require => Package['curl'],
-      }
-
-      file { $docker_compose_location_versioned:
-        owner   => $file_owner,
-        mode    => '0755',
-        seltype => 'container_runtime_exec_t',
-        require => Exec["Install Docker Compose ${version}"],
-      }
-
-      file { $docker_compose_location:
-        ensure  => 'link',
-        target  => $docker_compose_location_versioned,
-        require => File[$docker_compose_location_versioned],
-      }
-    }
-  } else {
-    file { $docker_compose_location_versioned:
-      ensure => absent,
-    }
-
-    file { $docker_compose_location:
-      ensure => absent,
     }
   }
 }

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -46,10 +46,10 @@ class docker::compose (
         }
       }
       'Windows': {
-        fail('Docker compose is installed with Docker Desktop on Windows')
+        fail('The docker compose portion of this module is not supported on Windows')
       }
       default: {
-        fail('This module only works on Debian, RedHat or Windows.')
+        fail('The docker compose portion of this module only works on Debian or RedHat')
       }
     }
   }

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -27,7 +27,7 @@ class docker::compose (
     case $facts['os']['family'] {
       'Debian': {
         $_require = $docker::use_upstream_package_source ? {
-          true  => Apt::Source['docker'],
+          true  => [Apt::Source['docker'], Class['apt::update']],
           false => undef,
         }
         package { 'docker-compose-plugin':

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -30,19 +30,11 @@ class docker::compose (
           true  => [Apt::Source['docker'], Class['apt::update']],
           false => undef,
         }
-        package { 'docker-compose-plugin':
-          ensure  => $package_ensure,
-          require => $_require,
-        }
       }
       'RedHat': {
         $_require = $docker::use_upstream_package_source ? {
           true  => Yumrepo['docker'],
           false => undef,
-        }
-        package { 'docker-compose-plugin':
-          ensure  => $package_ensure,
-          require => $_require,
         }
       }
       'Windows': {
@@ -51,6 +43,10 @@ class docker::compose (
       default: {
         fail('The docker compose portion of this module only works on Debian or RedHat')
       }
+    }
+    package { 'docker-compose-plugin':
+      ensure  => $package_ensure,
+      require => $_require,
     }
   }
 }

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -9,11 +9,15 @@
 #
 class docker::compose (
   Enum[present,absent] $ensure  = present,
-  Optional[String]     $version = $docker::params::compose_version,
-) inherits docker::params {
+  Optional[String]     $version = undef,
+) {
   if $docker::manage_package {
-    if $version and $ensure != 'absent' {
-      $package_ensure = $version
+    $_version = $version ? {
+      undef   => $docker::params::compose_version,
+      default => $version,
+    }
+    if $_version and $ensure != 'absent' {
+      $package_ensure = $_version
     } else {
       $package_ensure = $ensure
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,8 +47,7 @@ class docker::params {
   $dns                               = undef
   $dns_search                        = undef
   $proxy                             = undef
-  $compose_base_url                  = 'https://github.com/docker/compose/releases/download'
-  $compose_symlink_name              = 'docker-compose'
+  $compose_version                   = undef
   $no_proxy                          = undef
   $execdriver                        = undef
   $storage_driver                    = undef
@@ -90,16 +89,12 @@ class docker::params {
   $docker_command                    = 'docker'
 
   if ($facts['os']['family'] == 'windows') {
-    $compose_install_path   = "${facts['docker_program_files_path']}/Docker"
-    $compose_version        = '1.29.2'
     $docker_ee_package_name = 'Docker'
     $machine_install_path   = "${facts['docker_program_files_path']}/Docker"
     $tls_cacert             = "${facts['docker_program_data_path']}/docker/certs.d/ca.pem"
     $tls_cert               = "${facts['docker_program_data_path']}/docker/certs.d/server-cert.pem"
     $tls_key                = "${facts['docker_program_data_path']}/docker/certs.d/server-key.pem"
   } else {
-    $compose_install_path   = '/usr/local/bin'
-    $compose_version        = '1.29.2'
     $docker_ee_package_name = 'docker-ee'
     $machine_install_path   = '/usr/local/bin'
     $tls_cacert             = '/etc/docker/tls/ca.pem'

--- a/spec/acceptance/compose_v3_spec.rb
+++ b/spec/acceptance/compose_v3_spec.rb
@@ -26,7 +26,7 @@ describe 'docker compose' do
       install_code = <<-CODE
         class { 'docker': #{docker_args} }
         class { 'docker::compose':
-          version => '1.23.2',
+          version => '2.26.1',
         }
       CODE
       apply_manifest(install_code, catch_failures: true)

--- a/spec/acceptance/compose_v3_spec.rb
+++ b/spec/acceptance/compose_v3_spec.rb
@@ -134,7 +134,7 @@ describe 'docker compose', :win_broken do
     end
 
     it 'has removed the compose plugin' do
-      run_shell("docker compose version", expect_failures: true)
+      run_shell('docker compose version', expect_failures: true)
     end
   end
 end

--- a/spec/acceptance/compose_v3_spec.rb
+++ b/spec/acceptance/compose_v3_spec.rb
@@ -2,38 +2,21 @@
 
 require 'spec_helper_acceptance'
 
-if os[:family] == 'windows'
-  install_dir = '/cygdrive/c/Program Files/Docker'
-  file_extension = '.exe'
-  docker_args = 'docker_ee => true'
-  tmp_path = 'C:/cygwin64/tmp'
-  test_container = if %r{2019|2022}.match?(os[:release])
-                     'nanoserver'
-                   else
-                     'nanoserver-sac2016'
-                   end
-else
-  docker_args = ''
-  install_dir = '/usr/local/bin'
-  file_extension = ''
-  tmp_path = '/tmp'
-  test_container = 'debian'
-end
+tmp_path = '/tmp'
+test_container = 'debian'
 
-describe 'docker compose' do
+describe 'docker compose', :win_broken do
   before(:all) do
     retry_on_error_matching(60, 5, %r{connection failure running}) do
       install_code = <<-CODE
-        class { 'docker': #{docker_args} }
-        class { 'docker::compose':
-          version => '2.26.1',
-        }
+        class { 'docker': }
+        class { 'docker::compose': }
       CODE
       apply_manifest(install_code, catch_failures: true)
     end
   end
 
-  context 'Creating compose v3 projects', :win_broken do
+  context 'Creating compose v3 projects' do
     let(:install_pp) do
       <<-MANIFEST
         docker_compose { 'web':
@@ -51,15 +34,15 @@ describe 'docker compose' do
     end
 
     it 'has docker compose installed' do
-      run_shell('docker-compose --help', expect_failures: false)
+      run_shell('docker compose --help', expect_failures: false)
     end
 
     it 'finds a docker container' do
-      run_shell('docker inspect web_compose_test_1', expect_failures: false)
+      run_shell('docker inspect web-compose_test_1', expect_failures: false)
     end
   end
 
-  context 'creating compose projects with multi compose files', :win_broken do
+  context 'creating compose projects with multi compose files' do
     before(:all) do
       install_pp = <<-MANIFEST
         docker_compose { 'web1':
@@ -75,11 +58,11 @@ describe 'docker compose' do
     end
 
     it "finds container with #{test_container} tag" do
-      run_shell("docker inspect web1_compose_test_1 | grep #{test_container}", acceptable_exit_codes: [0])
+      run_shell("docker inspect web1-compose_test_1 | grep #{test_container}", acceptable_exit_codes: [0])
     end
   end
 
-  context 'Destroying project with multiple compose files', :win_broken do
+  context 'Destroying project with multiple compose files' do
     let(:destroy_pp) do
       <<-MANIFEST
         docker_compose { 'web1':
@@ -105,31 +88,26 @@ describe 'docker compose' do
     end
 
     it 'does not find a docker container' do
-      run_shell('docker inspect web1_compose_test_1', expect_failures: true)
+      run_shell('docker inspect web1-compose_test_1', expect_failures: true)
     end
   end
 
   context 'Requesting a specific version of compose' do
     let(:version) do
-      '1.21.2'
+      '2.25.0'
     end
 
     it 'is idempotent' do
       pp = <<-MANIFEST
         class { 'docker::compose':
-          version => '#{version}',
+          version => '#{version}-*',
         }
       MANIFEST
       idempotent_apply(pp)
     end
 
     it 'has installed the requested version' do
-      if os[:family] == 'redhat' && os[:release].to_i == 7
-        run_shell('sudo mv /usr/local/bin/docker-compose /usr/bin/docker-compose')
-        run_shell('sudo chmod +x /usr/bin/docker-compose')
-      end
-      command = 'docker-compose --version'
-      command = "export PATH=/usr/local/bin:$PATH && #{command}" if os[:family] == 'redhat'
+      command = 'docker compose version'
 
       run_shell(command, expect_failures: false) do |r|
         expect(r.stdout).to match(%r{#{version}})
@@ -138,13 +116,9 @@ describe 'docker compose' do
   end
 
   context 'Removing docker compose' do
-    let(:version) do
-      '1.21.2'
-    end
-
     after(:all) do
       install_pp = <<-MANIFEST
-        class { 'docker': #{docker_args}}
+        class { 'docker': }
         class { 'docker::compose': }
       MANIFEST
       apply_manifest(install_pp, catch_failures: true)
@@ -154,15 +128,13 @@ describe 'docker compose' do
       pp = <<-MANIFEST
         class { 'docker::compose':
           ensure  => absent,
-          version => '#{version}',
         }
       MANIFEST
       idempotent_apply(pp)
     end
 
-    it 'has removed the relevant files' do
-      run_shell("test -e \"#{install_dir}/docker-compose#{file_extension}\"", expect_failures: true)
-      run_shell("test -e \"#{install_dir}/docker-compose-#{version}#{file_extension}\"", expect_failures: true)
+    it 'has removed the compose plugin' do
+      run_shell("docker compose version", expect_failures: true)
     end
   end
 end

--- a/spec/classes/compose_spec.rb
+++ b/spec/classes/compose_spec.rb
@@ -9,29 +9,6 @@ tests = {
   },
   'with version => 1.7.0' => {
     'version' => '1.7.0'
-  },
-  'when proxy is provided' => {
-    'version' => '1.7.0',
-    'proxy' => 'http://proxy.example.org:3128/'
-  },
-  'when proxy is not a http proxy' => {
-    'proxy' => 'this is not a URL'
-  },
-  'when proxy contains username and password' => {
-    'version' => '1.7.0',
-    'proxy' => 'http://user:password@proxy.example.org:3128/'
-  },
-  'when proxy IP is provided' => {
-    'version' => '1.7.0',
-    'proxy' => 'http://10.10.10.10:3128/'
-  },
-  'when base_url is provided' => {
-    'version' => '1.7.0',
-    'base_url' => 'http://example.org'
-  },
-  'when raw_url is provided' => {
-    'version' => '1.7.0',
-    'raw_url' => 'http://example.org'
   }
 }
 
@@ -56,13 +33,7 @@ describe 'docker::compose', type: :class do
         context title do
           params = {
             'ensure' => 'present',
-            'version' => defaults['compose_version'],
-            'install_path' => defaults['compose_install_path'],
-            'symlink_name' => defaults['compose_symlink_name'],
-            'proxy' => :undef,
-            'base_url' => defaults['compose_base_url'],
-            'raw_url' => :undef,
-            'curl_ensure' => defaults['curl_ensure']
+            'version' => defaults['compose_version']
           }.merge(local_params)
 
           let(:facts) do
@@ -73,15 +44,7 @@ describe 'docker::compose', type: :class do
             params
           end
 
-          if title == 'when proxy is not a http proxy'
-            it 'raises an error for invalid proxy URL' do
-              expect(subject).to compile.and_raise_error(
-                %r{parameter 'proxy' expects an undef value or a match for Pattern},
-              )
-            end
-          else
-            include_examples 'compose', params, facts
-          end
+          include_examples 'compose', params, facts
         end
       end
     end

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -3,8 +3,6 @@
 def get_defaults(_facts)
   bip                               = :undef
   bridge                            = :undef
-  compose_base_url                  = 'https://github.com/docker/compose/releases/download'
-  compose_symlink_name              = 'docker-compose'
   curl_ensure                       = true
   default_gateway                   = :undef
   default_gateway_ipv6              = :undef
@@ -88,18 +86,15 @@ def get_defaults(_facts)
   tmp_dir                           = '/tmp/'
   tmp_dir_config                    = true
   version                           = :undef
+  compose_version                   = :undef
 
   if _facts[:os]['family'] == 'windows'
-    compose_install_path   = "#{_facts['docker_program_files_path']}/Docker"
-    compose_version        = '1.21.2'
     docker_ee_package_name = 'Docker'
     machine_install_path   = "#{_facts['docker_program_files_path']}/Docker"
     tls_cacert             = "#{_facts['docker_program_data_path']}/docker/certs.d/ca.pem"
     tls_cert               = "#{_facts['docker_program_data_path']}/docker/certs.d/server-cert.pem"
     tls_key                = "#{_facts['docker_program_data_path']}/docker/certs.d/server-key.pem"
   else
-    compose_install_path   = '/usr/local/bin'
-    compose_version        = '1.9.0'
     docker_ee_package_name = 'docker-ee'
     machine_install_path   = '/usr/local/bin'
     tls_cacert             = '/etc/docker/tls/ca.pem'
@@ -340,9 +335,6 @@ def get_defaults(_facts)
     'apt_source_pin_level' => apt_source_pin_level,
     'bip' => bip,
     'bridge' => bridge,
-    'compose_base_url' => compose_base_url,
-    'compose_install_path' => compose_install_path,
-    'compose_symlink_name' => compose_symlink_name,
     'compose_version' => compose_version,
     'curl_ensure' => curl_ensure,
     'default_gateway' => default_gateway,

--- a/spec/shared_examples/compose.rb
+++ b/spec/shared_examples/compose.rb
@@ -3,95 +3,22 @@
 shared_examples 'compose' do |_params, _facts|
   ensure_value = _params['ensure']
   version      = _params['version']
-  install_path = _params['install_path']
-  symlink_name = _params['symlink_name']
-  proxy        = _params['proxy']
-  base_url     = _params['base_url']
-  raw_url      = _params['raw_url']
-  curl_ensure  = _params['curl_ensure']
 
-  if _facts[:os]['family'] == 'windows'
-    file_extension = '.exe'
-    file_owner     = 'Administrator'
-  else
-    file_extension = ''
-    file_owner     = 'root'
-  end
-
-  docker_compose_location           = "#{install_path}/#{symlink_name}#{file_extension}"
-  docker_compose_location_versioned = "#{install_path}/docker-compose-#{version}#{file_extension}"
-
-  if ensure_value == 'present'
-    docker_compose_url = if raw_url == :undef
-                           "#{base_url}/#{version}/docker-compose-#{_facts[:kernel]}-x86_64#{file_extension}"
-                         else
-                           raw_url
-                         end
-
-    proxy_opt = if proxy == :undef
-                  ''
-                else
-                  "--proxy #{proxy}"
-                end
-
-    if _facts[:os]['family'] == 'windows'
-      docker_download_command = "if (Invoke-WebRequest #{docker_compose_url} #{proxy_opt} -UseBasicParsing -OutFile \"#{docker_compose_location_versioned}\") { exit 0 } else { exit 1 }"
-
-      it {
-        expect(subject).to contain_exec("Install Docker Compose #{version}").with(
-          'provider' => 'powershell',
-          'creates' => docker_compose_location_versioned,
-        )
-
-        expect(subject).to contain_file(docker_compose_location).with(
-          'ensure' => 'link',
-          'target' => docker_compose_location_versioned,
-        ).that_requires(
-          "Exec[Install Docker Compose #{version}]",
-        )
-      }
-    else
-      if curl_ensure
-        it {
-          expect(subject).to contain_package('curl')
-        }
+  if _params['manage_package']
+    ensure_value =
+      if _params['version'] != :undef && _params['ensure'] != 'absent'
+        _params['version']
+      else
+        _params['ensure']
       end
 
+    case _facts['os']['family']
+    when 'Debian', 'RedHat'
       it {
-        expect(subject).to contain_exec("Install Docker Compose #{version}").with(
-          'path' => '/usr/bin/',
-          'cwd' => '/tmp',
-          'command' => "curl -s -S -L #{proxy_opt} #{docker_compose_url} -o #{docker_compose_location_versioned}",
-          'creates' => docker_compose_location_versioned,
-        ).that_requires(
-          'Package[curl]',
-        )
-
-        expect(subject).to contain_file(docker_compose_location_versioned).with(
-          'owner' => file_owner,
-          'mode' => '0755',
-        ).that_requires(
-          "Exec[Install Docker Compose #{version}]",
-        )
-
-        expect(subject).to contain_file(docker_compose_location).with(
-          'ensure' => 'link',
-          'target' => docker_compose_location_versioned,
-        ).that_requires(
-          "File[#{docker_compose_location_versioned}]",
+        expect(subject).to contain_package('docker-compose-plugin').with(
+          ensure: ensure_value,
         )
       }
     end
-  else
-
-    it {
-      expect(subject).to contain_file(docker_compose_location_versioned).with(
-        'ensure' => 'absent',
-      )
-
-      expect(subject).to contain_file(docker_compose_location).with(
-        'ensure' => 'absent',
-      )
-    }
   end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -112,39 +112,6 @@ RSpec.configure do |c|
           image: *default-image
           command: /bin/sh -c "while true; do echo hello world; sleep 1; done"
     EOS
-    docker_compose_content_v3_windows = <<~EOS
-      version: "3"
-      services:
-        compose_test:
-          image: winamd64/hello-seattle
-          command: cmd.exe /C "ping 8.8.8.8 -t"
-      networks:
-        default:
-          external:
-            name: nat
-    EOS
-    docker_compose_override_v3_windows = <<~EOS
-      version: "3"
-      services:
-        compose_test:
-          image: winamd64/hello-seattle:nanoserver
-          command: cmd.exe /C "ping 8.8.8.8 -t"
-      networks:
-        default:
-          external:
-            name: nat
-    EOS
-    docker_compose_override_v3_windows2016 = <<~EOS
-      version: "3"
-      services:
-        compose_test:
-          image: winamd64/hello-seattle:nanoserver-sac2016
-          command: cmd.exe /C "ping 8.8.8.8 -t"
-      networks:
-        default:
-          external:
-            name: nat
-    EOS
     docker_stack_content_windows = <<~EOS
       version: "3"
       services:
@@ -165,13 +132,10 @@ RSpec.configure do |c|
           image: winamd64/hello-seattle:nanoserver-sac2016
     EOS
     if os[:family] == 'windows'
-      create_remote_file(host, '/tmp/docker-compose-v3.yml', docker_compose_content_v3_windows)
       create_remote_file(host, '/tmp/docker-stack.yml', docker_stack_content_windows)
       if %r{2019|2022}.match?(os[:release])
-        create_remote_file(host, '/tmp/docker-compose-override-v3.yml', docker_compose_override_v3_windows)
         create_remote_file(host, '/tmp/docker-stack-override.yml', docker_stack_override_windows)
       else
-        create_remote_file(host, '/tmp/docker-compose-override-v3.yml', docker_compose_override_v3_windows2016)
         create_remote_file(host, '/tmp/docker-stack-override.yml', docker_stack_override_windows2016)
       end
     else


### PR DESCRIPTION
## Summary

Use the docker-compose-plugin via 'docker compose' instead of 'docker-compose'

From https://docs.docker.com/compose/install/
> Docker's documentation refers to and describes Compose V2 functionality. Effective July 2023, Compose V1 stopped receiving updates and is no longer in new Docker Desktop releases. Compose V2 has replaced it and is now integrated into all current Docker Desktop versions. For more information, see [Migrate to Compose V2](https://docs.docker.com/compose/migrate).

## Additional Context
Based on #902. Created my own PR to hopefully get this resolved sooner.

## Related Issues (if any)
#891 

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)