### PR TITLE
Allow --icc=false option for docker daemon

### DIFF
--- a/templates/etc/conf.d/docker.epp
+++ b/templates/etc/conf.d/docker.epp
@@ -11,7 +11,7 @@ other_args="<% -%>
  --ip-forward=<%= $ip_forward -%>
  --iptables=<%= $iptables -%>
  --ip-masq=<%= $ip_masq -%>
-<% if $icc { %> --icc=<%= $icc %><% } -%>
+<% unless $icc == undef { %> --icc=<%= $icc %><% } -%>
 <% if $fixed_cidr { %> --fixed-cidr <%= $fixed_cidr %><% } -%>
 <% if $default_gateway { %> --default-gateway <%= $default_gateway %><% } -%>
 <% if $bridge { %> --bridge <%= $bridge %><% } -%>

--- a/templates/etc/conf.d/docker.gentoo.epp
+++ b/templates/etc/conf.d/docker.gentoo.epp
@@ -11,7 +11,7 @@ DOCKER_OPTS="<% -%>
  --ip-forward=<%= $ip_forward -%>
  --iptables=<%= $iptables -%>
  --ip-masq=<%= $ip_masq -%>
-<% if $icc { %> --icc=<%= $icc %><% } %>
+<% unless $icc == undef { %> --icc=<%= $icc %><% } %>
 <% if $fixed_cidr { %> --fixed-cidr <%= $fixed_cidr %><% } %>
 <% if $default_gateway { %> --default-gateway <%= $default_gateway %><% } %>
 <% if $bridge { %> --bridge <%= $bridge %><% } %>

--- a/templates/etc/default/docker.epp
+++ b/templates/etc/default/docker.epp
@@ -26,7 +26,7 @@ DOCKER_OPTS="\
  --ip-forward=<%= $ip_forward -%>
  --iptables=<%= $iptables -%>
  --ip-masq=<%= $ip_masq -%>
-<% if $icc { %> --icc=<%= $icc %><% } -%>
+<% unless $icc == undef { %> --icc=<%= $icc %><% } -%>
 <% if $fixed_cidr { %> --fixed-cidr <%= $fixed_cidr %><% } -%>
 <% if $bridge { %> --bridge <%= $bridge %><% } -%>
 <% if $default_gateway { %> --default-gateway <%= $default_gateway %><% } -%>

--- a/templates/etc/sysconfig/docker.epp
+++ b/templates/etc/sysconfig/docker.epp
@@ -11,7 +11,7 @@ other_args="<% -%>
  --ip-forward=<%= $ip_forward -%>
  --iptables=<%= $iptables -%>
  --ip-masq=<%= $ip_masq -%>
-<% if $icc { %> --icc=<%= $icc %><% } -%>
+<% unless $icc == undef { %> --icc=<%= $icc %><% } -%>
 <% if $fixed_cidr { %> --fixed-cidr <%= $fixed_cidr %><% } -%>
 <% if $bridge { %> --bridge <%= $bridge %><% } -%>
 <% if $default_gateway { %> --default-gateway <%= $default_gateway %><% } -%>

--- a/templates/etc/sysconfig/docker.systemd.epp
+++ b/templates/etc/sysconfig/docker.systemd.epp
@@ -8,7 +8,7 @@ OPTIONS="<% if $root_dir { %><%= $root_dir_flag %> <%= $root_dir %><% } -%>
  --ip-forward=<%= $ip_forward -%>
  --iptables=<%= $iptables -%>
  --ip-masq=<%= $ip_masq -%>
-<% if $icc { %> --icc=<%= $icc %><% } -%>
+<% unless $icc == undef { %> --icc=<%= $icc %><% } -%>
 <% if type($registry_mirror, 'generalized') == String { %> --registry-mirror=<%= $registry_mirror %><% } -%>
 <% if String(type($registry_mirror, 'generalized')).index('Array') == 0 { %><% $registry_mirror.each |$param| { %> --registry-mirror=<%= $param %><% } %><% } -%>
 <% if $fixed_cidr { %> --fixed-cidr <%= $fixed_cidr %><% } -%>


### PR DESCRIPTION
This used to be possible in version 9.1.0 and older, but got lost in translation from .erb to .epp templates.

Fixes #989

## Summary
Changes 5 templates to use unless instead of if for the --icc parameter

## Additional Context
If a user wants to specify the --icc parameter, they always will want to use --icc=false, as the default is true.
By using `if $icc` in the template, it is impossible to set -icc=false.

## Related Issues (if any)
See issue #989 

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)