### PR TITLE
docker::registry: accept Sensitive password

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,6 +922,16 @@ docker::registry_auth::registries:
     version: '<docker_version>'
 ```
 
+To keep the password out of the catalog stored in PuppetDB and out of reports, pass it as `Sensitive`
+(on Linux it is then supplied via `docker login --password-stdin` from a Sensitive exec command):
+
+```puppet
+docker::registry { 'example.docker.io:5000':
+  username => 'user',
+  password => Sensitive('secret'),
+}
+```
+
 If using Docker V1.11 or later, the docker login email flag has been deprecated. See the [docker_change_log](https://docs.docker.com/release-notes/docker-engine/#1110-2016-04-13).
 
 Add the following code to the manifest file:

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -13,7 +13,12 @@
 #
 # @param password
 #   Password for authentication to private Docker registry. Leave undef if
-#   auth is not required.
+#   auth is not required. May be given as Sensitive: on Linux the password is
+#   then fed to `docker login --password-stdin` from a Sensitive exec command
+#   instead of the exec environment, and the receipt hash is Sensitive too, so
+#   it is neither stored in the catalog (PuppetDB) nor shown in reports. On
+#   Windows (and for Docker <= 1.10 with `email`) the value is unwrapped and
+#   handled like a plain String.
 #
 # @param pass_hash
 #   The hash to be used for receipt. If left as undef, a hash will be generated
@@ -38,7 +43,7 @@ define docker::registry (
   Optional[String]      $server          = $title,
   Enum[present,absent]  $ensure          = 'present',
   Optional[String]      $username        = undef,
-  Optional[String]      $password        = undef,
+  Optional[Variant[String, Sensitive[String]]] $password = undef,
   Optional[String]      $pass_hash       = undef,
   Optional[String]      $email           = undef,
   String                $local_user      = 'root',
@@ -49,6 +54,9 @@ define docker::registry (
   include docker::params
 
   $docker_command = $docker::params::docker_command
+
+  $_password  = if $password =~ Sensitive { $password.unwrap } else { $password }
+  $_sensitive = ($password =~ Sensitive) and ($facts['os']['family'] != 'windows')
 
   if $facts['os']['family'] == 'windows' {
     $exec_environment = ["PATH=${facts['docker_program_files_path']}/Docker/",]
@@ -76,12 +84,17 @@ define docker::registry (
   }
 
   if $ensure == 'present' {
-    if $username != undef and $password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/ {
+    if $username != undef and $_password != undef and $email != undef and $version != undef and $version =~ /1[.][1-9]0?/ {
       $auth_cmd         = "${docker_command} login -u '${username}' -p \"${password_env}\" -e '${email}' ${server}"
-      $auth_environment = "password=${password}"
-    } elsif $username != undef and $password != undef {
+      $auth_environment = "password=${_password}"
+    } elsif $username != undef and $_password != undef and $_sensitive {
+      # Password only in the (Sensitive) command, never in the environment.
+      $_password_quoted = regsubst($_password, "'", "'\\\\''", 'G')
+      $auth_cmd         = "printf '%s' '${_password_quoted}' | ${docker_command} login -u '${username}' --password-stdin ${server}"
+      $auth_environment = ''
+    } elsif $username != undef and $_password != undef {
       $auth_cmd         = "${docker_command} login -u '${username}' -p \"${password_env}\" ${server}"
-      $auth_environment = "password=${password}"
+      $auth_environment = "password=${_password}"
     } else {
       $auth_cmd         = "${docker_command} login ${server}"
       $auth_environment = ''
@@ -93,7 +106,10 @@ define docker::registry (
 
   $docker_auth = "${title}${auth_environment}${auth_cmd}${local_user}"
 
-  if $auth_environment != '' {
+  if $_sensitive {
+    # $docker_auth embeds the password; only needed at runtime on Windows.
+    $exec_env = $exec_environment
+  } elsif $auth_environment != '' {
     $exec_env = concat($exec_environment, $auth_environment, "docker_auth=${docker_auth}")
   } else {
     $exec_env = concat($exec_environment, "docker_auth=${docker_auth}")
@@ -116,7 +132,7 @@ define docker::registry (
 
       file { "/${_local_user_home}/registry-auth-puppet_receipt_${server_strip}_${local_user}":
         ensure  => $ensure,
-        content => $_pass_hash,
+        content => if $_sensitive { Sensitive($_pass_hash) } else { $_pass_hash },
         owner   => $local_user,
         group   => $local_user,
         notify  => Exec["${title} auth"],
@@ -149,7 +165,7 @@ define docker::registry (
 
   exec { "${title} auth":
     environment => Deferred('docker::env', [$exec_env]),
-    command     => Deferred('sprintf', [$_auth_command]),
+    command     => if $_sensitive { Sensitive($_auth_command) } else { Deferred('sprintf', [$_auth_command]) },
     user        => $exec_user,
     path        => $exec_path,
     timeout     => $exec_timeout,

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -62,6 +62,14 @@ tests = {
     'pass_hash' => 'test1234',
     'receipt' => false
   },
+  'with username => user1, and password => Sensitive(secret)' => {
+    'ensure' => 'present',
+    'username' => 'user1',
+    'password' => RSpec::Puppet::Sensitive.new("se'cret"),
+    'version' => '17.06',
+    'pass_hash' => 'test1234',
+    'receipt' => false
+  },
   'with username => user1, and password => secret and local_user => testuser' => {
     'username' => 'user1',
     'password' => 'secret',

--- a/spec/shared_examples/registry.rb
+++ b/spec/shared_examples/registry.rb
@@ -12,6 +12,8 @@ shared_examples 'registry' do |title, params, facts, defaults|
   receipt      = params['receipt']
 
   docker_command = defaults['docker_command']
+  sensitive_pw   = password.respond_to?(:unwrap) && facts[:os]['family'] != 'windows'
+  password       = password.unwrap if password.respond_to?(:unwrap)
 
   if facts[:os]['family'] == 'windows'
     exec_environment = ["PATH=#{facts['docker_program_files_path']}/Docker/"]
@@ -34,6 +36,9 @@ shared_examples 'registry' do |title, params, facts, defaults|
     if username != :undef && password != :undef && email != :undef && version != :undef && version =~ %r{1[.][1-9]0?}
       auth_cmd         = "#{docker_command} login -u '#{username}' -p \"#{password_env}\" -e '#{email}' #{server}"
       auth_environment = "password=#{password}"
+    elsif username != :undef && password != :undef && sensitive_pw
+      auth_cmd         = "printf '%s' '#{password.gsub("'", "'\\\\''")}' | #{docker_command} login -u '#{username}' --password-stdin #{server}"
+      auth_environment = ''
     elsif username != :undef && password != :undef
       auth_cmd         = "#{docker_command} login -u '#{username}' -p \"#{password_env}\" #{server}"
       auth_environment = "password=#{password}"
@@ -48,7 +53,9 @@ shared_examples 'registry' do |title, params, facts, defaults|
 
   docker_auth = "#{title}#{auth_environment}#{auth_cmd}#{local_user}"
 
-  exec_env = if auth_environment == ''
+  exec_env = if sensitive_pw
+               exec_environment
+             elsif auth_environment == ''
                exec_environment << "docker_auth=#{docker_auth}"
              else
                exec_environment << auth_environment << "docker_auth=#{docker_auth}"
@@ -112,7 +119,7 @@ shared_examples 'registry' do |title, params, facts, defaults|
   it {
     expect(subject).to contain_exec("#{title} auth").with(
       'environment' => exec_env,
-      'command' => auth_command,
+      'command' => sensitive_pw ? sensitive(auth_command) : auth_command,
       'user' => exec_user,
       'path' => exec_path,
       'timeout' => exec_timeout,


### PR DESCRIPTION
## Summary
`docker::registry` only accepts `Optional[String] $password`, and the password reaches the catalog in three places: the defined-type parameter, the auth exec's `environment` (`password=...` and `docker_auth=...`, serialized in clear as `Deferred('docker::env', ...)` arguments), and the receipt file whose content is a crypt hash of a string embedding the password. All of it is stored by PuppetDB and visible in reports.

This PR lets `password` be `Sensitive[String]`. When it is (Linux):
- the password is fed to `docker login -u <user> --password-stdin <server>` via `printf '%s' '<pw>' |` inside the exec `command`, which is wrapped in `Sensitive` (redacted in catalog, logs and reports); nothing password-related is put in the exec `environment` any more (`$docker_auth` was only needed at runtime on Windows);
- the receipt file's `content` is `Sensitive`.

Plain `String` passwords, Windows, and the Docker <= 1.10 `-e email` path behave exactly as before, so this is opt-in with no behaviour change for existing users.

## Additional Context
- Root cause: exec `environment` is a parameter, so it cannot be marked Sensitive without a per-run agent warning; moving the secret into the Sensitive-aware `command` (using `--password-stdin`, the documented way to avoid `-p`) is the only sink that redacts cleanly. Tested on Puppet 8.4 agents: `Exec[... auth]` refreshes and logs in successfully, PuppetDB stores `Docker::Registry` without `password` and the exec without `command`.
- Shell-quoting of the password is handled (`'` -> `'\''`), covered by the new spec case.

## Related Issues (if any)
Addresses #789 (Deferred/Sensitive not working for docker::registry).

## Checklist
- [x] 🟢 Spec tests. (`spec/defines/registry_spec.rb`: 80 examples, new case with `Sensitive("se'cret")`; shared example extended)
- [ ] 🟢 Acceptance tests. (not run; no acceptance coverage exists for `docker::registry` credentials)
- [x] Manually verified. (`puppet agent -t` on Ubuntu hosts against a private registry; login succeeds, catalog in PuppetDB has no password)