### PR TITLE
(CAT) Fix Windows docker facts failing when powershell not on PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 .plan_cache.json
 .rerun.json
 bolt-debug.log
+.claude/settings.local.json

--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -32,7 +32,12 @@ Facter.add(:docker_user_temp_path) do
 end
 
 docker_command = if Facter.value(:kernel) == 'windows'
-                   'powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c docker'
+                   # Invoke PowerShell by its absolute path. When the Puppet agent runs as the
+                   # SYSTEM service, its PATH frequently omits the WindowsPowerShell directory, so
+                   # a bare 'powershell' cannot be resolved by Facter and fails with
+                   # "command not found" even when docker itself is on the PATH.
+                   powershell = "#{ENV.fetch('SystemRoot', 'C:\\Windows')}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                   "\"#{powershell}\" -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c docker"
                  else
                    'docker'
                  end

--- a/spec/unit/lib/facter/docker_spec.rb
+++ b/spec/unit/lib/facter/docker_spec.rb
@@ -6,7 +6,8 @@ require 'json'
 describe 'Facter::Util::Fact' do
   let(:docker_command) do
     if Facter.value(:kernel) == 'windows'
-      'powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c docker'
+      powershell = "#{ENV.fetch('SystemRoot', 'C:\\Windows')}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+      "\"#{powershell}\" -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c docker"
     else
       'docker'
     end


### PR DESCRIPTION
The docker custom facts wrap Docker CLI calls in powershell but invoked it as the bare name 'powershell'. When the Puppet agent runs as the SYSTEM service its PATH often omits the WindowsPowerShell directory, so Facter's internal which('powershell') fails and reports "command not found" even though docker itself is on the PATH.

Invoke powershell by its absolute path derived from %SystemRoot% so it is always resolvable. Also ignore .claude/settings.local.json.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- The code  emitted and error on windows machines (even if not calling the module) - Error: Facter: Error while resolving custom fact fact='docker_version', resolution='<anonymous>': Could not execute 'powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c docker version --format '{{json .}}'': command not found . to reproduce just run in windows 11 
- The root cause was  that the path to the powershell was not being passed
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

