### PR TITLE
Update package source to use rhel repo instead of deprecated centos.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -207,9 +207,9 @@ class docker::params {
       $apt_source_pin_level        = undef
       $detach_service_in_init      = false
       $package_ce_key_id           = undef
-      $package_ce_key_source       = 'https://download.docker.com/linux/centos/gpg'
+      $package_ce_key_source       = 'https://download.docker.com/linux/rhel/gpg'
       $package_ce_release          = undef
-      $package_ce_source_location  = "https://download.docker.com/linux/centos/${facts['os']['release']['major']}/${facts['os']['architecture']}/${docker_ce_channel}"
+      $package_ce_source_location  = "https://download.docker.com/linux/rhel/${facts['os']['release']['major']}/${facts['os']['architecture']}/${docker_ce_channel}"
       $package_ee_key_id           = $docker_ee_key_id
       $package_ee_key_source       = $docker_ee_key_source
       $package_ee_package_name     = $docker_ee_package_name


### PR DESCRIPTION
Possible fix for issue #998 

## Summary
use rhel repo instead of deprecated centos

## Additional Context

We expect docker stopped updating the centos repos when CentOS 8 streams went EoL.  While the enterprise redhat8, rocky8 and alma8 are still supported by vendors.  CentOS8 is not.
