### PR TITLE
docker_compose: Fix idempotence

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -66,7 +66,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
       if compose_services[service_name]['extends']
         image = get_image(compose_services[service_name]['extends'], compose_services)
       elsif compose_services[service_name]['build']
-        image = "#{name}_#{service_name}"
+        image = "#{name}-#{service_name}"
       end
     end
     image


### PR DESCRIPTION
## Summary
When the module checks for running containers, it runs something like the following:

```
/usr/bin/docker ps --format '{{.Label "com.docker.compose.service"}}-{{.Image}}' --filter label=com.docker.compose.project=name_of_resource
```

The output of which appears similar to as follows:

```
web-name_of_resource-web
celery-name_of_resource-celery
celery-beat-name_of_resource-celery-beat
flower-mher/flower:2.0
postgres-postgres:15-alpine
redis-redis:7-alpine
```

However, when getting the *expected* name of the image to check, the module hardcodes an underscore, resulting in things like `web-name_of_resource_web`.

When the counting is done to check for existence, this does not match, so nothing is found, so the module tries to recreate the whole composition.

## Root cause
The root cause is simply a change on Docker's side. On Ubuntu 24.04, when installing from Canonical's packages, Docker compose is v1.29 and the separator is an underscore. If you install with the this module, you get much newer versions, and the separator is a hyphen.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)

## Reproduce:
On any Ubuntu (I tested on 18.04, 20.04, 22.04, 24.04):

1. Create some test files (I did this all as root, in root's homedir)

Dockerfile:
```dockerfile
FROM python:3.12-alpine
WORKDIR /code
COPY app.py .
RUN pip install Flask
EXPOSE 5000
CMD ["flask", "run"]
```
app.py:
```python
from flask import Flask

app = Flask(__name__)

@app.route("/")
def hello():
    return "Hello, World!"
```
compose.yaml:
```yaml
services:
  bob:
    container_name: bob
    network_mode: host
    restart: on-failure
    build: .
  redis:
    container_name: dole
    image: redis:alpine
    restart: on-failure
```
test.pp
```puppet
include docker::compose

docker_compose { 'webapp':
  ensure        => present,
  compose_files => ["/root/compose.yaml"],
}
```

2. `puppet module install puppetlabs-docker --version 10.4.0`
3. `puppet apply test.pp`
4. At this point, apply Puppet a few times. Notice it recreates the composition every time.
5. `sed -i.bak 's,image = "#{name}_#{service_name}",image = "#{name}-#{service_name}",' /etc/puppetlabs/code/environments/production/modules/docker/lib/puppet/provider/docker_compose/ruby.rb`
6. At this point, note the composition is not recreated.