### PR TITLE
metadata: allow puppetlabs/apt 10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.4.1 < 10.0.0"
+      "version_requirement": ">= 4.4.1 < 11.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
## Summary
Allow puppetlabs/apt 10, which includes no breaking changes other than dropping support for Debian 10.