### PR TITLE
Replace YAML.safe_load with Puppet::Util::Yaml.safe_load in docker_stack

### DIFF
--- a/lib/puppet/provider/docker_stack/ruby.rb
+++ b/lib/puppet/provider/docker_stack/ruby.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:docker_stack).provide(:ruby) do
     stack_services = {}
     stack_containers = []
     resource[:compose_files].each do |file|
-      compose_file = YAML.safe_load(File.read(file), [], [], true)
+      compose_file = Puppet::Util::Yaml.safe_load(File.read(file))
       # rubocop:disable Style/StringLiterals
       containers = docker([
                             'ps',


### PR DESCRIPTION
## Summary
Addresses #973. Using Puppet::Util::Yaml.safe_load rather than just YAML.safe_load already contains a [check for this specific issue. ](https://fossies.org/linux/puppet/lib/puppet/util/yaml.rb)

Note, there are numerous other issues with this method and file, (#968, #878, #848, etc). I will be proposing a separate update to fix those, but this is just a small atomic update to fix this specific issue.

## Additional Context
#973 contains the additional context

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [X] 🟢 Spec tests.
- [X] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)