### PR TITLE
fix: remove empty lines from docker-storage-setup

### DIFF
--- a/templates/etc/sysconfig/docker-storage-setup.epp
+++ b/templates/etc/sysconfig/docker-storage-setup.epp
@@ -5,15 +5,14 @@
 # /usr/lib/docker-storage-setup/docker-storage-setup.
 #
 # For more details refer to "man docker-storage-setup"
-
-<% if $storage_driver { %>STORAGE_DRIVER=<%= $storage_driver %><% } %>
-<% if $storage_devs { %>DEVS="<%= $storage_devs %>"<% } %>
-<% if $storage_vg { %>VG=<%= $storage_vg %><% } %>
-<% if $storage_root_size { %>ROOT_SIZE=<%= $storage_root_size %><% } %>
-<% if $storage_data_size { %>DATA_SIZE=<%= $storage_data_size %><% } %>
-<% if $storage_min_data_size { %>MIN_DATA_SIZE=<%= $storage_min_data_size %><% } %>
-<% if $storage_chunk_size { %>CHUNK_SIZE=<%= $storage_chunk_size %><% } %>
-<% if $storage_growpart { %>GROWPART=<%= $storage_growpart %><% } %>
-<% if $storage_auto_extend_pool { %>AUTO_EXTEND_POOL=<%= $storage_auto_extend_pool %><% } %>
-<% if $storage_pool_autoextend_threshold { %>POOL_AUTOEXTEND_THRESHOLD=<%= $storage_pool_autoextend_threshold %><% } %>
-<% if $storage_pool_autoextend_percent { %>POOL_AUTOEXTEND_PERCENT=<%= $storage_pool_autoextend_percent %><% } %>
+<% if $storage_driver { %>STORAGE_DRIVER=<%= $storage_driver %><% } -%>
+<% if $storage_devs { %>DEVS="<%= $storage_devs %>"<% } -%>
+<% if $storage_vg { %>VG=<%= $storage_vg %><% } -%>
+<% if $storage_root_size { %>ROOT_SIZE=<%= $storage_root_size %><% } -%>
+<% if $storage_data_size { %>DATA_SIZE=<%= $storage_data_size %><% } -%>
+<% if $storage_min_data_size { %>MIN_DATA_SIZE=<%= $storage_min_data_size %><% } -%>
+<% if $storage_chunk_size { %>CHUNK_SIZE=<%= $storage_chunk_size %><% } -%>
+<% if $storage_growpart { %>GROWPART=<%= $storage_growpart %><% } -%>
+<% if $storage_auto_extend_pool { %>AUTO_EXTEND_POOL=<%= $storage_auto_extend_pool %><% } -%>
+<% if $storage_pool_autoextend_threshold { %>POOL_AUTOEXTEND_THRESHOLD=<%= $storage_pool_autoextend_threshold %><% } -%>
+<% if $storage_pool_autoextend_percent { %>POOL_AUTOEXTEND_PERCENT=<%= $storage_pool_autoextend_percent %><% } -%>


### PR DESCRIPTION
Currently, template adds many empty files to the config file
