### PR TITLE
(CAT-2665) Add safe fork CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,35 @@ on:
   pull_request:
     branches:
       - "main"
+  pull_request_target:
+    types: [labeled, reopened]
+    branches:
+      - "main"
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Spec:
+    if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       runs_on: "ubuntu-24.04"
     secrets: "inherit"
 
   Acceptance:
-    needs: Spec
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.fork == true &&
+       contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
       flags: '--provision-prefer provision_service --provision-exclude docker --arch-exclude arm --puppetlabs --nightly'

--- a/.github/workflows/fork_ci_label_guard.yml
+++ b/.github/workflows/fork_ci_label_guard.yml
@@ -1,0 +1,12 @@
+name: "Fork CI Label Guard"
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "Publish module"
 
 on:
   workflow_dispatch:
-  
+ 
 jobs:
   release: 
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_release.yml@main"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,3 +27,9 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log

--- a/.pdkignore
+++ b/.pdkignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,6 +27,12 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log
 /.fixtures.yml
 /Gemfile
 /.gitattributes

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -6,5 +6,4 @@
 --no-autoloader_layout-check
 --no-documentation-check
 --no-single_quote_string_with_variables-check
---no-anchor_resource-check
 --ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,15 @@
 ---
-require:
+plugins:
 - rubocop-performance
+- rubocop-hash_inspect
 - rubocop-rspec
+- rubocop-rspec_rails
+- rubocop-factory_bot
+- rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '3.1'
+  TargetRubyVersion: 3.1
   Include:
   - "**/*.rb"
   Exclude:
@@ -107,6 +111,8 @@ Performance/StringInclude:
   Enabled: true
 Performance/Sum:
   Enabled: true
+Security/IoMethods:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
@@ -120,6 +126,12 @@ Bundler/InsecureProtocolSource:
 Capybara/CurrentPathExpectation:
   Enabled: false
 Capybara/VisibilityMatcher:
+  Enabled: false
+FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+FactoryBot/CreateList:
+  Enabled: false
+FactoryBot/FactoryClassName:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
@@ -295,8 +307,6 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
 RSpec/ContainExactly:
   Enabled: false
 RSpec/ContextMethod:
@@ -304,6 +314,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/Dialect:
   Enabled: false
 RSpec/EmptyHook:
   Enabled: false
@@ -320,12 +332,6 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -374,8 +380,6 @@ RSpec/VariableDefinition:
 RSpec/VoidExpect:
   Enabled: false
 RSpec/Yield:
-  Enabled: false
-Security/Open:
   Enabled: false
 Style/AccessModifierDeclarations:
   Enabled: false
@@ -501,6 +505,12 @@ Capybara/SpecificFinders:
   Enabled: false
 Capybara/SpecificMatcher:
   Enabled: false
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+FactoryBot/FactoryNameStyle:
+  Enabled: false
+FactoryBot/SyntaxMethods:
+  Enabled: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DevelopmentDependencies:
@@ -528,6 +538,8 @@ Lint/DeprecatedConstants:
 Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateMagicComment:
+  Enabled: false
+Lint/DuplicateMatchPattern:
   Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: false
@@ -599,27 +611,11 @@ RSpec/DuplicatedMetadata:
   Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
-  Enabled: false
-RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-RSpec/Rails/InferredSpecType:
-  Enabled: false
-RSpec/Rails/MinitestAssertions:
-  Enabled: false
-RSpec/Rails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -631,9 +627,17 @@ RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
   Enabled: false
-Security/CompoundHash:
+RSpecRails/AvoidSetupHook:
   Enabled: false
-Security/IoMethods:
+RSpecRails/HaveHttpStatus:
+  Enabled: false
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/MinitestAssertions:
+  Enabled: false
+RSpecRails/TravelAround:
+  Enabled: false
+Security/CompoundHash:
   Enabled: false
 Style/ArgumentsForwarding:
   Enabled: false
@@ -644,6 +648,8 @@ Style/CollectionCompact:
 Style/ComparableClamp:
   Enabled: false
 Style/ConcatArrayLiterals:
+  Enabled: false
+Style/DataInheritance:
   Enabled: false
 Style/DirEmpty:
   Enabled: false
@@ -713,6 +719,8 @@ Style/RedundantHeredocDelimiterQuotes:
   Enabled: false
 Style/RedundantInitialize:
   Enabled: false
+Style/RedundantLineContinuation:
+  Enabled: false
 Style/RedundantSelfAssignmentBranch:
   Enabled: false
 Style/RedundantStringEscape:
@@ -723,5 +731,3 @@ Style/StringChars:
   Enabled: false
 Style/SwapValues:
   Enabled: false
-Style/HashSyntax:
-  EnforcedShorthandSyntax: never

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,3 +53,8 @@ RSpec/NamedSubject:
     - 'spec/defines/plugin_spec.rb'
     - 'spec/defines/run_spec.rb'
     - 'spec/defines/services_spec.rb'
+
+# Offense count: 6
+RSpec/IndexedLet:
+  Exclude:
+    - 'spec/acceptance/docker_params_changed_spec.rb'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "Shopify.ruby-lsp"
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,81 +1,96 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# frozen_string_literal: true
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+end
+source gemsource_default
 
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+def location_for(place_or_constraint, fake_constraint = nil, opts = {})
+  git_url_regex  = /\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?/
+  file_url_regex = %r{\Afile://(?<path>.*)}
+
+  if place_or_constraint && (git_url = place_or_constraint.match(git_url_regex))
+    # Git source → ignore :source, keep fake_constraint
+    [fake_constraint, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+
+  elsif place_or_constraint && (file_url = place_or_constraint.match(file_url_regex))
+    # File source → ignore :source, keep fake_constraint or default >= 0
+    [fake_constraint || '>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+
   else
-    [place_or_version, { require: false }]
+    # Plain version constraint → merge opts (including :source if provided)
+    [place_or_constraint, { require: false }.merge(opts)]
+  end
+end
+
+# Print debug information if DEBUG_GEMS or VERBOSE is set
+def print_gem_statement_for(gems)
+  puts 'DEBUG: Gem definitions that will be generated:'
+  gems.each do |gem_name, gem_params|
+    puts "DEBUG:   gem #{([gem_name.inspect] + gem_params.map(&:inspect)).join(', ')}"
   end
 end
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.18.0',                        require: false if Gem::Requirement.create(['>= 4.0.0', '< 5.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.18',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "metadata-json-lint", '~> 3.0',            require: false
+  gem "metadata-json-lint", '~> 4.0',            require: false
   gem "json-schema", '< 5.1.1',                  require: false
-  gem "rspec-puppet-facts", '~> 2.0',            require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rspec-puppet-facts", '~> 4.0',            require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rspec-puppet-facts", '~> 5.0',            require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "codecov", '~> 0.2',                       require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.5',             require: false
+  gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.6',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
-  gem "puppet-strings", '~> 4.0',                require: false
-  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "rubocop", '~> 1.73.0',                    require: false
+  gem "rubocop-performance", '~> 1.24.0',        require: false
+  gem "rubocop-hash_inspect", '~> 0.2',          require: false
+  gem "rubocop-rspec", '~> 3.5.0',               require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',        require: false
+  gem "rubocop-capybara", '~> 2.22.0',           require: false
+  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:windows]
+  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:windows]
   gem "ruby-pwsh",                               require: false
   gem "mocha", '< 1.2.0',                        require: false
 end
-group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "serverspec", '~> 2.41',   require: false
-  gem "rspec-retry",             require: false
-end
 group :development, :release_prep do
-  gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
-  gem "puppet-blacksmith", '~> 7.0',      require: false
+  gem "puppet-strings", '~> 4.0',              require: false
+  gem "puppetlabs_spec_helper", '~> 8.0',      require: false
+  gem "puppet-blacksmith", '>= 7.0', '< 10.0', require: false
 end
-
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
+group :system_tests do
+  gem "puppet_litmus", '~> 2.5',   require: false
+  gem "faraday", '~> 2.5',         require: false
+  gem "CFPropertyList", '< 3.0.7', require: false if RUBY_PLATFORM.include?('darwin')
+  gem "serverspec", '~> 2.41',     require: false
+  gem "rspec-retry",               require: false
+end
 
 gems = {}
-
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-# If facter or hiera versions have been specified via the environment
-# variables
-# If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
-# Otherwise, do as before and use location_for to fetch gems from the default source
-if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-else
-  gems['puppet'] = location_for(puppet_version)
-  gems['facter'] = location_for(facter_version) if facter_version
-end
-gems['hiera'] = location_for(hiera_version) if hiera_version
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
+gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
+gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version
 
+# Generate the gem definitions
+print_gem_statement_for(gems) if ENV['DEBUG']
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end
@@ -83,12 +98,14 @@ end
 # Evaluate Gemfile.local and ~/.gemfile if they exist
 extra_gemfiles = [
   "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
+  File.join(Dir.home, '.gemfile')
 ]
 
 extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
+  next unless File.file?(gemfile) && File.readable?(gemfile)
+
+  # rubocop:disable Security/Eval
+  eval(File.read(gemfile), binding)
+  # rubocop:enable Security/Eval
 end
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
+
+PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
@@ -14,4 +16,3 @@ PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
 
-PuppetLint.configuration.send('disable_relative')

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -20,7 +20,6 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
 
   def exists?
     Puppet.info("Checking for compose project #{name}")
-    compose_services = {}
     compose_containers = []
 
     set_tmpdir

--- a/lib/puppet/provider/docker_stack/ruby.rb
+++ b/lib/puppet/provider/docker_stack/ruby.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:docker_stack).provide(:ruby) do
     stack_services = {}
     stack_containers = []
     resource[:compose_files].each do |file|
-      compose_file = YAML.safe_load(File.read(file), [], [], true)
+      compose_file = YAML.safe_load_file(file, [], [], true)
       # rubocop:disable Style/StringLiterals
       containers = docker([
                             'ps',
@@ -79,7 +79,7 @@ Puppet::Type.type(:docker_stack).provide(:ruby) do
   end
 
   def bundle_file
-    return resource[:bundle_file].map { |x| ['-c', x] }.flatten unless resource[:bundle_file].nil?
+    resource[:bundle_file]&.map { |x| ['-c', x] }&.flatten
   end
 
   def compose_files

--- a/metadata.json
+++ b/metadata.json
@@ -64,7 +64,7 @@
       "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.5.0 (ga43db72)",
+  "pdk-version": "3.7.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g11c0f3d"
+  "template-ref": "heads/main-0-gc391e21"
 }

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper_acceptance'
 if os[:kernel] == 'windows'
   docker_args = 'docker_ee => true'
   default_image = 'winamd64/hello-seattle'
-  default_image_tag = if os[:release][:major] == '2019' || os[:release][:major] == '2022'
+  default_image_tag = if ['2019', '2022'].include?(os[:release][:major])
                         'nanoserver'
                       else
                         'nanoserver-sac2016'
@@ -40,7 +40,6 @@ else
   default_docker_exec_lr_command = '/bin/sh -c "touch /root/test_file.txt; while true; do echo hello world; sleep 1; done"'
   default_docker_exec_command = 'touch /root/test_file.txt'
   docker_mount_path = '/root'
-  storage_driver = 'devicemapper'
   storage_driver = if os[:family] == 'RedHat'
                      'devicemapper'
                    else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+    default_facts.merge!(YAML.safe_load_file(f, [], [], true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -60,7 +60,7 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    if os[:family] == 'debian' || os[:family] == 'ubuntu'
+    if ['debian', 'ubuntu'].include?(os[:family])
       run_shell('apt-get update -y')
       # run_shell('apt-get upgrade -y')
       run_shell('apt-get install -y lsb-release')

--- a/spec/unit/lib/puppet/provider/docker_compose/ruby_spec.rb
+++ b/spec/unit/lib/puppet/provider/docker_compose/ruby_spec.rb
@@ -16,8 +16,7 @@ describe Puppet::Type.type(:docker_compose).provider(:ruby) do
   describe '#exists?' do
     before(:each) do
       allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
-      allow(provider).to receive(:execute).and_return(YAML.safe_load("services:\n  web:\n    image: mysql\n    restart: always\n"))
-      allow(provider).to receive(:docker).and_return("'db-mysql'\n")
+      allow(provider).to receive_messages(execute: YAML.safe_load("services:\n  web:\n    image: mysql\n    restart: always\n"), docker: "'db-mysql'\n")
     end
 
     it 'ignores services with restart: no' do

--- a/spec/unit/lib/puppet/type/docker_compose_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_compose_spec.rb
@@ -23,13 +23,13 @@ describe compose do
 
   it 'has expected properties' do
     properties.each do |property|
-      expect(compose.properties.map(&:name)).to be_include(property)
+      expect(compose.properties.map(&:name)).to include(property)
     end
   end
 
   it 'has expected parameters' do
     params.each do |param|
-      expect(compose.parameters).to be_include(param)
+      expect(compose.parameters).to include(param)
     end
   end
 

--- a/spec/unit/lib/puppet/type/docker_network_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_network_spec.rb
@@ -29,13 +29,13 @@ describe network do
 
   it 'has expected properties' do
     properties.each do |property|
-      expect(network.properties.map(&:name)).to be_include(property)
+      expect(network.properties.map(&:name)).to include(property)
     end
   end
 
   it 'has expected parameters' do
     params.each do |param|
-      expect(network.parameters).to be_include(param)
+      expect(network.parameters).to include(param)
     end
   end
 end

--- a/spec/unit/lib/puppet/type/docker_stack_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_stack_spec.rb
@@ -21,13 +21,13 @@ describe stack do
 
   it 'has expected properties' do
     properties.each do |property|
-      expect(stack.properties.map(&:name)).to be_include(property)
+      expect(stack.properties.map(&:name)).to include(property)
     end
   end
 
   it 'has expected parameters' do
     params.each do |param|
-      expect(stack.parameters).to be_include(param)
+      expect(stack.parameters).to include(param)
     end
   end
 

--- a/spec/unit/lib/puppet/type/docker_volume_spec.rb
+++ b/spec/unit/lib/puppet/type/docker_volume_spec.rb
@@ -22,13 +22,13 @@ describe volume do
 
   it 'has expected properties' do
     properties.each do |property|
-      expect(volume.properties.map(&:name)).to be_include(property)
+      expect(volume.properties.map(&:name)).to include(property)
     end
   end
 
   it 'has expected parameters' do
     params.each do |param|
-      expect(volume.parameters).to be_include(param)
+      expect(volume.parameters).to include(param)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `pull_request_target` trigger with `labeled`/`reopened` types to gate acceptance tests for fork PRs behind an `allowed-for-ci` label
- Adds `fork_ci_label_guard.yml` workflow to strip the `allowed-for-ci` label on new pushes and PR close
- Applies pdk 3.7.0 template updates and fixes rubocop offenses (autocorrected + adds `RSpec/IndexedLet` exclusions)

## Test plan
- [x] Spec CI passes on this PR
- [ ] After merge: open fork test PR, add `allowed-for-ci` label, verify acceptance triggers
- [ ] Push new commit to fork test PR, verify label is stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)