### PR TITLE
systemd service overrides: restore whitespace to pre-conversion

### DIFF
--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.epp
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.epp
@@ -1,8 +1,8 @@
 <% if $service_after_override { -%>
 [Unit]
-After=<%= $service_after_override %>  
-<% } -%>
+After=<%= $service_after_override %>
 
+<% } -%>
 [Service]
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.epp
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.epp
@@ -1,8 +1,8 @@
 <% if $service_after_override { -%>
 [Unit]
 After=<%= $service_after_override %>
-<% } -%>
 
+<% } -%>
 [Service]
 EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage


### PR DESCRIPTION
When these templates were converted from ERB to EPP in commit 3e101cb3151c3e739cd8541dfbc5329f6ae6b647 (#944), these lines were swapped, causing a whitespace change and unnecessary service restarts.
