### PR TITLE
Add support for EL9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,12 +1011,13 @@ For information on classes, types, and functions, see the [REFERENCE.md](https:/
 
 This module supports:
 
-* Centos 7.0
+* EL 7 - limited support available, see note below.
+* EL 8
+* EL 9
 * Debian 8.0
 * Debian 9.0
 * Debian 10
 * Debian 11
-* RedHat 7.0 - limited support available
 * Ubuntu 18.04
 * Ubuntu 20.04
 * Ubuntu 22.04
@@ -1024,7 +1025,7 @@ This module supports:
 * Windows Server 2019 (Docker Enterprise Edition only)
 * Windows Server 2022 (Docker Enterprise Edition only)
 
-On RedHat 7 the default docker package installs docker server version 1.13.1. The default docker.service uses the docker-storage-service in this version and creates /etc/sysconfig/docker-storage based on the container-storage-setup configuration and /etc/sysconfig/docker-storage-setup file. As the puppetlabs-docker module manages both the docker-storage and docker-storage-setup files it causes a conflict with the container-storage-setup forcing a docker service restart, therefore a workaround was included in the service manifest that disables the service restart on storage configuration changes for this version of docker on RedHat 7. As a side effect of these changes, storage configuration changes with this docker version on RedHat 7 are not picked up by default by the docker.service. 
+On RedHat 7 the default docker package installs docker server version 1.13.1. The default docker.service uses the docker-storage-service in this version and creates /etc/sysconfig/docker-storage based on the container-storage-setup configuration and /etc/sysconfig/docker-storage-setup file. As the puppetlabs-docker module manages both the docker-storage and docker-storage-setup files it causes a conflict with the container-storage-setup forcing a docker service restart, therefore a workaround was included in the service manifest that disables the service restart on storage configuration changes for this version of docker on RedHat 7. As a side effect of these changes, storage configuration changes with this docker version on RedHat 7 are not picked up by default by the docker.service.
 
 ## License
 

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
This patch is meant to show explicit support for EL9 including RHEL, CentOS, Rocky, etc.