### PR TITLE
Add support for overlay2.size setting used to limit container storage usage

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -150,6 +150,7 @@ The following parameters are available in the `docker` class:
 * [`dm_blkdiscard`](#-docker--dm_blkdiscard)
 * [`dm_override_udev_sync_check`](#-docker--dm_override_udev_sync_check)
 * [`overlay2_override_kernel_check`](#-docker--overlay2_override_kernel_check)
+* [`overlay2_size`](#-docker--overlay2_size)
 * [`manage_package`](#-docker--manage_package)
 * [`service_name`](#-docker--service_name)
 * [`docker_users`](#-docker--docker_users)
@@ -735,6 +736,16 @@ Data type: `Boolean`
 Overrides the Linux kernel version check allowing using overlay2 with kernel < 4.0.
 
 Default value: `$docker::params::overlay2_override_kernel_check`
+
+##### <a name="-docker--overlay2_size"></a>`overlay2_size`
+
+Data type: `Optional[String]`
+
+Sets the default max size of the container. It is supported only when the
+backing filesystem is xfs and mounted with pquota mount option.
+storage_driver needs to be set explicitely to overlay2 to be respected.
+
+Default value: `$docker::params::overlay2_size`
 
 ##### <a name="-docker--manage_package"></a>`manage_package`
 
@@ -1590,6 +1601,7 @@ The following parameters are available in the `docker::service` class:
 * [`dm_blkdiscard`](#-docker--service--dm_blkdiscard)
 * [`dm_override_udev_sync_check`](#-docker--service--dm_override_udev_sync_check)
 * [`overlay2_override_kernel_check`](#-docker--service--overlay2_override_kernel_check)
+* [`overlay2_size`](#-docker--service--overlay2_size)
 * [`storage_devs`](#-docker--service--storage_devs)
 * [`storage_vg`](#-docker--service--storage_vg)
 * [`storage_root_size`](#-docker--service--storage_root_size)
@@ -2039,6 +2051,14 @@ Data type: `Boolean`
 
 
 Default value: `$docker::overlay2_override_kernel_check`
+
+##### <a name="-docker--service--overlay2_size"></a>`overlay2_size`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `$docker::overlay2_size`
 
 ##### <a name="-docker--service--storage_devs"></a>`storage_devs`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,6 +238,11 @@
 # @param overlay2_override_kernel_check
 #   Overrides the Linux kernel version check allowing using overlay2 with kernel < 4.0.
 #
+# @param overlay2_size
+#   Sets the default max size of the container.
+#   It is supported only when the backing filesystem is xfs and mounted with pquota mount option.
+#   storage_driver needs to be set explicitely to overlay2 to be respected.
+#
 # @param manage_package
 #   Won't install or define the docker package, useful if you want to use your own package
 #
@@ -433,6 +438,7 @@ class docker (
   Optional[Boolean]                       $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
   Optional[Boolean]                       $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
   Boolean                                 $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
+  Optional[String]                        $overlay2_size                     = $docker::params::overlay2_size,
   Optional[String]                        $execdriver                        = $docker::params::execdriver,
   Boolean                                 $manage_package                    = $docker::params::manage_package,
   Optional[String]                        $package_source                    = $docker::params::package_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,7 @@ class docker::params {
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
   $overlay2_override_kernel_check    = false
+  $overlay2_size                     = undef
   $manage_package                    = true
   $package_source                    = undef
   $service_name_default              = 'docker'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -117,6 +117,8 @@
 #
 # @param overlay2_override_kernel_check
 #
+# @param overlay2_size
+#
 # @param storage_devs
 #
 # @param storage_vg
@@ -230,6 +232,7 @@ class docker::service (
   Optional[Boolean]                       $dm_blkdiscard                     = $docker::dm_blkdiscard,
   Optional[Boolean]                       $dm_override_udev_sync_check       = $docker::dm_override_udev_sync_check,
   Boolean                                 $overlay2_override_kernel_check    = $docker::overlay2_override_kernel_check,
+  Optional[String]                        $overlay2_size                     = $docker::overlay2_size,
   Optional[String]                        $storage_devs                      = $docker::storage_devs,
   Optional[String]                        $storage_vg                        = $docker::storage_vg,
   Optional[String]                        $storage_root_size                 = $docker::storage_root_size,
@@ -416,6 +419,7 @@ class docker::service (
     'dm_blkdiscard'                     => $dm_blkdiscard,
     'dm_override_udev_sync_check'       => $dm_override_udev_sync_check,
     'overlay2_override_kernel_check'    => $overlay2_override_kernel_check,
+    'overlay2_size'                     => $overlay2_size,
   }
 
   if $storage_config {
@@ -480,6 +484,7 @@ class docker::service (
     'dm_blkdiscard' => $dm_blkdiscard,
     'dm_override_udev_sync_check' => $dm_override_udev_sync_check,
     'overlay2_override_kernel_check' => $overlay2_override_kernel_check,
+    'overlay2_size' => $overlay2_size,
     'labels' => $labels,
     'extra_parameters' => $extra_parameters,
     'extra_parameters_array' => $extra_parameters_array,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -131,6 +131,7 @@ describe 'docker', type: :class do
             'nuget_package_provider_version' => defaults['nuget_package_provider_version'],
             'os_lc' => defaults['os_lc'],
             'overlay2_override_kernel_check' => defaults['overlay2_override_kernel_check'],
+            'overlay2_size' => defaults['overlay2_size'],
             'package_release' => defaults['package_release'],
             'package_source' => defaults['package_source'],
             'pin_upstream_package_source' => defaults['pin_upstream_package_source'],

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -58,6 +58,7 @@ def get_defaults(_facts)
   nuget_package_provider_version    = :undef
   os_lc                             = _facts[:os]['name']
   overlay2_override_kernel_check    = false
+  overlay2_size                     = :undef
   package_source                    = :undef
   proxy                             = :undef
   registry_mirror                   = :undef
@@ -399,6 +400,7 @@ def get_defaults(_facts)
     'nuget_package_provider_version' => nuget_package_provider_version,
     'os_lc' => os_lc,
     'overlay2_override_kernel_check' => overlay2_override_kernel_check,
+    'overlay2_size' => overlay2_size,
     'package_ce_key_id' => package_ce_key_id,
     'package_ce_key_source' => package_ce_key_source,
     'package_ce_release' => package_ce_release,

--- a/templates/etc/conf.d/docker.epp
+++ b/templates/etc/conf.d/docker.epp
@@ -43,6 +43,7 @@ other_args="<% -%>
 <%- if $dm_override_udev_sync_check { %> --storage-opt dm.override_udev_sync_check=<%= $dm_override_udev_sync_check %><% } -%>
 <% } elsif $storage_driver == 'overlay2' { -%>
   <%- if $overlay2_override_kernel_check { %> --storage-opt overlay2.override_kernel_check=<%= $overlay2_override_kernel_check %><% } -%>
+  <%- if $overlay2_size { %> --storage-opt overlay2.size=<%= $overlay2_size %><% } -%>
 <% } -%>
 <% $labels.each |$label| { %> --label <%= $label %><% } -%>
 <% if $extra_parameters { %><% $extra_parameters_array.each |$param| { %> <%= $param %><% } %><% } -%>

--- a/templates/etc/conf.d/docker.gentoo.epp
+++ b/templates/etc/conf.d/docker.gentoo.epp
@@ -43,6 +43,7 @@ DOCKER_OPTS="<% -%>
 <%- if $dm_override_udev_sync_check { %> --storage-opt dm.override_udev_sync_check=<%= $dm_override_udev_sync_check %><% } %>
 <% } elsif $storage_driver == 'overlay2' { -%>
   <%- if $overlay2_override_kernel_check { %> --storage-opt overlay2.override_kernel_check=<%= $overlay2_override_kernel_check %><% } %>
+  <%- if $overlay2_size { %> --storage-opt overlay2.size=<%= $overlay2_size %><% } %>
 <% } -%>
 <% $labels.each |$label| { %> --label <%= $label %><% } %>
 <% if $extra_parameters { %><% $extra_parameters_array.each |$param| { %> <%= $param %><% } %><% } %>

--- a/templates/etc/default/docker.epp
+++ b/templates/etc/default/docker.epp
@@ -62,6 +62,7 @@ DOCKER_OPTS="\
 <%- if $dm_override_udev_sync_check { %> --storage-opt dm.override_udev_sync_check=<%= $dm_override_udev_sync_check %><% } -%>
 <% } elsif $storage_driver == 'overlay2' { -%>
   <%- if $overlay2_override_kernel_check { %> --storage-opt overlay2.override_kernel_check=<%= $overlay2_override_kernel_check %><% } -%>
+  <%- if $overlay2_size { %> --storage-opt overlay2.size=<%= $overlay2_size %><% } -%>
 <% } -%>
 <% $labels.each |$label| { %> --label <%= $label %><% } -%>
 <% if $extra_parameters { %><% $extra_parameters_array.each |$param| { %> <%= $param %><% } %><% } -%>

--- a/templates/etc/sysconfig/docker-storage.epp
+++ b/templates/etc/sysconfig/docker-storage.epp
@@ -35,5 +35,6 @@ DOCKER_STORAGE_OPTIONS="<% -%>
 <%- if $dm_override_udev_sync_check { %> --storage-opt dm.override_udev_sync_check=<%= $dm_override_udev_sync_check %><% } -%>
 <% } elsif $storage_driver == 'overlay2' { -%>
   <%- if $overlay2_override_kernel_check { %> --storage-opt overlay2.override_kernel_check=<%= $overlay2_override_kernel_check %><% } -%>
+  <%- if $overlay2_size { %> --storage-opt overlay2.size=<%= $overlay2_size %><% } -%>
 <% } -%>
 "


### PR DESCRIPTION
* Usable when overlay2 storage is backed by an xfs filesystem with pquoata support
* https://docs.docker.com/reference/cli/dockerd/#overlay2size

## Summary
Support defining overlay2.size setting, which allows restriction of storage usage per container: See [Docker Reference](https://docs.docker.com/reference/cli/dockerd/#overlay2size)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)