### PR TITLE
(MODULES-11929) Point EL7 at the centos Docker CE repo path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -204,9 +204,18 @@ class docker::params {
 
       $apt_source_pin_level        = undef
       $detach_service_in_init      = false
-      $package_ce_key_source       = 'https://download.docker.com/linux/rhel/gpg'
+      # Docker publishes EL packages under both linux/centos and linux/rhel, but it
+      # retired linux/rhel/7 while still shipping EL7 builds (up to docker-ce 26.1.4)
+      # under linux/centos/7. Point EL7 at the centos path and leave EL8+ on rhel,
+      # which is where this branch has pointed since e08575f. The signing key is
+      # byte-identical between the two paths.
+      $package_ce_distro_path      = ($facts['os']['release']['major'] == '7') ? {
+        true    => 'centos',
+        default => 'rhel',
+      }
+      $package_ce_key_source       = "https://download.docker.com/linux/${package_ce_distro_path}/gpg"
       $package_ce_release          = undef
-      $package_ce_source_location  = "https://download.docker.com/linux/rhel/${facts['os']['release']['major']}/${facts['os']['architecture']}/${docker_ce_channel}"
+      $package_ce_source_location  = "https://download.docker.com/linux/${package_ce_distro_path}/${facts['os']['release']['major']}/${facts['os']['architecture']}/${docker_ce_channel}"
       $package_ee_key_source       = $docker_ee_key_source
       $package_ee_package_name     = $docker_ee_package_name
       $package_ee_release          = undef

--- a/spec/classes/params_ce_repo_spec.rb
+++ b/spec/classes/params_ce_repo_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# docker::params builds the Docker CE repo URL for the RedHat family. Docker retired
+# linux/rhel/7 but still ships EL7 packages under linux/centos/7, so EL7 has to resolve
+# to the centos path while EL8+ stays on rhel.
+#
+# init_spec.rb feeds docker_ce_source_location / docker_ce_key_source in as class
+# parameters, so it never exercises the docker::params defaults. This does -- it declares
+# the class without them and asserts what params.pp actually produces.
+describe 'docker', type: :class do
+  on_supported_os.each do |os, os_facts|
+    next unless os_facts[:os]['family'] == 'RedHat'
+
+    major = os_facts[:os]['release']['major']
+    arch = os_facts[:os]['architecture']
+    expected_path = (major == '7') ? 'centos' : 'rhel'
+
+    context "on #{os} with the default CE repo settings" do
+      let(:facts) { os_facts }
+      let(:params) { { 'docker_users' => [] } }
+
+      it "points the docker yumrepo at linux/#{expected_path}/#{major}" do
+        is_expected.to contain_yumrepo('docker').with(
+          'baseurl' => "https://download.docker.com/linux/#{expected_path}/#{major}/#{arch}/stable",
+          'gpgkey' => "https://download.docker.com/linux/#{expected_path}/gpg",
+        )
+      end
+    end
+  end
+end

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -160,9 +160,11 @@ def get_defaults(_facts)
 
     apt_source_pin_level        = :undef
     detach_service_in_init      = false
-    package_ce_key_source       = 'https://download.docker.com/linux/centos/gpg'
+    # Must track the same EL7-vs-EL8+ split as docker::params; see the comment there.
+    package_ce_distro_path      = (_facts[:os]['release']['major'] == '7') ? 'centos' : 'rhel'
+    package_ce_key_source       = "https://download.docker.com/linux/#{package_ce_distro_path}/gpg"
     package_ce_release          = :undef
-    package_ce_source_location  = "https://download.docker.com/linux/centos/#{_facts[:os]['release']['major']}/#{_facts[:os]['architecture']}/#{docker_ce_channel}"
+    package_ce_source_location  = "https://download.docker.com/linux/#{package_ce_distro_path}/#{_facts[:os]['release']['major']}/#{_facts[:os]['architecture']}/#{docker_ce_channel}"
     package_ee_key_source       = docker_ee_key_source
     package_ee_package_name     = docker_ee_package_name
     package_ee_release          = :undef


### PR DESCRIPTION
`docker::params` cannot install Docker CE on **any EL7 host**. The `RedHat` osfamily branch hardcodes the `linux/rhel/` repo path, but Docker retired `linux/rhel/7` while still publishing EL7 builds under `linux/centos/7`.

```
Error: Execution of '/bin/yum -d 0 -e 0 -y install docker-ce' returned 1:
failure: repodata/repomd.xml from docker: [Errno 256] No more mirrors to try.
https://download.docker.com/linux/rhel/7/x86_64/stable/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
```

## Evidence

What `download.docker.com` actually serves:

| path | gpg | 7 | 8 | 9 |
|---|---|---|---|---|
| `linux/rhel/` | 200 | **404** | 200 | 200 |
| `linux/centos/` | 200 | **200** | 200 | 200 |

- `linux/centos/7` carries `docker-ce` up to `26.1.4-1.el7` — Docker's final EL7 release.
- The signing keys at `linux/rhel/gpg` and `linux/centos/gpg` are **byte-identical** (sha256 `e6c650e0700b1bf4868b693b30761b926844befc8a0acb7ac0dd9b1faf1b7423`), so switching the key URL is a no-op.
- `linux/rhel/8` and `linux/rhel/9` are both live, so **EL8+ is deliberately left untouched**.

## Root cause

Introduced by e08575f (2024-09-18), *"Update package source to use rhel repo instead of deprecated centos repo."* That flipped `centos` → `rhel` for the whole RedHat family — correct for EL8/9, where both paths work, but wrong for EL7, where only the centos path exists.

## Why this went unnoticed for ~2 years

e08575f never updated `spec/helper/get_defaults.rb`, so the helper has returned the `centos` URL while the manifest returned `rhel`.

That stayed invisible because `spec/classes/init_spec.rb` feeds the helper's values *into* the class as parameters (`let(:params) { params }`) rather than asserting the `docker::params` default, and `spec/shared_examples/repos.rb` asserts against that same injected `location`. The manifest's own default for `package_ce_source_location` had **no unit coverage at all**.

The break only ever surfaced in CentOS-7 acceptance, which had been written off as EOL platform rot.

## Changes

- **`manifests/params.pp`** — resolve the CE distro path per EL major: `centos` for 7, `rhel` for 8+. EL8/9 behaviour unchanged.
- **`spec/helper/get_defaults.rb`** — track the same split so the helper stops diverging from the manifest.
- **`spec/classes/params_ce_repo_spec.rb`** *(new)* — declares the class *without* `docker_ce_source_location` / `docker_ce_key_source` and asserts the resulting yumrepo `baseurl` and `gpgkey` per EL major. This is the test that would have caught e08575f.

## Out of scope

Other red acceptance jobs on `main`'s nightly, none of which this touches:

- **Debian-10** — buster is archived at `deb.debian.org`, so `puppet-agent`'s installer fails before the module runs. Genuine EOL platform drop; sibling to MODULES-11913.
- **CentOS-8, Ubuntu-20.04** — ABS provision service returns `HTTP 500`. Infrastructure.
- **Windows-2016 / Windows-2022** — WinRM connect timeouts and `Access is denied`. Transient.

## Checklist

- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.

> **Note:** I could not run the suite locally (no usable Ruby toolchain in my checkout), so the new spec is unverified — CI is the first real check on it. The URL and GPG-key claims above were verified directly against `download.docker.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
