### PR TITLE
Do not limit puppetlabs/apt requirement < v12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 9.2.0 <= 11.2.0"
+      "version_requirement": ">= 9.2.0 <= 12.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
## Summary

The current version of puppetlabs/apt ist 11.3.1. However, that cannot be used as it causes a cross-compat issue with this module here.

If everybody does their SemVer homework right, there should be no breaking changes before the v12 version of puppetlabs/apt, and so all those versions should be allowed here. Limiting the upper versions of dependencies to minor or even bugfix releases makes the entire dependency management pointless, as you will always be locked in by too specific constraints and everybody is busy just updating allowed dependency versions.
