### PR TITLE
(MODULES-11475): Fix formatting in docker run and service manifests

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -470,7 +470,7 @@ define docker::run (
         $detect_changes = Deferred('docker_params_changed', [$docker_params_changed_args])
 
         notify { "${title}_docker_params_changed":
-          message  => $detect_changes,
+          message => $detect_changes,
         }
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -319,7 +319,7 @@ class docker::service (
 
     $dirs.each |$dir| {
       file { $dir:
-        ensure  => directory,
+        ensure => directory,
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.4.1 < 10.0.0"
+      "version_requirement": ">= 4.4.1 < 11.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
## Summary
Fix formatting in docker run and service manifests

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)