### PR TITLE
Bump range for puppetlabs/reboot dependency to accept 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/reboot",
-      "version_requirement": ">=2.0.0 < 6.0.0"
+      "version_requirement": ">=2.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary
A new version of puppetlabs/reboot (6.0.0) has been released. CI currently fails because the current range does not accept this version. This PR bumps the range max from 6.0.0 to 7.0.0

## Checklist
- [X] 🟢 Spec tests.
- [X] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)