### PR TITLE
(CDPE-6220) Fix variable references in run.pp

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -264,8 +264,8 @@ define docker::run (
     $docker_command = $docker::params::docker_command
   }
 
-  $service_name = $docker::service_name
-  $docker_group = $docker::docker_group
+  $service_name = $docker::params::service_name
+  $docker_group = $docker::params::docker_group
 
   if $restart {
     assert_type(Pattern[/^(no|always|unless-stopped|on-failure)|^on-failure:[\d]+$/], $restart)


### PR DESCRIPTION


## Summary

Currently, CD4PE is using this module as part of the version 5 installation. When we use docker::run, as part of starting up the application containers, we're getting warnings like this in the customer-facing terminal output:

Unknown variable: 'docker::docker_group'. (file: /Users/eric.putnam/ws/cd4pe/PipelinesInfra/deploy/envs/cdpe6633/.modules/docker/manifests/run.pp, line: 268, column: 19)
Unknown variable: 'docker::service_name'. (file: /Users/eric.putnam/ws/cd4pe/PipelinesInfra/deploy/envs/cdpe6633/.modules/docker/manifests/run.pp, line: 267, column: 19)

This doesn't make for a very good customer experience. Since these vars are in docker::params, I added "::params" to the two lines where docker_group and service_name are assigned and that seemed to take care of the warnings. Please correct me if I'm wrong about this change, our main goal is to get rid of these warnings.


## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
These warnings can be seen by running the following bolt plan, which requires this module:
```
plan whalesay::docker_run() {
  apply_prep('localhost')

  apply('localhost') {
    docker::run{'example run':
      image            => 'docker/whalesay',
      pull_on_start    => true,
      restart          => "no",
    }
  }
}
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)