### PR TITLE
fix Debian package dependencies

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -365,7 +365,7 @@ class docker::params {
   # https://github.com/docker/docker/issues/4734
   $prerequired_packages = $facts['os']['family'] ? {
     'Debian' => $facts['os']['name'] ? {
-      'Debian' => ['cgroupfs-mount',],
+      'Debian' => ['apparmor',],
       'Ubuntu' => ['cgroup-lite', 'apparmor',],
       default  => [],
     },


### PR DESCRIPTION
cgroupfs-mount was removed from Debian trixie and I am not aware of it really being required in bookworm either.

apparmor, on the other hand, is quite necessary and docker fails to start without it, even in bookworm.

## Summary

When trying to run this manifest on Debian trixie, it fails with:

```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install cgroupfs-mount' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Package cgroupfs-mount is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'cgroupfs-mount' has no installation candidate
Error: /Stage[main]/Docker::Repos/Package[cgroupfs-mount]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install cgroupfs-mount' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Package cgroupfs-mount is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'cgroupfs-mount' has no installation candidate (corrective)
Notice: /Stage[main]/Docker::Install/Package[docker]: Dependency Package[cgroupfs-mount] has failures: true
Warning: /Stage[main]/Docker::Install/Package[docker]: Skipping because of failed dependencies
Warning: /Stage[main]/Docker::Install/Package[docker-ce-cli]: Skipping because of failed dependencies
Warning: /Stage[main]/Docker::Install/Package[containerd.io]: Skipping because of failed dependencies
```

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)

not sure what acceptance tests are here, nor what spec tests i should change, but i did my best.