### PR TITLE
Use networking.interfaces fact

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -38,7 +38,7 @@ docker_command = if Facter.value(:kernel) == 'windows'
                  end
 
 def interfaces
-  Facter.value(:interfaces).split(',')
+  Facter.value('networking.interfaces').keys
 end
 
 Facter.add(:docker_version) do

--- a/spec/unit/lib/facter/docker_spec.rb
+++ b/spec/unit/lib/facter/docker_spec.rb
@@ -50,7 +50,12 @@ describe 'Facter::Util::Fact' do
 
   describe 'docker fact with composer network' do
     before :each do
-      allow(Facter.fact(:interfaces)).to receive(:value).and_return('br-c5810f1e3113,docker0,eth0,lo')
+      allow(Facter.fact('networking.interfaces')).to receive(:value).and_return({
+        'br-c5810f1e3113' => {},
+        'docker0' => {},
+        'eth0' => {},
+        'lo' => {},
+      })
     end
 
     it do


### PR DESCRIPTION
## Summary
Remove use of the interfaces fact but rely on networking.interfaces

## Additional Context
See https://www.puppet.com/docs/puppet/8/upgrading-from-puppet7-to-puppet8#upgrading-from-puppet7-to-puppet8-legacy-facts-deprecation

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)